### PR TITLE
extras/slaveactivity: fix potential segfault if no master activity is set

### DIFF
--- a/rtt/extras/SlaveActivity.cpp
+++ b/rtt/extras/SlaveActivity.cpp
@@ -179,7 +179,9 @@ namespace RTT {
 
     bool SlaveActivity::trigger()
     {
-        ExecutionEngine *master = dynamic_cast<ExecutionEngine*>( mmaster->getRunner() );
+        ExecutionEngine *master = 0;
+        if (mmaster)
+            master = dynamic_cast<ExecutionEngine*>( mmaster->getRunner() );
         ExecutionEngine * r= dynamic_cast<ExecutionEngine*>( runner );
         if(!master || !r){
             Logger::log() << Logger::Fatal << " SlaveActivity: cannot push messages to another engine, current engine is unsupported." << Logger::endl;


### PR DESCRIPTION
There is some unprotected usage of mmaster in trigger. Starting a component with a SlaveActivity without a MasterActivity results in a segfault.

Signed-off-by: Ruben Smits ruben.smits@intermodalics.eu
