### PR TITLE
types: added assignment operators to RTT::types::carray to assign from boost::serialization::array and boost::array

### DIFF
--- a/rtt/types/carray.hpp
+++ b/rtt/types/carray.hpp
@@ -146,12 +146,44 @@ namespace RTT
              * the contents of the remaining elements is left unmodified. If it's greater,
              * the excess elements are ignored.
              */
-            const carray<T>& operator=( const carray<T>& orig ) {
+            template <class OtherT>
+            const carray<T>& operator=( const carray<OtherT>& orig ) {
                 if (&orig != this)
                     for(std::size_t i = 0; i != orig.count() && i != count(); ++i)
                         m_t[i] = orig.address()[i];
                 return *this;
             }
+
+            /**
+             * Assignment only copies max(this->count(), orig.count()) elements
+             * from orig to this object. If orig.count() is smaller than this->count()
+             * the contents of the remaining elements is left unmodified. If it's greater,
+             * the excess elements are ignored.
+             * @param orig
+             */
+            template <class OtherT>
+            const carray<T>& operator=( boost::serialization::array<OtherT> const& orig ) {
+                if (orig.address() != m_t)
+                    for(std::size_t i = 0; i != orig.count() && i != count(); ++i)
+                        m_t[i] = orig.address()[i];
+                return *this;
+            }
+
+            /**
+             * Assignment only copies max(this->count(), orig.size()) elements
+             * from orig to this object. If orig.size() is smaller than this->count()
+             * the contents of the remaining elements is left unmodified. If it's greater,
+             * the excess elements are ignored.
+             * @param orig
+             */
+            template <class OtherT, std::size_t OtherN>
+            const carray<T>& operator=( const boost::array<OtherT,OtherN>& orig ) {
+                if (orig.data() != m_t)
+                    for(std::size_t i = 0; i != orig.size() && i != count(); ++i)
+                        m_t[i] = orig[i];
+                return *this;
+            }
+
         private:
             value_type* m_t;
             std::size_t m_element_count;


### PR DESCRIPTION
The `boost::array` operator is required to assign an array data source from a `boost::array`, e.g. a fixed-sized
field of a ROS message. The `boost::serialization::array` assignment operator was added for completeness as carray also
has a `boost::serialization::array` constructor.

The value type of the RHS of the assignment may differ from the value type of the carray as long as the elements are assignable.
