### PR TITLE
Re-enable auto-linking for catkin builds

### DIFF
--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -115,12 +115,12 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
     set (OROCOS_SUFFIX "/${OROCOS_TARGET}")
   endif()
 
+  # Enable auto-linking
+  set(OROCOS_NO_AUTO_LINKING OFF CACHE BOOL "Disable automatic linking to targets in orocos_use_package() or from dependencies in the package manifest. Auto-linking is enabled by default.")
+
   if (ORO_USE_ROSBUILD)
     # Infer package name from directory name.
     get_filename_component(ORO_ROSBUILD_PACKAGE_NAME ${PROJECT_SOURCE_DIR} NAME)
-
-    # Enable auto-linking
-    set(OROCOS_NO_AUTO_LINKING False CACHE BOOL "Disable automatic linking to targets in orocos_use_package() or from dependencies in the package manifest. Auto-linking is enabled for rosbuild packages by default.")
 
     # Modify default rosbuild output paths if using Eclipse
     if (CMAKE_EXTRA_GENERATOR STREQUAL "Eclipse CDT4")
@@ -165,14 +165,11 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
     rosbuild_invoke_rospack(${ORO_ROSBUILD_PACKAGE_NAME} pkg DEPS depends1)
     string(REGEX REPLACE "\n" ";" pkg_DEPS2 "${pkg_DEPS}" )
     foreach(ROSDEP ${pkg_DEPS2})
-      orocos_use_package( ${ROSDEP} )
+      orocos_use_package( ${ROSDEP} OROCOS_ONLY)
     endforeach(ROSDEP ${pkg_DEPS2})
 
   elseif(ORO_USE_CATKIN)
-    # Disable auto-linking
-    set(OROCOS_NO_AUTO_LINKING True CACHE BOOL "Disable automatic linking to targets in orocos_use_package() or from dependencies in the package manifest. Auto-linking is disabled for catkin packages by default.")
-
-    # Parse package.xml file
+     # Parse package.xml file
     if(NOT _CATKIN_CURRENT_PACKAGE)
       catkin_package_xml()
     endif()
@@ -200,9 +197,6 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
     endforeach(DEP ${DEPS}) 
 
   else()
-    # Enable auto-linking
-    set(OROCOS_NO_AUTO_LINKING False CACHE BOOL "Disable automatic linking to targets in orocos_use_package() or from dependencies in the package manifest. Auto-linking is enabled by default.")
-
     # Set output directories relative to CMAKE_LIBRARY_OUTPUT_DIRECTORY or built in the current binary directory (cmake default).
     if(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
       set(ORO_COMPONENT_OUTPUT_DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/orocos${OROCOS_SUFFIX}/${PROJECT_NAME})
@@ -218,7 +212,7 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
     orocos_get_manifest_deps( DEPS )
     #message("orocos_get_manifest_deps are: ${DEPS}")
     foreach(DEP ${DEPS})
-      orocos_use_package( ${DEP} ) 
+      orocos_use_package( ${DEP} OROCOS_ONLY) 
     endforeach(DEP ${DEPS}) 
   endif()
 


### PR DESCRIPTION
With the current version of the `UseOROCOS-RTT.cmake` macro definitions I do not see a problem anymore to re-enable the auto-linking option (set the `OROCOS_NO_AUTO_LINKING` to `OFF`) also for builds that use catkin as a build tool. Using different default settings for this option depending on the build tool is not good practice and should be avoided if there is no very good reason to do so.

In the first versions of rtt adapted for catkin enabling auto-linking was indeed not a good idea as catkin also generates pkg-config files and the Orocos auto-linking feature used to generate huge linker command line as it could not distinguish between Orocos and non-Orocos packages. But especially since the introduction of the `OROCOS_ONLY` flag in 6c48b01c and the fact that auto-linking only acts on targets that are defined by the `orocos_*` macros since 4b7fc974 this should be solved now.

Furthermore I added the `OROCOS_ONLY` option also for dependencies parsed from the `manifest.xml` file in rosbuild and pure cmake packages. rosbuild packages can depend on catkin-packages and the rosbuild macros `rosbuild_add_*` already use the catkin-generated pkg-files to get compile and linker flags in this case (by invoking `rospack` internally). So the same reasoning why we need `OROCOS_ONLY` for catkin to avoid double linking applies to rosbuild, too.
