### PR TITLE
Several updates for UseOROCOS-RTT.cmake

### DIFF
--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -772,12 +772,12 @@ macro( orocos_library LIB_TARGET_NAME )
       set(PC_NAME ${ORO_CREATE_PC_DEFAULT_ARGS})
     else ( ORO_CREATE_PC_DEFAULT_ARGS )
       set(PACKAGE_NAME ${PROJECT_NAME} )
-      if ( NOT ${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${${PROJECT_NAME}_SOURCE_DIR} )
+      if ( NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL ${PROJECT_NAME}_SOURCE_DIR )
         # Append -subdir-subdir-... to pc name:
         file(RELATIVE_PATH RELPATH ${${PROJECT_NAME}_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR} )
         string(REPLACE "/" "-" PC_NAME_SUFFIX ${RELPATH} )
         set(PACKAGE_NAME ${PACKAGE_NAME}-${PC_NAME_SUFFIX})
-      endif ( NOT ${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${${PROJECT_NAME}_SOURCE_DIR} )
+      endif ( NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL ${PROJECT_NAME}_SOURCE_DIR )
       set(PC_NAME ${PACKAGE_NAME}-${OROCOS_TARGET})
     endif ( ORO_CREATE_PC_DEFAULT_ARGS )
 
@@ -900,6 +900,22 @@ Cflags: -I\${includedir} \@PC_EXTRA_INCLUDE_DIRS\@
 
     # Also set the uninstall target:
     orocos_uninstall_target()
+
+    # Call catkin_package() here if the user has not called it before.
+    if( ORO_USE_CATKIN
+        AND NOT ${PROJECT_NAME}_CATKIN_PACKAGE
+        AND NOT ORO_CREATE_PC_DEFAULT_ARGS # no package name given in orocos_generate_package()
+        AND CMAKE_CURRENT_SOURCE_DIR STREQUAL ${PROJECT_NAME}_SOURCE_DIR
+        AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/package.xml" )
+
+      # Always assume that catkin is a buildtool_depend. This silently disables a FATAL_ERROR in catkin_package().
+      # See https://github.com/ros/catkin/commit/7482dda520e94db5b532b57220dfefb10eeda15b
+      list(APPEND ${PROJECT_NAME}_BUILDTOOL_DEPENDS catkin)
+
+      catkin_package(
+        INCLUDE_DIRS ${${PROJECT_NAME}_EXPORTED_INCLUDE_DIRS}
+      )
+    endif()
 
   endmacro( orocos_generate_package )
 


### PR DESCRIPTION
This pull request contains several updates for the `UseOROCOS-RTT.cmake` script. They are more or less independent from each other. The primary goal is to simplify usage of RTT and the macros from catkin packages.
- https://github.com/meyerj/rtt/commit/e7bcf7e347a387c70dd6e1d6c6a25979eaa63d29 :
  This adds an optional `FILES` and a `DIRECTORY` argument to `orocos_install_headers()`. You don't have to enumerate all header files anymore if there is already an include folder in the package source:
  
  ``` cmake
     orocos_install_headers(
       DIRECTORY include/${PROJECT_NAME}
     )
  ```
- https://github.com/meyerj/rtt/commit/2fe01be3f8ef6141d04440b0304f8335580f0fdd :
  
  Adds an `INCLUDE_DIRS` argument to `orocos_generate_package()`. This can be used to export arbitrary folders as include directories to using packages without having to call `catkin_package()`. It basically has the same semantics than `catkin_package(INCLUDE_DIRS ...)`.
  
  `${PROJECT_SOURCE_DIR}/include/orocos` is the default exported include directory, if its exists and no other include directory has been given as argument.
  
  This has no effect on installation. Only headers installed to `include/orocos` will be available from install-space (default behavior in Orocos RTT < 2.7).
- https://github.com/meyerj/rtt/commit/45c2fba9e10ea8ec3b97c19b7eb9305ec9d8c141 :
  
  This one is a bugfix for the `DEPENDS_TARGETS` argument. I haven't found a package that is using that argument, but we should use it in rtt_ros_integration for multi-target support.
- https://github.com/meyerj/rtt/commit/2adfe68e7dccf300eaadf7189c1fccb12d76a8b0 :
  
  The version number from the `package.xml` file will be used as default version number for the generated pkg-config file.
- https://github.com/meyerj/rtt/commit/2103f2912be1a32eafbbd6ae41bdde98966d890f :
  
  This is probably the most critical patch. It will call `catkin_package()` silently under certain conditions if the user has not called it before. The advantage is that this allows to add plain cmake Orocos packages to a catkin workspace. They just have to add a `package.xml` file, but are not required to call catkin macros in their `CMakeLists.txt` file itself.
  
  Invoking `catkin_package()` in `orocos_generate_package()` of package `foo` basically has three purposes:
  - Installing the `package.xml` file in `share/foo`.
  - Generating a pkg-config file without the `OROCOS_TARGET` suffix and without library targets. This is only required for rosbuild packages that depend on us (We could perhaps submit a patch for rosbuild/rospack to fail silently if no pkg-config file is found. We would not need to install two different pc files per package then).
  - Generating a cmake configuration for the `foo` package that sets the include directories only, also without libraries. This can probably be skipped if `catkin_package()` has been called from `orocos_generate_package()`, as include directories will be imported automatically if `UseOROCOS-RTT.cmake` is included from a catkin or rosbuild package. Without the cmake config it is not possible to call `find_package(foo)` or `find_package(catkin REQUIRED COMPONENTS foo)`, but there is not so much use anyway.
  
  I tested this modification with a patched version of rtt_ros_integration, where almost all `catkin_package()` calls have been removed. As most Orocos package will never be used by non-Orocos packages, you do not have to call `catkin_package()` **and** `orocos_generate_package()` anymore, especially in connection with https://github.com/meyerj/rtt/commit/2fe01be3f8ef6141d04440b0304f8335580f0fdd.

Most of these patches should be considered for the Toolchain 2.7 release (orocos-toolchain/orocos_toolchain#5).
