### PR TITLE
Added a new Activity constructor

### DIFF
--- a/rtt/Activity.cpp
+++ b/rtt/Activity.cpp
@@ -67,15 +67,20 @@ namespace RTT
     {
     }
 
-     Activity::Activity(int scheduler, int priority, Seconds period, RunnableInterface* r, const std::string& name )
-         : ActivityInterface(r), os::Thread(scheduler, priority, period, 0, name )
-     {
-     }
+    Activity::Activity(int scheduler, int priority, RunnableInterface* r, const std::string& name )
+        : ActivityInterface(r), os::Thread(scheduler, priority, 0.0, 0, name )
+    {
+    }
 
-     Activity::Activity(int scheduler, int priority, Seconds period, unsigned cpu_affinity, RunnableInterface* r, const std::string& name )
-     : ActivityInterface(r), os::Thread(scheduler, priority, period, cpu_affinity, name )
-     {
-     }
+    Activity::Activity(int scheduler, int priority, Seconds period, RunnableInterface* r, const std::string& name )
+        : ActivityInterface(r), os::Thread(scheduler, priority, period, 0, name )
+    {
+    }
+
+    Activity::Activity(int scheduler, int priority, Seconds period, unsigned cpu_affinity, RunnableInterface* r, const std::string& name )
+    : ActivityInterface(r), os::Thread(scheduler, priority, period, cpu_affinity, name )
+    {
+    }
 
     Activity::~Activity()
     {

--- a/rtt/Activity.hpp
+++ b/rtt/Activity.hpp
@@ -103,6 +103,21 @@ namespace RTT
                  base::RunnableInterface* r = 0, const std::string& name ="Activity");
 
         /**
+         * @brief Create an Activity with a given scheduler type and priority.
+         *
+         * @param scheduler
+         *        The scheduler in which the activity's thread must run. Use ORO_SCHED_OTHER or
+         *        ORO_SCHED_RT.
+         * @param priority
+         *        The priority of this activity.
+         * @param r
+         *        The optional base::RunnableInterface to run exclusively within this Activity
+         * @param name The name of the underlying thread.
+         */
+        Activity(int scheduler, int priority,
+                 base::RunnableInterface* r = 0, const std::string& name ="Activity");
+
+        /**
          * @brief Create an Activity with a given scheduler type, priority and period.
          *
          * @param scheduler


### PR DESCRIPTION
This patch adds a constructor with the signature

``` cpp
Activity(int scheduler, int priority, base::RunnableInterface* r = 0, const std::string& name ="Activity");
```

to the `RTT::Activity` class.

Otherwise, the contructor call `Activity(ORO_SCHED_RT, os::HighestPriority)` would interpret the second argument as a double period time (= 99 seconds) and `ORO_SCHED_RT` as a priority (= 0), which can lead to very strange and unforeseen results:

``` cpp
Activity(int priority, Seconds period, base::RunnableInterface* r = 0, const std::string& name ="Activity");
```
