### PR TITLE
corba: explicitly provide GlobalEngine::Instance when calling operations

### DIFF
--- a/rtt/transports/corba/OperationInterfaceI.cpp
+++ b/rtt/transports/corba/OperationInterfaceI.cpp
@@ -74,6 +74,7 @@
 #include "../../internal/OperationCallerC.hpp"
 #include "../../internal/SendHandleC.hpp"
 #include "../../Logger.hpp"
+#include "../../internal/GlobalEngine.hpp"
 
 using namespace RTT;
 using namespace RTT::detail;
@@ -326,7 +327,7 @@ void RTT_corba_COperationInterface_i::checkOperation (
         throw ::RTT::corba::CNoSuchNameException( operation );
     try {
         OperationInterfacePart* mofp = mfact->getPart(operation);
-        OperationCallerC mc(mofp, operation, 0);
+        OperationCallerC mc(mofp, operation, internal::GlobalEngine::Instance());
         for (unsigned int i = 0; i < mofp->arity() && i < args.length(); ++i) {
             const TypeInfo* ti = mofp->getArgumentType(i+1);
             assert(ti);
@@ -364,7 +365,7 @@ void RTT_corba_COperationInterface_i::checkOperation (
         throw ::RTT::corba::CNoSuchNameException( operation );
     // convert Corba args to C++ args.
     try {
-        OperationCallerC orig(mfact->getPart(operation), operation, 0);
+        OperationCallerC orig(mfact->getPart(operation), operation, internal::GlobalEngine::Instance());
         vector<DataSourceBase::shared_ptr> results;
         for (size_t i =0; i != args.length(); ++i) {
             const TypeInfo* ti = mfact->getPart(operation)->getArgumentType( i + 1);
@@ -421,7 +422,7 @@ void RTT_corba_COperationInterface_i::checkOperation (
         throw ::RTT::corba::CNoSuchNameException( operation );
     // convert Corba args to C++ args.
     try {
-        OperationCallerC orig(mfact->getPart(operation), operation, 0);
+        OperationCallerC orig(mfact->getPart(operation), operation, internal::GlobalEngine::Instance());
         for (size_t i =0; i != args.length(); ++i) {
             const TypeInfo* ti = mfact->getPart(operation)->getArgumentType( i + 1);
             CorbaTypeTransporter* ctt = dynamic_cast<CorbaTypeTransporter*> ( ti->getProtocol(ORO_CORBA_PROTOCOL_ID) );


### PR DESCRIPTION
This fixes calling operations after dc81be1

Operations now must have an explicit engine assigned, but the CORBA
layer was still passing the NULL engine (which was defaulting to
GlobalEngine() beforehand).
