### PR TITLE
cmake: remove duplicate rpath settings for Apple

### DIFF
--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -299,7 +299,6 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       SET_TARGET_PROPERTIES( ${COMPONENT_NAME} PROPERTIES
 	INSTALL_NAME_DIR "@rpath"
 	)
-      orocos_add_link_flags( ${COMPONENT_NAME} "-Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX},-rpath,${CMAKE_INSTALL_PREFIX}/lib,-rpath,${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
     endif()
 
     orocos_add_compile_flags( ${COMPONENT_NAME} ${USE_OROCOS_CFLAGS_OTHER})
@@ -389,7 +388,6 @@ macro( orocos_library LIB_TARGET_NAME )
       SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
         INSTALL_NAME_DIR "@rpath"
         )
-      orocos_add_link_flags( ${LIB_TARGET_NAME} "-Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib,-rpath,${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
     endif()
 
     orocos_add_compile_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_CFLAGS_OTHER} )
@@ -459,7 +457,6 @@ macro( orocos_library LIB_TARGET_NAME )
       SET_TARGET_PROPERTIES( ${EXE_TARGET_NAME} PROPERTIES
 	INSTALL_NAME_DIR "@rpath"
 	)
-      orocos_add_link_flags( ${EXE_TARGET_NAME} "-Wl,-rpath,${CMAKE_INSTALL_PREFIX}/bin,-rpath,${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
     endif()
 
     if(CMAKE_DEBUG_POSTFIX)
@@ -594,7 +591,6 @@ macro( orocos_library LIB_TARGET_NAME )
       SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
 	INSTALL_NAME_DIR "@rpath"
 	)
-      orocos_add_link_flags( ${LIB_TARGET_NAME} "-Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib,-rpath,${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/types,-rpath,${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
     endif()
 
     orocos_add_compile_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_CFLAGS_OTHER})
@@ -682,7 +678,6 @@ macro( orocos_library LIB_TARGET_NAME )
       SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
 	INSTALL_NAME_DIR "@rpath"
 	)
-      orocos_add_link_flags( ${LIB_TARGET_NAME} "-Wl,-rpath,${CMAKE_INSTALL_PREFIX}/lib,-rpath,${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/plugins,-rpath,${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
     endif()
 
     orocos_add_compile_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_CFLAGS_OTHER})


### PR DESCRIPTION
On OSX 10.9, with Apple Clang 5.1 and cmake 3.0.0 I got an error from install_name_tool complaining about duplicate paths resulting in broken dylibs and executables. The attached patch fixes this and has been verified to not break stuff on OSX 10.8 with Apple Clang 5.1 and cmake 2.8.12 and Ubuntu 12.04, gcc cmake 2.8.10.

Signed-off-by: Ruben Smits ruben.smits@intermodalics.eu
