### PR TITLE
Remove duplicates from component/plugin search paths in ComponentLoader and PluginLoader

### DIFF
--- a/rtt/deployment/ComponentLoader.cpp
+++ b/rtt/deployment/ComponentLoader.cpp
@@ -15,6 +15,9 @@
 # include <dlfcn.h>
 #endif
 
+#include <vector>
+#include <set>
+
 using namespace RTT;
 using namespace RTT::detail;
 using namespace std;
@@ -57,6 +60,15 @@ static const std::string delimiters(":;");
 static const char default_delimiter(':');
 # endif
 
+// define RTT_UNUSED macro
+#ifndef RTT_UNUSED
+  #ifdef __GNUC__
+    #define RTT_UNUSED __attribute__((unused))
+  #else
+    #define RTT_UNUSED
+  #endif
+#endif
+
 /** Determine whether a file extension is actually part of a library version
 
     @return true if \a ext satisfies "^\.[:digit:]+$"
@@ -65,7 +77,7 @@ static const char default_delimiter(':');
     returns true  for ".1", ".12", ".123"
     returns false for ".a", "1", "123", ".123 ", "a", "", ".1.a", ".1a2"
 */
-static bool isExtensionVersion(const std::string& ext)
+static RTT_UNUSED bool isExtensionVersion(const std::string& ext)
 {
     bool isExtensionVersion = false;
 
@@ -142,50 +154,9 @@ static bool isLoadableLibrary(const path& filename)
     return isLoadable;
 }
 
-namespace RTT {
-    extern char const* default_comp_path_build;
-}
-
-namespace {
-    /**
-     * Reads the RTT_COMPONENT_PATH and inits the ComponentLoader.
-     */
-    int loadComponents()
-    {
-        std::string default_comp_path = ::default_comp_path_build;
-
-        char* paths = getenv("RTT_COMPONENT_PATH");
-        string component_paths;
-        if (paths) {
-            component_paths = paths;
-            // prepend the default search path.
-            if ( !default_comp_path.empty() )
-                component_paths = component_paths + default_delimiter + default_comp_path;
-            log(Info) <<"RTT_COMPONENT_PATH was set to: " << paths << " . Searching in: "<< component_paths<< endlog();
-        } else {
-            component_paths = default_comp_path;
-            log(Info) <<"No RTT_COMPONENT_PATH set. Using default: " << component_paths <<endlog();
-        }
-        // we set the component path such that we can search for sub-directories/projects lateron
-        ComponentLoader::Instance()->setComponentPath(component_paths);
-        return 0;
-    }
-
-    os::InitFunction component_loader( &loadComponents );
-
-    void unloadComponents()
-    {
-        ComponentLoader::Release();
-    }
-
-    os::CleanupFunction component_unloader( &unloadComponents );
-}
-
-static boost::shared_ptr<ComponentLoader> instance2;
-
 namespace {
 
-    // copied from RTT::PluginLoader
+// copied from RTT::PluginLoader
 static vector<string> splitPaths(string const& str)
 {
     vector<string> paths;
@@ -210,6 +181,33 @@ static vector<string> splitPaths(string const& str)
     return paths;
 }
 
+static void removeDuplicates(string& path_list)
+{
+    vector<string> paths;
+    set<string> seen;
+    string result;
+
+    // split path_lists
+    paths = splitPaths( path_list );
+
+    // iterate over paths and append to result
+    for(vector<string>::const_iterator it = paths.begin(); it != paths.end(); ++it)
+    {
+        if (seen.count(*it))
+            continue;
+        else
+            seen.insert(*it);
+
+        result = result + *it + default_delimiter;
+    }
+
+    // remove trailing delimiter
+    if (result.size() > 0 && result.at(result.size() - 1) == default_delimiter)
+        result = result.substr(0, result.size() - 1);
+
+    path_list.swap(result);
+}
+
 /**
  * Strips the 'lib' prefix and '.so'/'.dll'/... suffix (ie SO_EXT) from a filename.
  * Do not provide paths, only filenames, for example: "libcomponent.so"
@@ -227,7 +225,7 @@ static string makeShortFilename(string const& str) {
 
 }
 
-static bool hasEnding(string const &fullString, string const &ending)
+static RTT_UNUSED bool hasEnding(string const &fullString, string const &ending)
 {
     if (fullString.length() > ending.length()) {
         return (0 == fullString.compare (fullString.length() - ending.length(), ending.length(), ending));
@@ -235,6 +233,49 @@ static bool hasEnding(string const &fullString, string const &ending)
         return false;
     }
 }
+
+namespace RTT {
+    extern char const* default_comp_path_build;
+}
+
+namespace {
+    /**
+     * Reads the RTT_COMPONENT_PATH and inits the ComponentLoader.
+     */
+    int loadComponents()
+    {
+        std::string default_comp_path = ::default_comp_path_build;
+
+        char* paths = getenv("RTT_COMPONENT_PATH");
+        string component_paths;
+        if (paths) {
+            component_paths = paths;
+            // prepend the default search path.
+            if ( !default_comp_path.empty() )
+                component_paths = component_paths + default_delimiter + default_comp_path;
+            removeDuplicates( component_paths );
+            log(Info) <<"RTT_COMPONENT_PATH was set to: " << paths << " . Searching in: "<< component_paths<< endlog();
+        } else {
+            component_paths = default_comp_path;
+            removeDuplicates( component_paths );
+            log(Info) <<"No RTT_COMPONENT_PATH set. Using default: " << component_paths <<endlog();
+        }
+        // we set the component path such that we can search for sub-directories/projects lateron
+        ComponentLoader::Instance()->setComponentPath(component_paths);
+        return 0;
+    }
+
+    os::InitFunction component_loader( &loadComponents );
+
+    void unloadComponents()
+    {
+        ComponentLoader::Release();
+    }
+
+    os::CleanupFunction component_unloader( &unloadComponents );
+}
+
+static boost::shared_ptr<ComponentLoader> instance2;
 
 boost::shared_ptr<ComponentLoader> ComponentLoader::Instance() {
     if (!instance2)


### PR DESCRIPTION
This patch removes duplicates from the search path for components and plugins.

The env-hook in `rtt_ros` sets the `RTT_COMPONENT_PATH` environment variable to list of all catkin devel- and install-spaces with the `lib/orocos` suffix appended to each of them. As the ComponentLoader and the PluginLoader append the default path to the contents of the environment variable and there is no other mechanism that checks if a directory has already been search during the import call, the package directories that are in the same workspace than rtt itself (like if everything is installed in `/opt/ros/hydro`) are imported twice:

```
[...]

(Initialization of the PluginLoader:)
0.001 [ Info   ][Logger] RTT_COMPONENT_PATH was set to: /opt/orocos/hydro/lib/orocos:/opt/ros/hydro/lib/orocos . Searching in: /opt/orocos/hydro/lib/orocos:/opt/ros/hydro/lib/orocos:/opt/orocos/hydro/lib/orocos
0.001 [ Debug  ][Logger] PluginLoader Created

[...]

(Initialization of the ComponentLoader:)
0.098 [ Info   ][Logger] RTT_COMPONENT_PATH was set to: /opt/orocos/hydro/lib/orocos:/opt/ros/hydro/lib/orocos . Searching in: /opt/orocos/hydro/lib/orocos:/opt/ros/hydro/lib/orocos:/opt/orocos/hydro/lib/orocos
0.098 [ Info   ][Logger] OCL factory set for real-time logging

[...]

Deployer [S]> import("rtt_ros")
7.050 [ Info   ][DeploymentComponent::import] Importing directory /opt/orocos/hydro/lib/orocos/gnulinux/rtt_ros ...
7.050 [ Debug  ][DeploymentComponent::import] Scanning file /opt/orocos/hydro/lib/orocos/gnulinux/rtt_ros/plugins ...not a regular file: ignored.
7.050 [ Debug  ][DeploymentComponent::import] Looking for plugins or typekits in directory /opt/orocos/hydro/lib/orocos/gnulinux/rtt_ros ...
7.051 [ Debug  ][DeploymentComponent::import] No such directory: "/opt/orocos/hydro/lib/orocos/gnulinux/rtt_ros/types"
7.051 [ Info   ][DeploymentComponent::import] Loading plugin libraries from directory /opt/orocos/hydro/lib/orocos/gnulinux/rtt_ros/plugins ...
7.061 [ Debug  ][DeploymentComponent::import] Scanning file /opt/orocos/hydro/lib/orocos/gnulinux/rtt_ros/plugins/librtt_ros-gnulinux.so ...Found library librtt_ros-gnulinux.so
7.061 [ Info   ][DeploymentComponent::import] Loaded RTT Plugin 'ros' from 'rtt_ros'
7.061 [ Info   ][DeploymentComponent::import] Importing directory /opt/orocos/hydro/lib/orocos/gnulinux/rtt_ros ...
7.061 [ Debug  ][DeploymentComponent::import] Scanning file /opt/orocos/hydro/lib/orocos/gnulinux/rtt_ros/plugins ...not a regular file: ignored.
7.061 [ Debug  ][DeploymentComponent::import] Looking for plugins or typekits in directory /opt/orocos/hydro/lib/orocos/gnulinux/rtt_ros ...
7.062 [ Debug  ][DeploymentComponent::import] No such directory: "/opt/orocos/hydro/lib/orocos/gnulinux/rtt_ros/types"
7.062 [ Info   ][DeploymentComponent::import] Loading plugin libraries from directory /opt/orocos/hydro/lib/orocos/gnulinux/rtt_ros/plugins ...
7.062 [ Debug  ][DeploymentComponent::import] Scanning file /opt/orocos/hydro/lib/orocos/gnulinux/rtt_ros/plugins/librtt_ros-gnulinux.so ...plugin '/opt/orocos/hydro/lib/orocos/gnulinux/rtt_ros/plugins/librtt_ros-gnulinux.so' already loaded. Not reloading it.
 = true 
```

In this case the toolchain and rtt_ros_integration are installed to `/opt/orocos/hydro` which overlays `/opt/ros/hydro`. Note that even the Info level output is duplicated, not only Debug messages.

Removing duplicates from the search paths is IMHO the cleanest solution to solve that "cosmetic" problem. The `rtt_ros` env-hook cannot easily know which of the overlayed catkin workspaces contains the RTT installation.

I also eliminated some compiler warnings about defined but unsed helper functions by adding `__attribute__((unused))` (gcc only).
