### PR TITLE
Do not invoke user callbacks or trigger the component if it is not running

### DIFF
--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -424,10 +424,14 @@ namespace RTT
 
     void TaskContext::dataOnPort(PortInterface* port)
     {
-        if ( this->dataOnPortHook(port) && this->isRunning() ) {
+        if ( this->dataOnPortHook(port) ) {
             portqueue->enqueue( port );
             this->getActivity()->trigger();
         }
+    }
+
+    bool TaskContext::dataOnPortHook( base::PortInterface* ) {
+        return this->isRunning();
     }
 
     void TaskContext::dataOnPortCallback(InputPortInterface* port, TaskContext::SlotFunction callback) {

--- a/rtt/TaskContext.hpp
+++ b/rtt/TaskContext.hpp
@@ -606,14 +606,15 @@ namespace RTT
          * event ports is handled by the component. This
          * method will be executed in the writer's thread.
          *
+         * The default implementation returns true if and only if
+         * the component is running.
+         *
          * @retval true to indicate that the user callback should be
-         * invoked and trigger the component (the default)
+         * invoked and trigger the component
          * @retval false to ignore the new data and not trigger the
          * component or invoke a user callback
          */
-        virtual bool dataOnPortHook( base::PortInterface* port ) {
-            return true;
-        }
+        virtual bool dataOnPortHook( base::PortInterface* port );
 
     private:
 


### PR DESCRIPTION
Possible fix for #61: addEventPort callbacks are called too often
