### PR TITLE
Fix getnsec simtime

### DIFF
--- a/rtt/os/TimeService.cpp
+++ b/rtt/os/TimeService.cpp
@@ -139,7 +139,7 @@ namespace RTT {
     TimeService::nsecs
     TimeService::getNSecs() const
     {
-        return rtos_get_time_ns();
+        return ticks2nsecs(offset) + (use_clock) ? (rtos_get_time_ns()) : (0); 
     }
 
     TimeService::nsecs


### PR DESCRIPTION
Currently, `TimeService::getNSecs()` does not check if `use_clock` is set like `TimeService::getTicks()` does. This adds that check.
