### PR TITLE
Added os::Timer::waitFor(...) and os::Timer::waitForUntil(...… …) member functions

### DIFF
--- a/rtt/os/Timer.cpp
+++ b/rtt/os/Timer.cpp
@@ -47,6 +47,7 @@ namespace RTT {
     using namespace os;
 
     bool Timer::initialize() {
+        mdo_quit = false;
         // only start if non periodic.
         return this->getThread()->getPeriod() == 0;
     }
@@ -72,8 +73,8 @@ namespace RTT {
                 // represent as much in the future (until 2038) // XXX Year-2038 Bug
                 wake_up_time = (TimeService::InfiniteNSecs/4)-1;
                 for (TimerIds::iterator it = mtimers.begin(); it != mtimers.end(); ++it) {
-                    if ( it->first != 0 && it->first < wake_up_time  ) {
-                        wake_up_time = it->first;
+                    if ( it->expires != 0 && it->expires < wake_up_time  ) {
+                        wake_up_time = it->expires;
                         next_timer_id = it - mtimers.begin();
                     }
                 }
@@ -89,25 +90,32 @@ namespace RTT {
             // Timeout handling
             if (ret == -1) {
                 // a timer expired
-                // First: reset/reprogram the timer that expired:
+                // expires: reset/reprogram the timer that expired:
                 {
                     MutexLock locker(m);
                     // detect corner case for resize:
                     if ( next_timer_id < int(mtimers.size()) ) {
                         // now clear or reprogram it.
                         TimerIds::iterator tim = mtimers.begin() + next_timer_id;
-                        if ( tim->second ) {
+                        if ( tim->period ) {
                             // periodic timer
-                            tim->first += tim->second;
+                            tim->expires += tim->period;
                         } else {
                             // aperiodic timer
-                            tim->first = 0;
+                            tim->expires = 0;
                         }
                     }
                 }
-                // Second: send the timeout signal and allow (within the callback)
+
+                // Second: notify waiting threads
+                {// This scope is for MutexLock.
+                    MutexLock locker(m);
+                    mtimers[next_timer_id].expired.broadcast();
+                }// MutexLock
+
+                // Third: send the timeout signal and allow (within the callback)
                 // to reprogram the timer.
-                // If we would first call timeout(), the code above would overwrite
+                // If we would expires call timeout(), the code above would overwrite
                 // user settings.
                 timeout( next_timer_id );
             }
@@ -118,6 +126,10 @@ namespace RTT {
     {
         mdo_quit = true;
         msem.signal();
+        // kill all timers to abort all threads blocking in waitFor()
+        for (TimerId i = 0; i < (int) mtimers.size(); ++i) {
+            killTimer(i);
+        }
         return true;
     }
 
@@ -145,7 +157,7 @@ namespace RTT {
     void Timer::setMaxTimers(TimerId max)
     {
         MutexLock locker(m);
-        mtimers.resize(max, std::make_pair(Time(0), Time(0)) );
+        mtimers.resize(max, TimerInfo() );
     }
 
     bool Timer::startTimer(TimerId timer_id, double period)
@@ -160,8 +172,8 @@ namespace RTT {
 
         {
             MutexLock locker(m);
-            mtimers[timer_id].first = due_time;
-            mtimers[timer_id].second = Seconds_to_nsecs( period );
+            mtimers[timer_id].expires = due_time;
+            mtimers[timer_id].period = Seconds_to_nsecs( period );
         }
         msem.signal();
         return true;
@@ -180,8 +192,8 @@ namespace RTT {
 
         {
             MutexLock locker(m);
-            mtimers[timer_id].first  = due_time;
-            mtimers[timer_id].second = 0;
+            mtimers[timer_id].expires  = due_time;
+            mtimers[timer_id].period = 0;
         }
         msem.signal();
         return true;
@@ -195,7 +207,7 @@ namespace RTT {
             log(Error) << "Invalid timer id" << endlog();
             return false;
         }
-        return mtimers[timer_id].first != 0;
+        return mtimers[timer_id].expires != 0;
     }
 
     double Timer::timeRemaining(TimerId timer_id) const
@@ -207,7 +219,7 @@ namespace RTT {
             return 0.0;
         }
         Time now = rtos_get_time_ns();
-        Time result = mtimers[timer_id].first - now;
+        Time result = mtimers[timer_id].expires - now;
         // detect corner cases.
         if ( result < 0 )
             return 0.0;
@@ -222,9 +234,36 @@ namespace RTT {
             log(Error) << "Invalid timer id" << endlog();
             return false;
         }
-        mtimers[timer_id].first = 0;
-        mtimers[timer_id].second = 0;
+        mtimers[timer_id].expires = 0;
+        mtimers[timer_id].period = 0;
+        mtimers[timer_id].expired.broadcast();
         return true;
+    }
+
+    bool Timer::waitFor(TimerId timer_id)
+    {
+        MutexLock locker(m);
+        if (timer_id < 0 || timer_id >= int(mtimers.size()) )
+        {
+            log(Error) << "Invalid timer id" << endlog();
+            return false;
+        }
+        if (mtimers[timer_id].expires == 0) return false;
+
+        return mtimers[timer_id].expired.wait(m) && this->getThread()->isRunning();
+    }
+
+    bool Timer::waitForUntil(TimerId timer_id, nsecs abs_time)
+    {
+        MutexLock locker(m);
+        if (timer_id < 0 || timer_id >= int(mtimers.size()) )
+        {
+            log(Error) << "Invalid timer id" << endlog();
+            return false;
+        }
+        if (mtimers[timer_id].expires == 0) return false;
+
+        return mtimers[timer_id].expired.wait_until(m, abs_time) && this->getThread()->isRunning();
     }
 
 

--- a/rtt/os/Timer.cpp
+++ b/rtt/os/Timer.cpp
@@ -250,7 +250,7 @@ namespace RTT {
         }
         if (mtimers[timer_id].expires == 0) return false;
 
-        return mtimers[timer_id].expired.wait(m) && this->getThread()->isRunning();
+        return mtimers[timer_id].expired.wait(m);
     }
 
     bool Timer::waitForUntil(TimerId timer_id, nsecs abs_time)
@@ -263,7 +263,7 @@ namespace RTT {
         }
         if (mtimers[timer_id].expires == 0) return false;
 
-        return mtimers[timer_id].expired.wait_until(m, abs_time) && this->getThread()->isRunning();
+        return mtimers[timer_id].expired.wait_until(m, abs_time);
     }
 
 

--- a/rtt/os/Timer.cpp
+++ b/rtt/os/Timer.cpp
@@ -150,7 +150,7 @@ namespace RTT {
 
     bool Timer::startTimer(TimerId timer_id, double period)
     {
-        if ( timer_id < 0 || timer_id > int(mtimers.size()) || period < 0.0)
+        if ( timer_id < 0 || timer_id >= int(mtimers.size()) || period < 0.0)
         {
             log(Error) << "Invalid timer id or period" << endlog();
             return false;
@@ -169,7 +169,7 @@ namespace RTT {
 
     bool Timer::arm(TimerId timer_id, double wait_time)
     {
-        if ( timer_id < 0 || timer_id > int(mtimers.size()) || wait_time < 0.0)
+        if ( timer_id < 0 || timer_id >= int(mtimers.size()) || wait_time < 0.0)
         {
             log(Error) << "Invalid timer id or wait time" << endlog();
             return false;
@@ -190,7 +190,7 @@ namespace RTT {
     bool Timer::isArmed(TimerId timer_id) const
     {
         MutexLock locker(m);
-        if (timer_id < 0 || timer_id > int(mtimers.size()) )
+        if (timer_id < 0 || timer_id >= int(mtimers.size()) )
         {
             log(Error) << "Invalid timer id" << endlog();
             return false;
@@ -201,7 +201,7 @@ namespace RTT {
     double Timer::timeRemaining(TimerId timer_id) const
     {
         MutexLock locker(m);
-        if (timer_id < 0 || timer_id > int(mtimers.size()) )
+        if (timer_id < 0 || timer_id >= int(mtimers.size()) )
         {
             log(Error) << "Invalid timer id" << endlog();
             return 0.0;
@@ -217,7 +217,7 @@ namespace RTT {
     bool Timer::killTimer(TimerId timer_id)
     {
         MutexLock locker(m);
-        if (timer_id < 0 || timer_id > int(mtimers.size()) )
+        if (timer_id < 0 || timer_id >= int(mtimers.size()) )
         {
             log(Error) << "Invalid timer id" << endlog();
             return false;

--- a/rtt/os/Timer.hpp
+++ b/rtt/os/Timer.hpp
@@ -175,8 +175,7 @@ namespace RTT
         /**
          * Wait for a timer to expire.
          * @param timer_id The number of the timer, starting from zero.
-         * @returns true if timer has expired and false if the timer is not armed
-         * @note low-priority threads could miss
+         * @returns true if timer has expired or if it was killed and false if the timer is not armed
          */
         bool waitFor(RTT::os::Timer::TimerId id);
 
@@ -186,8 +185,7 @@ namespace RTT
          * @param  abs_time The absolute time to wait until before the condition happens.
          * Use rtos_get_time_ns() to get the current time and Seconds_to_nsecs to add a
          * certain amount to the result.
-         * @returns true if timer has expired and false if the timer is not armed
-         * @note low-priority threads could miss
+         * @returns true if timer has expired or if it was killed before abs_time passed and false if the timer is not armed
          */
         bool waitForUntil(RTT::os::Timer::TimerId id, nsecs abs_time);
 

--- a/rtt/os/Timer.hpp
+++ b/rtt/os/Timer.hpp
@@ -185,7 +185,7 @@ namespace RTT
          * @param  abs_time The absolute time to wait until before the condition happens.
          * Use rtos_get_time_ns() to get the current time and Seconds_to_nsecs to add a
          * certain amount to the result.
-         * @returns true if timer has expired or if it was killed before abs_time passed and false if the timer is not armed
+         * @returns true if timer has expired or if it was killed before abs_time and false if the timer is not armed
          */
         bool waitForUntil(RTT::os::Timer::TimerId id, nsecs abs_time);
 

--- a/rtt/os/Timer.hpp
+++ b/rtt/os/Timer.hpp
@@ -43,6 +43,7 @@
 #include "TimeService.hpp"
 #include "Mutex.hpp"
 #include "Semaphore.hpp"
+#include "Condition.hpp"
 #include "ThreadInterface.hpp"
 #include "../base/RunnableInterface.hpp"
 #include <vector>
@@ -76,12 +77,21 @@ namespace RTT
         Semaphore msem;
         mutable Mutex m;
         typedef TimeService::nsecs Time;
+
+        struct TimerInfo
+        {
+            TimerInfo() : expires(0), period(0) {}
+            Time expires; // was .first
+            Time period;  // was .second
+            Condition expired;
+        };
+
         /**
          * Index in vector is the timer id.
          * 1st Time is the absolute time upon which the timer expires.
          * 2nd Time is the optional period of the timer.
          */
-        typedef std::vector<std::pair<Time, Time> > TimerIds;
+        typedef std::vector<TimerInfo> TimerIds;
         TimerIds mtimers;
         bool mdo_quit;
 
@@ -161,6 +171,25 @@ namespace RTT
          * @param timer_id The number of the timer, starting from zero.
          */
         bool killTimer(TimerId timer_id);
+
+        /**
+         * Wait for a timer to expire.
+         * @param timer_id The number of the timer, starting from zero.
+         * @returns true if timer has expired and false if the timer is not armed
+         * @note low-priority threads could miss
+         */
+        bool waitFor(RTT::os::Timer::TimerId id);
+
+        /**
+         * Wait for a timer to expire with timeout.
+         * @param timer_id The number of the timer, starting from zero.
+         * @param  abs_time The absolute time to wait until before the condition happens.
+         * Use rtos_get_time_ns() to get the current time and Seconds_to_nsecs to add a
+         * certain amount to the result.
+         * @returns true if timer has expired and false if the timer is not armed
+         * @note low-priority threads could miss
+         */
+        bool waitForUntil(RTT::os::Timer::TimerId id, nsecs abs_time);
 
     };
 }}


### PR DESCRIPTION
This is needed for the implementation of `OCL::TimerComponent::wait()` and `OCL::TimerComponent::waitFor()`.
See orocos-toolchain/ocl#23 and orocos-toolchain/ocl#24.