### PR TITLE
Clear service requester in TaskContext::clear()

### DIFF
--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -384,6 +384,7 @@ namespace RTT
     void TaskContext::clear()
     {
         tcservice->clear();
+        tcrequests->clear();
     }
 
     bool TaskContext::ready()


### PR DESCRIPTION
Just for completeness...

I was thinking about use cases where the user's component destructor uses the `TaskContext::clear()` method to cleanup its interface before it is destroyed to avoid pure virtual method calls or segfaults if services would still use a reference to the owner, but ServiceRequesters should be non-critical in this respect.
