### PR TITLE
Do not reset the caller engine in OperationCaller assignment

### DIFF
--- a/rtt/OperationCaller.hpp
+++ b/rtt/OperationCaller.hpp
@@ -219,7 +219,7 @@ namespace RTT
         {
             if (this->impl && this->impl == implementation)
                 return *this;
-            OperationCaller<Signature> tmp(implementation);
+            OperationCaller<Signature> tmp(implementation, mcaller);
             *this = tmp;
             return *this;
         }
@@ -241,7 +241,7 @@ namespace RTT
             }
             if (this->impl && this->impl == part->getLocalOperation() )
                 return *this;
-            OperationCaller<Signature> tmp(part);
+            OperationCaller<Signature> tmp(part, mcaller);
             *this = tmp;
             return *this;
         }
@@ -263,7 +263,7 @@ namespace RTT
                 log(Error) << "Can't initialise unnamed OperationCaller from service '"<<service->getName() <<"'."<<endlog();
                 return *this;
             }
-            OperationCaller<Signature> tmp(mname,service);
+            OperationCaller<Signature> tmp(mname, service, mcaller);
             *this = tmp;
             return *this;
         }


### PR DESCRIPTION
The caller engine given in the OperationCaller constructor is overwritten by the assignment operator. If the RHS of the assignment does not have its own caller (e.g. another OperationCaller instance), the original caller should not be reset.

Use case:

```
RTT::OperationCaller<bool()> op("bar", this->engine());
op = this->getPeer("foo")->getOperation("bar");
assert(op.mcaller);
```
