### PR TITLE
ServiceRequesters are managed by shared pointers

### DIFF
--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -134,7 +134,7 @@ namespace RTT
             // [Rule no 2: Don't call virtual functions in a constructor.]
             tcservice->clear();
 
-            delete tcrequests;
+            tcrequests->clear();
 
             // remove from all users.
             while( !musers.empty() ) {
@@ -201,7 +201,7 @@ namespace RTT
         for (vector<string>::iterator it = myreqs.begin();
              it != myreqs.end();
              ++it) {
-            ServiceRequester* sr = this->requires(*it);
+            ServiceRequester::shared_ptr sr = this->requires(*it);
             if ( !sr->ready() ) {
                 if (peer->provides()->hasService( *it ))
                     success = sr->connectTo( peer->provides(*it) ) && success;
@@ -215,7 +215,7 @@ namespace RTT
         for (vector<string>::iterator it = peerreqs.begin();
                 it != peerreqs.end();
                 ++it) {
-            ServiceRequester* sr = peer->requires(*it);
+            ServiceRequester::shared_ptr sr = peer->requires(*it);
             if ( !sr->ready() ) {
                 if (this->provides()->hasService(*it))
                     success = sr->connectTo( this->provides(*it) ) && success;

--- a/rtt/TaskContext.hpp
+++ b/rtt/TaskContext.hpp
@@ -278,13 +278,13 @@ namespace RTT
          * Returns the object that manages which methods this Task
          * requires to be implemented by another task.
          */
-        ServiceRequester* requires() { return tcrequests; }
+        ServiceRequester::shared_ptr requires() { return tcrequests; }
 
         /**
          * Returns the object that manages which methods this Task
          * requires to be implemented by another service.
          */
-        ServiceRequester* requires(const std::string& service_name) {
+        ServiceRequester::shared_ptr requires(const std::string& service_name) {
             return tcrequests->requires(service_name);
         }
 
@@ -670,7 +670,7 @@ namespace RTT
         LocalServices localservs;
 
         Service::shared_ptr tcservice;
-        ServiceRequester*           tcrequests;
+        ServiceRequester::shared_ptr tcrequests;
         os::Mutex mportlock;
 
         // non copyable

--- a/rtt/transports/corba/ServiceRequesterI.cpp
+++ b/rtt/transports/corba/ServiceRequesterI.cpp
@@ -74,7 +74,7 @@ using namespace RTT;
 using namespace RTT::detail;
 
 // Implementation skeleton constructor
-RTT_corba_CServiceRequester_i::RTT_corba_CServiceRequester_i ( RTT::ServiceRequester* service, PortableServer::POA_ptr poa )
+RTT_corba_CServiceRequester_i::RTT_corba_CServiceRequester_i ( RTT::ServiceRequester::shared_ptr service, PortableServer::POA_ptr poa )
     : mservice(service), mpoa( PortableServer::POA::_duplicate(poa) )
 {
 }

--- a/rtt/transports/corba/ServiceRequesterI.h
+++ b/rtt/transports/corba/ServiceRequesterI.h
@@ -87,12 +87,12 @@ class  RTT_corba_CServiceRequester_i
     : public virtual POA_RTT::corba::CServiceRequester, public virtual PortableServer::RefCountServantBase
 {
 protected:
-    RTT::ServiceRequester* mservice;
+    RTT::ServiceRequester::shared_ptr mservice;
     std::map<std::string, std::pair<RTT::corba::CServiceRequester_var, PortableServer::ServantBase_var> > mrequests;
     PortableServer::POA_var mpoa;
 public:
   // Constructor 
-    RTT_corba_CServiceRequester_i (RTT::ServiceRequester* service, PortableServer::POA_ptr poa);
+    RTT_corba_CServiceRequester_i (RTT::ServiceRequester::shared_ptr service, PortableServer::POA_ptr poa);
   
   // Destructor 
   virtual ~RTT_corba_CServiceRequester_i (void);

--- a/rtt/transports/corba/TaskContextProxy.cpp
+++ b/rtt/transports/corba/TaskContextProxy.cpp
@@ -197,7 +197,7 @@ namespace RTT
         log(Debug) << "All Done."<<endlog();
     }
 
-    void TaskContextProxy::fetchRequesters(ServiceRequester* parent, CServiceRequester_ptr csrq)
+    void TaskContextProxy::fetchRequesters(ServiceRequester::shared_ptr parent, CServiceRequester_ptr csrq)
     {
         COperationCallerNames_var opcnames = csrq->getOperationCallerNames();
 
@@ -216,7 +216,7 @@ namespace RTT
                 continue;
             CServiceRequester_var cobj = csrq->getRequest(rqlist[i]);
 
-            ServiceRequester* tobj = this->requires(std::string(rqlist[i]));
+            ServiceRequester::shared_ptr tobj = this->requires(std::string(rqlist[i]));
 
             // Recurse:
             this->fetchRequesters( tobj, cobj.in() );

--- a/rtt/transports/corba/TaskContextProxy.hpp
+++ b/rtt/transports/corba/TaskContextProxy.hpp
@@ -117,7 +117,7 @@ namespace RTT
          */
         static PortableServer::POA_var proxy_poa;
 
-        void fetchRequesters(ServiceRequester* parent, CServiceRequester_ptr csrq);
+        void fetchRequesters(ServiceRequester::shared_ptr parent, CServiceRequester_ptr csrq);
         void fetchServices(Service::shared_ptr parent, CService_ptr mtask);
         void fetchPorts(Service::shared_ptr parent, CDataFlowInterface_ptr serv);
     public:


### PR DESCRIPTION
Recreated from #24, but removed inheritance from `DataFlowInterface`:
- Use shared pointers to manage ServiceRequester instances internally, like for Services.
- Added `ServiceRequester::addServiceRequester(shared_ptr)` and
  `ServiceRequester::setOwner(TaskContext *)` member functions to add service
  requesters created elsewhere to the interface (in analogy to `Service::addService(shared_ptr)`).
- Make `ServiceRequester::connectTo()` a virtual function so that implementations can
  override it (e.g. to connect ports). This replaces inheritance from `DataFlowInterface` compared to #24
  and still enables ServiceRequesters which have ports.

This patch breaks the `ServiceRequester` API and requires patches in [ocl](https://github.com/orocos-toolchain/ocl/compare/master...servicerequester-refactoring) and [rtt_ros_integration/ros_comm](https://github.com/orocos/rtt_ros_integration/compare/hydro-devel...servicerequester-refactoring).
