### PR TITLE
More UseOROCOS-RTT.cmake updates

### DIFF
--- a/UseOROCOS-RTT-helpers.cmake
+++ b/UseOROCOS-RTT-helpers.cmake
@@ -256,6 +256,7 @@ endmacro( orocos_find_package PACKAGE )
 #   
 # It will also aggregate the following variables for all packages found in this
 # scope:
+#   USE_OROCOS_PACKAGES
 #   USE_OROCOS_LIBRARIES
 #   USE_OROCOS_INCLUDE_DIRS
 #   USE_OROCOS_LIBRARY_DIRS
@@ -310,18 +311,11 @@ macro( orocos_use_package PACKAGE )
       # Include the aggregated include directories
       include_directories(${${PACKAGE}_INCLUDE_DIRS})
 
-      # Only link in case there is something *and* the user didn't opt-out:
-      if(NOT OROCOS_NO_AUTO_LINKING AND ${PACKAGE}_LIBRARIES)
-        link_libraries( ${${PACKAGE}_LIBRARIES} )
-        if("$ENV{VERBOSE}" OR ORO_USE_VERBOSE)
-          message(STATUS "[UseOrocos] Linking all targets with libraries from package '${PACKAGE}'. To disable this, set OROCOS_NO_AUTO_LINKING to true.")
-        endif()
-      endif()
-
       # Set a flag so we don't over-link (Don't cache this, it should remain per project)
       set(${PACKAGE}_${OROCOS_TARGET}_USED true)
 
       # Store aggregated variables
+      list(APPEND USE_OROCOS_PACKAGES "${PACKAGE}")
       list(APPEND USE_OROCOS_INCLUDE_DIRS "${${PACKAGE}_INCLUDE_DIRS}")
       list(APPEND USE_OROCOS_LIBRARIES "${${PACKAGE}_LIBRARIES}")
       list(APPEND USE_OROCOS_LIBRARY_DIRS "${${PACKAGE}_LIBRARY_DIRS}")

--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -298,6 +298,14 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       #${OROCOS-RTT_TYPEKIT_LIBRARIES} 
       )
 
+    # Only link in case there is something *and* the user didn't opt-out:
+    if(NOT OROCOS_NO_AUTO_LINKING AND USE_OROCOS_LIBRARIES)
+      target_link_libraries( ${COMPONENT_NAME} ${USE_OROCOS_LIBRARIES} )
+      if("$ENV{VERBOSE}" OR ORO_USE_VERBOSE)
+        message(STATUS "[UseOrocos] Linking target '${COMPONENT_NAME}' with libraries from packages '${USE_OROCOS_PACKAGES}'. To disable this, set OROCOS_NO_AUTO_LINKING to true.")
+      endif()
+    endif()
+
     # Install
     # On win32, component runtime (.dll) should go in orocos folder
     if( ${OROCOS_TARGET} STREQUAL "win32" )
@@ -380,6 +388,14 @@ macro( orocos_library LIB_TARGET_NAME )
       #${OROCOS-RTT_TYPEKIT_LIBRARIES} 
       )
 
+    # Only link in case there is something *and* the user didn't opt-out:
+    if(NOT OROCOS_NO_AUTO_LINKING AND USE_OROCOS_LIBRARIES)
+      target_link_libraries( ${LIB_TARGET_NAME} ${USE_OROCOS_LIBRARIES} )
+      if("$ENV{VERBOSE}" OR ORO_USE_VERBOSE)
+        message(STATUS "[UseOrocos] Linking target '${LIB_TARGET_NAME}' with libraries from packages '${USE_OROCOS_PACKAGES}'. To disable this, set OROCOS_NO_AUTO_LINKING to true.")
+      endif()
+    endif()
+
     INSTALL(TARGETS ${LIB_TARGET_NAME} LIBRARY DESTINATION ${AC_INSTALL_DIR} ARCHIVE DESTINATION lib RUNTIME DESTINATION ${AC_INSTALL_RT_DIR})
 
     # Necessary for .pc file generation
@@ -444,6 +460,14 @@ macro( orocos_library LIB_TARGET_NAME )
     TARGET_LINK_LIBRARIES( ${EXE_TARGET_NAME} 
       ${OROCOS-RTT_LIBRARIES} 
       )
+
+    # Only link in case there is something *and* the user didn't opt-out:
+    if(NOT OROCOS_NO_AUTO_LINKING AND USE_OROCOS_LIBRARIES)
+      target_link_libraries( ${EXE_TARGET_NAME} ${USE_OROCOS_LIBRARIES} )
+      if("$ENV{VERBOSE}" OR ORO_USE_VERBOSE)
+        message(STATUS "[UseOrocos] Linking target '${EXE_TARGET_NAME}' with libraries from packages '${USE_OROCOS_PACKAGES}'. To disable this, set OROCOS_NO_AUTO_LINKING to true.")
+      endif()
+    endif()
 
     # We install the exe, the user must make sure that the install dir is not
     # beneath the ROS package (if any).
@@ -565,6 +589,14 @@ macro( orocos_library LIB_TARGET_NAME )
       ${OROCOS-RTT_LIBRARIES} 
       )
 
+    # Only link in case there is something *and* the user didn't opt-out:
+    if(NOT OROCOS_NO_AUTO_LINKING AND USE_OROCOS_LIBRARIES)
+      target_link_libraries( ${LIB_TARGET_NAME} ${USE_OROCOS_LIBRARIES} )
+      if("$ENV{VERBOSE}" OR ORO_USE_VERBOSE)
+        message(STATUS "[UseOrocos] Linking target '${LIB_TARGET_NAME}' with libraries from packages '${USE_OROCOS_PACKAGES}'. To disable this, set OROCOS_NO_AUTO_LINKING to true.")
+      endif()
+    endif()
+
     # On win32, typekit runtime (.dll) should go in orocos/types folder
     if( ${OROCOS_TARGET} STREQUAL "win32" )
       INSTALL(TARGETS ${LIB_TARGET_NAME} LIBRARY DESTINATION ${AC_INSTALL_DIR} ARCHIVE DESTINATION lib RUNTIME DESTINATION ${AC_INSTALL_DIR})
@@ -645,6 +677,14 @@ macro( orocos_library LIB_TARGET_NAME )
       ${OROCOS-RTT_LIBRARIES}
       #${OROCOS-RTT_TYPEKIT_LIBRARIES} 
       )
+
+    # Only link in case there is something *and* the user didn't opt-out:
+    if(NOT OROCOS_NO_AUTO_LINKING AND USE_OROCOS_LIBRARIES)
+      target_link_libraries( ${LIB_TARGET_NAME} ${USE_OROCOS_LIBRARIES} )
+      if("$ENV{VERBOSE}" OR ORO_USE_VERBOSE)
+        message(STATUS "[UseOrocos] Linking target '${LIB_TARGET_NAME}' with libraries from packages '${USE_OROCOS_PACKAGES}'. To disable this, set OROCOS_NO_AUTO_LINKING to true.")
+      endif()
+    endif()
 
     # On win32, plugins runtime (.dll) should go in orocos/plugins folder
     if( ${OROCOS_TARGET} STREQUAL "win32" )


### PR DESCRIPTION
**The patches in this pull request are very experimental and need extensive testing!**

All patches could be applied independently. I built rtt_ros_integration and some catkin and rosbuild packages without problems, but especially the auto-linking patch (4b7fc9749e3ee366dc8620b2a090974eb4d44004) has to be tested on different platforms and with different compilers.
- https://github.com/meyerj/rtt/commit/7e561cc363ab9b2bbdb2492175202392be8a17df: adds a guard to not parse `UseOROCOS-RTT.cmake` twice. This is only a minor issue and suppresses duplicate output messages due to multiple direct and indirect includes in the same package, e.g. for typekit / service proxy packages.
- https://github.com/meyerj/rtt/commit/95ac8857e9705d86bb18c2c055e15122e471576c: can be considered a bug fix. Due to the renamed `USE_OROCOS_COMPILE_FLAGS` and `USE_OROCOS_LINK_FLAGS` variables and the set commands in [UseOROCOS-RTT-helpers.cmake:347](https://github.com/meyerj/rtt/blob/4b7fc9749e3ee366dc8620b2a090974eb4d44004/UseOROCOS-RTT-helpers.cmake#L347) the initial settings in [UseOROCOS-RTT.cmake:55](https://github.com/meyerj/rtt/blob/4b7fc9749e3ee366dc8620b2a090974eb4d44004/UseOROCOS-RTT.cmake#L55) are overridden by the `orocos_use_package()` macro. I replaced them with the new names `USE_OROCOS_CFLAGS_OTHER` and `USE_OROCOS_LDFLAGS_OTHER`. Or do you prefer to keep the old names?
- https://github.com/meyerj/rtt/commit/b39f12bcfe5cffd0323cfaec2ce429df2fd45e1f: `LINK_DIRECTORIES( ${CMAKE_CURRENT_BINARY_DIR} )` seems to be an remnant from the very beginning of UseOROCOS-RTT.cmake and is obviously not required any more.
- https://github.com/meyerj/rtt/commit/4b7fc9749e3ee366dc8620b2a090974eb4d44004: changes the way the auto-linking is done. Instead of using the deprecated `link_libraries()` cmake command to link all targets to the `USE_OROCOS_LIBRARIES`, only the targets created with the `orocos_*()` macros will link automatically unless `OROCOS_NO_AUTO_LINKING` is set. Another advantage is that auto-linking can still be disabled or enabled after `UseOROCOS-RTT.cmake` has been included.
  
  Furthermore, I do not see a good reason not to enable auto-linking by default in catkin builds if it works like this and has no effect on non-Orocos targets. It has been disabled in https://github.com/jhu-lcsr-forks/rtt/commit/071e19778bd4fb5fc5abc1246e435bfd6fc35de8, I guess in order to mimic the need for explicit linking to `${catkin_LIBRARIES}` in catkin. But especially if catkin is only used as a build-tool and a package has no dependencies to non-Orocos packages there is no reason to break the meaning of `orocos_use_package()` or to confuse users with different effects for different build systems.
