### PR TITLE
Fixed RTT::Timer

### DIFF
--- a/rtt/os/Timer.hpp
+++ b/rtt/os/Timer.hpp
@@ -72,7 +72,6 @@ namespace RTT
          */
         typedef int TimerId;
     protected:
-        TimeService* mTimeserv;
         base::ActivityInterface* mThread;
         Semaphore msem;
         mutable Mutex m;


### PR DESCRIPTION
Commit 2c7c2c8e4a74ebb442e91da3a9e6f7e9cbdf01cb broke RTT timers as the due time is set using relative `RTT::TimeService::getNSecs()` while timers use semaphores waiting in absolute time internally. This patch replaces the TimeService call by `rtos_get_time_ns()` directly.

TimeService normally counts time from zero, while `rtos_get_time_ns()` uses CLOCK_REALTIME directly.
Timers are using semaphores internally which can only handle CLOCK_REALTIME.
