### PR TITLE
PluginLoader: Making mutex recursive to enable plugins to load other plugins

### DIFF
--- a/rtt/plugin/PluginLoader.hpp
+++ b/rtt/plugin/PluginLoader.hpp
@@ -105,7 +105,7 @@ namespace RTT {
             /**
              * Protects for concurrent access of this shared object.
              */
-            mutable os::Mutex listlock;
+            mutable os::MutexRecursive listlock;
 
             /**
              * Internal function that does all library loading.


### PR DESCRIPTION
Is there any particular reason why this shouldn't be a recursive lock? I ran into a deadlock when a call to `loadService` caused a service to use a service requester to load _another_ service.
