### PR TITLE
Always set cmake library, runtime and archive output directories according to the build-tool in use

### DIFF
--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -114,9 +114,19 @@ if(OROCOS-RTT_FOUND)
     # Infer package name from directory name.
     get_filename_component(ORO_ROSBUILD_PACKAGE_NAME ${PROJECT_SOURCE_DIR} NAME)
 
+    # Modify default rosbuild output paths if using Eclipse
+    if (CMAKE_EXTRA_GENERATOR STREQUAL "Eclipse CDT4")
+      message(WARNING "[UseOrocos] Eclipse Generator detected. I'm setting EXECUTABLE_OUTPUT_PATH and LIBRARY_OUTPUT_PATH")
+      message(WARNING "[UseOrocos] This will not affect the real output paths of libraries and executables!")
+      #set the default path for built executables to the "bin" directory
+      set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
+      #set the default path for built libraries to the "lib" directory
+      set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
+    endif()
+
     # Set output directories for rosbuild in-source builds,
     # but respect deprecated LIBRARY_OUTPUT_PATH, EXECUTABLE_OUTPUT_PATH and ARCHIVE_OUTPUT_PATH variables
-    # as they are commonly used in rosbuild CMakeLists.txt files
+    # as they are set by rosbuild_init() and commonly used in rosbuild CMakeLists.txt files
     if(NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
       if(DEFINED LIBRARY_OUTPUT_PATH)
         set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${LIBRARY_OUTPUT_PATH})


### PR DESCRIPTION
The previous version only set the `CMAKE_LIBRARY_OUTPUT_DIRECTORY` variable in [UseOROCOS-RTT.cmake:164ff](https://github.com/meyerj/rtt/compare/cmake-output-directories?expand=1#diff-910740529571d9132ed755a83e4c9b3eL164) and did not respect the build-tool in use. The `orocos_component()`, `orocos_plugin()` and `orocos_typekit()` macros can now use the same output directory for all build types relative to `${CMAKE_LIBRARY_OUTPUT_DIRECTORY}`.

catkin has it's own macro [catkin_destinations()](http://docs.ros.org/api/catkin/html/dev_guide/generated_cmake_api.html#catkin-destinations) that sets the `CMAKE_*_OUTPUT_DIRECTORY` variables and additionally some useful variables that specify default install destinations.

I also removed the special check for Eclipse CDT4 as I consider it as deprecated. `EXECUTABLE_OUTPUT_PATH` and `LIBRARY_OUTPUT_PATH` shouldn't be used anymore in cmake >=2.6, which is required.

The `CMAKE_*_OUTPUT_DIRECTORY` are only overridden if they are not already defined (except for catkin).
