### PR TITLE
clear DataFlowInterface in Service::clear()

### DIFF
--- a/rtt/Service.cpp
+++ b/rtt/Service.cpp
@@ -216,6 +216,7 @@ namespace RTT {
 
         OperationInterface::clear();
         ConfigurationInterface::clear();
+        DataFlowInterface::clear();
         while ( !services.empty() ) {
         	this->removeService( services.begin()->first );
         }

--- a/rtt/Service.hpp
+++ b/rtt/Service.hpp
@@ -217,7 +217,8 @@ namespace RTT
         bool hasService(const std::string& service_name);
 
         /**
-         * Clear all added operations from the repository, saving memory space.
+         * Clear all added operations, properties, attributes, ports and services from the repository,
+         * saving memory space.
          */
         void clear();
 


### PR DESCRIPTION
This pull request adds the missing `DataFlowInterface::clear()` call to `Service::clear()` and updates the documentation of this function.

Note that `DataFlowInterface::clear()` only removes the ports from the service and does not automatically disconnect. The port instances might already have been destroyed (dangling pointers) if `clear()` is called from the service's destructor! There is no way to check if the ports still exists or if they are connected...
