### PR TITLE
updateHook() called too often

### DIFF
--- a/rtt/DataFlowInterface.cpp
+++ b/rtt/DataFlowInterface.cpp
@@ -153,6 +153,8 @@ namespace RTT
 #endif
         if (callback)
             mservice->getOwner()->dataOnPortCallback(&port,callback); // the handle will be deleted when the port is removed.
+        else
+            mservice->getOwner()->dataOnPortCallback(&port,boost::bind(&TaskCore::trigger, mservice->getOwner()) ); // default schedules an updateHook()
 
 #ifndef ORO_SIGNALLING_PORTS
         port.signalInterface(true);

--- a/rtt/DataFlowInterface.hpp
+++ b/rtt/DataFlowInterface.hpp
@@ -107,9 +107,12 @@ namespace RTT
          * add a Service with the same name of the port.
          * @param name The name to give to the port.
          * @param port The port to add.
-         * @param callback (Optional) provide a function which will be called asynchronously
-         * when new data arrives on this port. You can add more functions by using the port
-         * directly using base::PortInterface::getNewDataOnPort().
+         * @param callback (Optional) provide a function which will be called
+         * when new data arrives on this port. The callback function will
+         * be called \b instead of updateHook(). Use this->trigger() in your
+         * callback function in order to schedule an updateHook() nevertheless
+         * in the same cycle. If callback is not provided, updateHook() will be
+         * executed by default.
          */
         base::InputPortInterface& addEventPort(const std::string& name, base::InputPortInterface& port, SlotFunction callback = SlotFunction() ) {
             if ( !chkPtr("addEventPort", name, &port) ) return port;
@@ -121,12 +124,14 @@ namespace RTT
          * Add an Event triggering Port to the interface of this task and
          * add a Service with the same name of the port.
          * When data arrives on this port your TaskContext will be woken up
-         * and updateHook will be executed.
+         * and updateHook() will be executed by default.
          * @param port The port to add.
          * @param callback (Optional) provide a function which will be called
          * when new data arrives on this port. The callback function will
-         * be called in sequence with updateHook(), so asynchronously with
-         * regard to the arrival of data on the port.
+         * be called \b instead of updateHook(). Use this->trigger() in your
+         * callback function in order to schedule an updateHook() nevertheless
+         * in the same cycle. If callback is not provided, updateHook() will be
+         * executed by default.
          * @return \a port
          */
         base::InputPortInterface& addEventPort(base::InputPortInterface& port, SlotFunction callback = SlotFunction() );

--- a/rtt/ExecutionEngine.cpp
+++ b/rtt/ExecutionEngine.cpp
@@ -46,6 +46,7 @@
 #include "TaskContext.hpp"
 #include "internal/CatchConfig.hpp"
 #include "extras/SlaveActivity.hpp"
+#include "os/TimeService.hpp"
 
 #include <boost/bind.hpp>
 #include <boost/ref.hpp>
@@ -73,7 +74,7 @@ namespace RTT
         : taskc(owner),
           mqueue(new MWSRQueue<DisposableInterface*>(ORONUM_EE_MQUEUE_SIZE) ),
           f_queue( new MWSRQueue<ExecutableInterface*>(ORONUM_EE_MQUEUE_SIZE) ),
-          mmaster(0)
+          mmaster(0), update_period(-1.0), mtrigger(false)
     {
     }
 
@@ -284,6 +285,16 @@ namespace RTT
         mmaster = master;
     }
 
+    bool ExecutionEngine::setPeriod( Seconds s ) {
+        update_period = s;
+        this->getActivity()->setPeriod(0.0);
+        return true;
+    }
+
+    Seconds ExecutionEngine::getPeriod() const {
+        return update_period >= 0.0 ? update_period : this->getActivity()->getPeriod();
+    }
+
     void ExecutionEngine::setActivity( base::ActivityInterface* task )
     {
         extras::SlaveActivity *slave_activity = dynamic_cast<extras::SlaveActivity *>(task);
@@ -344,10 +355,83 @@ namespace RTT
         }
     }
 
+    bool ExecutionEngine::trigger() {
+        if ( update_period < 0) {
+            mtrigger = true;
+            return this->getActivity()->trigger();
+        }
+        if ( update_period > 0) {
+            return false;
+        }
+        mtrigger = true;
+        msg_cond.broadcast();
+        return this->getActivity()->trigger();
+    }
+
+    bool ExecutionEngine::execute() {
+        if ( update_period < 0) {
+            return this->getActivity()->execute();
+        }
+        step();
+        return true;
+    }
+
     void ExecutionEngine::step() {
         processMessages();
+        if (taskc) taskc->prepareUpdateHook();
         processFunctions();
-        processChildren(); // aren't these ExecutableInterfaces ie functions ?
+        processChildren();
+    }
+
+    void ExecutionEngine::loop() {
+        nsecs wakeup = 0;
+
+        while ( true ) {
+            // since update_period may be changed at any time, we need to recheck it each time:
+            if ( update_period > 0.0) {
+                // initialize first wakeup time if we are periodic.
+                if ( wakeup == 0 ) {
+                    wakeup = os::TimeService::Instance()->getNSecs() + Seconds_to_nsecs(update_period);
+                }
+            } else {
+                // only clear if update_period <= 0.0 :
+                wakeup = 0;
+            }
+
+            // first, process messages + execute callback functions
+            processMessages();
+            if (taskc) taskc->prepareUpdateHook();
+
+
+            // periodic: we flag mtrigger below; non-periodic: we flag mtrigger in trigger()
+            if (mtrigger) {
+                mtrigger = false;
+                processFunctions();
+                processChildren();
+            }
+            // next, sleep/wait
+            os::MutexLock lock(msg_lock);
+            if ( wakeup == 0 ) {
+                // non periodic, default behavior:
+                //msg_cond.wait(msg_lock);
+                return;
+            } else {
+                // If periodic, sleep until wakeup time or a message comes in.
+                // when wakeup time passed, wait_until will return false and we recalculate wakeup + mtrigger
+                bool time_elapsed = ! msg_cond.wait_until(msg_lock,wakeup);
+
+                if (time_elapsed) {
+                    // calculate next wakeup point, overruns causes skips:
+                    while ( wakeup < os::TimeService::Instance()->getNSecs() )
+                        wakeup = wakeup + Seconds_to_nsecs(update_period);
+                    mtrigger = true;
+                }
+            }
+            if (mstopRequested) {
+                mstopRequested = false; // guarded by Mutex lock
+                return;
+            }
+        }
     }
 
     void ExecutionEngine::processChildren() {
@@ -356,7 +440,6 @@ namespace RTT
             // A trigger() in startHook() will be ignored, we trigger in TaskCore after startHook finishes.
             if ( taskc->mTaskState == TaskCore::Running && taskc->mTargetState == TaskCore::Running ) {
                 TRY (
-                    taskc->prepareUpdateHook();
                     taskc->updateHook();
                 ) CATCH(std::exception const& e,
                     log(Error) << "in updateHook(): switching to exception state because of unhandled exception" << endlog();
@@ -421,6 +504,11 @@ namespace RTT
         for (std::vector<TaskCore*>::iterator it = children.begin(); it != children.end();++it) {
             ok = (*it)->breakUpdateHook() && ok;
             }
+        os::MutexLock lock(msg_lock); // protects stopRequested
+        if (ok) {
+            mstopRequested = true;
+            msg_cond.broadcast();
+        }
         return ok;
     }
 

--- a/rtt/ExecutionEngine.hpp
+++ b/rtt/ExecutionEngine.hpp
@@ -109,6 +109,37 @@ namespace RTT
         base::TaskCore* getTaskCore() const { return taskc; }
 
         /**
+         * Sets the period at which updateHook() will be called, in seconds.
+         * If s == 0, updateHook() will be called each time trigger() is called.
+         */
+        bool setPeriod(Seconds s);
+
+        /**
+         * Returns the update period of this engine.
+         */
+        Seconds getPeriod() const;
+
+        /**
+         * Invoke this method to \a trigger the thread of this ExecutionEngine to execute
+         * and call the updateHook() method asynchronously.
+         * @retval false if this->engine()->getActivity()->trigger() == false
+         * @retval true otherwise.
+         */
+        bool trigger();
+
+        /**
+         * Invoke this method to \a execute
+         * the updateHook() method synchronously. This
+         * method is only useful if this Engine is a Slave (ie
+         * it doesn't have it's own thread) and is to be called
+         * from the Master.
+         *
+         * @retval false if this->engine()->getActivity()->execute() == false
+         * @retval true otherwise.
+         */
+        bool execute();
+
+        /**
          * Queue and execute (process) a given message. The message is
          * executed in step() or loop() directly after all other
          * queued ActionInterface objects. The constructor parameter
@@ -269,6 +300,16 @@ namespace RTT
          */
         ExecutionEngine *mmaster;
 
+        /**
+         * The period at which the TaskCore's updateHook() must be called.
+         */
+        double update_period;
+
+        /**
+         * When set to true, a next step() will execute runFunctions() and if Running, updateHook() as well.
+         */
+        bool mtrigger, mstopRequested;
+
         void processMessages();
         void processFunctions();
         void processChildren();
@@ -280,6 +321,8 @@ namespace RTT
          * functions of this TaskContext and its children.
          */
         virtual void step();
+
+        virtual void loop();
 
         virtual bool breakLoop();
 

--- a/rtt/base/TaskCore.cpp
+++ b/rtt/base/TaskCore.cpp
@@ -89,16 +89,16 @@ namespace RTT {
 
     bool TaskCore::update()
     {
-        if ( !this->engine()->getActivity() )
+        if ( !this->engine() )
             return false;
-        return this->engine()->getActivity()->execute();
+        return this->engine()->execute();
     }
 
     bool TaskCore::trigger()
     {
-        if ( !this->engine()->getActivity() )
+        if ( !this->engine() )
             return false;
-        return this->engine()->getActivity()->trigger();
+        return this->engine()->trigger();
     }
 
     bool TaskCore::configure() {
@@ -271,12 +271,12 @@ namespace RTT {
 
     Seconds TaskCore::getPeriod() const
     {
-        return this->engine()->getActivity() ? this->engine()->getActivity()->getPeriod() : -1.0;
+        return this->engine() ? this->engine()->getPeriod() : -1.0;
     }
 
     bool TaskCore::setPeriod(Seconds s)
     {
-        return this->engine()->getActivity() ? this->engine()->getActivity()->setPeriod(s) : false;
+        return this->engine() ? this->engine()->setPeriod(s) : false;
     }
 
     unsigned TaskCore::getCpuAffinity() const

--- a/rtt/base/TaskCore.hpp
+++ b/rtt/base/TaskCore.hpp
@@ -275,16 +275,20 @@ namespace RTT
 
         /**
          * Invoke this method to \a execute
-         * the ExecutionEngine and the update() method.
-         * @retval false if this->engine()->getActivity()->execute() == false
+         * the ExecutionEngine and the updateHook() method. This
+         * method is only useful if this TaskCore is a Slave (ie
+         * it doesn't have it's own thread) and is to be called
+         * from the Master.
+         *
+         * @retval false if this->engine()->execute() == false
          * @retval true otherwise.
          */
         virtual bool update();
 
         /**
-         * Invoke this method to \a trigger the thread of this TaskContext to execute
-         * its ExecutionEngine and the update() method.
-         * @retval false if this->engine()->getActivity()->trigger() == false
+         * Invoke this method to \a trigger the thread of this TaskCore to execute
+         * its ExecutionEngine and the updateHook() method asynchronously.
+         * @retval false if this->engine()->trigger() == false
          * @retval true otherwise.
          */
         virtual bool trigger();

--- a/tests/corba_ipc_server.cpp
+++ b/tests/corba_ipc_server.cpp
@@ -53,8 +53,12 @@ public:
     bool is_calling, is_sending;
     int cbcount;
 
+    void eventCallback( base::PortInterface* port) {
+        this->trigger(); // call updateHook()
+    }
+
     TheServer(string name) : TaskContext(name), mi1("mi"), mo1("mo"), is_calling(false), is_sending(false), cbcount(0) {
-        ports()->addEventPort( mi1 );
+        ports()->addEventPort( mi1, boost::bind(&TheServer::eventCallback, this, _1) );
         ports()->addPort( mo1 );
         this->createOperationCallerFactories( this );
         ts = corba::TaskContextServer::Create( this, true ); //use-naming

--- a/tests/corba_ipc_server.cpp
+++ b/tests/corba_ipc_server.cpp
@@ -53,12 +53,8 @@ public:
     bool is_calling, is_sending;
     int cbcount;
 
-    void eventCallback( base::PortInterface* port) {
-        this->trigger(); // call updateHook()
-    }
-
     TheServer(string name) : TaskContext(name), mi1("mi"), mo1("mo"), is_calling(false), is_sending(false), cbcount(0) {
-        ports()->addEventPort( mi1, boost::bind(&TheServer::eventCallback, this, _1) );
+        ports()->addEventPort( mi1 );
         ports()->addPort( mo1 );
         this->createOperationCallerFactories( this );
         ts = corba::TaskContextServer::Create( this, true ); //use-naming

--- a/tests/taskstates_test.cpp
+++ b/tests/taskstates_test.cpp
@@ -284,6 +284,8 @@ BOOST_AUTO_TEST_CASE( testTrigger )
     BOOST_CHECK( pertc.trigger() == false );
     BOOST_CHECK( pertc.start() == true );
     BOOST_CHECK( pertc.trigger() == false );
+    usleep(1000*1000); // let it run for 1s
+    BOOST_CHECK( pertc.trigger() == false );
 }
 
 /**


### PR DESCRIPTION
As discussed in length in this forum thread: http://www.orocos.org/forum/rtt/rtt-dev/changing-behaviour-updatehook :

We have observed lately two major issues:

> 1. updateHook() is called *too many times* (even according to
> specifications), especially when 'OwnThread' operations are implemented OR
> called(!).
> -> This was due to internal bookkeeping of the ExecutionEngine to dispatch
> the asynchronous requests. Users found it confusing that updateHook was
> called during the use of operations. This also kills performance of Lua
> state machines
> sitting in updateHook(), since they are evaluated too many times.
>
> 2. Installing a callback for an event port caused calling that callback AND
> updateHook(), instead of calling only the callback.
> -> The callback does not replace the call to updateHook(). This is also
> related to users being surprised that an event port callback is only called
> periodically in periodic threads, while they thought it would be called
> immediately upon each event reception, and eventually updateHook
> periodically (but serialized with the callbacks).
>
> The idea then rose to have updateHook() to only be called after:
> 1) any call to TaskContext::trigger()
> -> for activities which allow this user control
> 2) the component's activity triggered itself (periodic, file descriptor,
> ...)
> -> what users expect
> 3) the component is being update()
> -> for slave activity behavior

I'm creating a simple patch that addresses both issues, in a backwards compatible way.

