### PR TITLE
Fix installation of empty directory if DESTDIR environment variable is set

### DIFF
--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -954,7 +954,7 @@ Cflags: -I\${includedir} \@PC_EXTRA_INCLUDE_DIRS\@
     orocos_uninstall_target()
 
     # Create install target for orocos installed package directory
-    install(CODE "FILE(MAKE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME})")
+    install(CODE "FILE(MAKE_DIRECTORY \$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME})")
 
     # Call catkin_package() here if the user has not called it before.
     if( ORO_USE_CATKIN


### PR DESCRIPTION
This patch should fix https://github.com/orocos-toolchain/rtt/commit/db7879ab36d16ec062e828c2ce33ea59fe3a1e5e#commitcomment-5313342. Tested locally with git-bloom-release and dpkg-buildpackage as an unprivileged used without write permission to the real install directory.
