### PR TITLE
tests: don't require that a fd activity is running right after component...

### DIFF
--- a/tests/taskthread_fd_test.cpp
+++ b/tests/taskthread_fd_test.cpp
@@ -183,7 +183,6 @@ BOOST_AUTO_TEST_CASE(testFileDescriptor_Write )
     BOOST_CHECK( mtask->isWatched(mcomp.fd[0]) == true );
 
     BOOST_CHECK( mcomp.start() == true );
-    BOOST_CHECK( mtask->isRunning() == false );
     BOOST_CHECK( mtask->hasError() == false );
     BOOST_CHECK( mtask->hasTimeout() == false );
 
@@ -258,7 +257,6 @@ BOOST_AUTO_TEST_CASE(testFileDescriptor_Timeout )
 	mtask->setTimeout( timeout_ms );
 	BOOST_CHECK( timeout_ms == mtask->getTimeout() );
     BOOST_CHECK( mcomp.start() == true );
-    BOOST_CHECK( mtask->isRunning() == false );
 
 	// no activity
     usleep(1000000/4);


### PR DESCRIPTION
... start

Since components trigger when started, the fd activity is shortly running.
Travis found this from time to time.
