### PR TITLE
Fixed blocking trigger() calls on FileDescriptorActivities if the step() function takes too long

### DIFF
--- a/rtt/extras/FileDescriptorActivity.cpp
+++ b/rtt/extras/FileDescriptorActivity.cpp
@@ -55,7 +55,9 @@
 #else
 #include <sys/select.h>
 #include <unistd.h>
+#include <fcntl.h>
 #include <errno.h>
+
 #endif
 
 #include <boost/cstdint.hpp>
@@ -63,10 +65,7 @@
 using namespace RTT;
 using namespace extras;
 using namespace base;
-const char FileDescriptorActivity::CMD_BREAK_LOOP;
-const char FileDescriptorActivity::CMD_TRIGGER;
-const char FileDescriptorActivity::CMD_UPDATE_SETS;
-
+const char FileDescriptorActivity::CMD_ANY_COMMAND;
 
 /**
  * Create a FileDescriptorActivity with a given priority and RunnableInterface
@@ -105,6 +104,9 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Runn
     , m_period(0)
     , m_has_error(false)
     , m_has_timeout(false)
+    , m_break_loop(false)
+    , m_trigger(false)
+    , m_update_sets(false)
 {
     FD_ZERO(&m_fd_set);
     FD_ZERO(&m_fd_work);
@@ -118,6 +120,9 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Seco
     , m_period(period >= 0.0 ? period : 0.0)        // intended period
     , m_has_error(false)
     , m_has_timeout(false)
+    , m_break_loop(false)
+    , m_trigger(false)
+    , m_update_sets(false)
 {
     FD_ZERO(&m_fd_set);
     FD_ZERO(&m_fd_work);
@@ -131,6 +136,9 @@ FileDescriptorActivity::FileDescriptorActivity(int scheduler, int priority, Seco
     , m_period(period >= 0.0 ? period : 0.0)        // intended period
     , m_has_error(false)
     , m_has_timeout(false)
+    , m_break_loop(false)
+    , m_trigger(false)
+    , m_update_sets(false)
 {
     FD_ZERO(&m_fd_set);
     FD_ZERO(&m_fd_work);
@@ -200,9 +208,10 @@ void FileDescriptorActivity::clearAllWatches()
 }
 void FileDescriptorActivity::triggerUpdateSets()
 {
-    // i works around warn_unused_result
-    int i = write(m_interrupt_pipe[1], &CMD_UPDATE_SETS, 1);
-    i = i;
+    { RTT::os::MutexLock lock(m_command_mutex);
+        m_update_sets = true;
+    }
+    write(m_interrupt_pipe[1], &CMD_ANY_COMMAND, 1);
 }
 bool FileDescriptorActivity::isUpdated(int fd) const
 { return FD_ISSET(fd, &m_fd_work); }
@@ -225,6 +234,27 @@ bool FileDescriptorActivity::start()
         return false;
     }
 
+#ifndef WIN32
+    // set m_interrupt_pipe to non-blocking
+    int flags = 0;
+    if ((flags = fcntl(m_interrupt_pipe[0], F_GETFL, 0)) == -1 ||
+        fcntl(m_interrupt_pipe[0], F_SETFL, flags | O_NONBLOCK) == -1 ||
+        (flags = fcntl(m_interrupt_pipe[1], F_GETFL, 0)) == -1 ||
+        fcntl(m_interrupt_pipe[1], F_SETFL, flags | O_NONBLOCK) == -1)
+    {
+        close(m_interrupt_pipe[0]);
+        close(m_interrupt_pipe[1]);
+        m_interrupt_pipe[0] = m_interrupt_pipe[1] = -1;
+        log(Error) << "FileDescriptorActivity: could not set the control pipe to non-blocking mode" << endlog();
+        return false;
+    }
+#endif
+
+    // reset flags
+    m_break_loop = false;
+    m_trigger = false;
+    m_update_sets = false;
+
     if (!Activity::start())
     {
         close(m_interrupt_pipe[0]);
@@ -238,9 +268,13 @@ bool FileDescriptorActivity::start()
 
 bool FileDescriptorActivity::trigger()
 { 
-    if (isActive() ) 
-        return write(m_interrupt_pipe[1], &CMD_TRIGGER, 1) == 1; 
-    else
+    if (isActive() ) {
+        { RTT::os::MutexLock lock(m_command_mutex);
+            m_trigger = true;
+        }
+        write(m_interrupt_pipe[1], &CMD_ANY_COMMAND, 1);
+        return true;
+    } else
         return false;
 }
 
@@ -252,7 +286,7 @@ struct fd_watch {
         if (fd != -1) 
             close(fd);
         fd = -1;
-    };
+    }
 };
 
 void FileDescriptorActivity::loop()
@@ -301,29 +335,17 @@ void FileDescriptorActivity::loop()
             m_has_timeout = true;
         }
 
-        bool do_break = false, do_trigger = true;
+        // Empty all commands queued in the pipe
         if (ret > 0 && FD_ISSET(pipe, &m_fd_work)) // breakLoop or trigger requests
-        { // Empty all commands queued in the pipe
-
+        {
             // These variables are used in order to loop with select(). See the
             // while() condition below.
             fd_set watch_pipe;
             timeval timeout;
-
-            do_trigger = false;
+            char dummy;
             do
             {
-                boost::uint8_t code;
-                if (read(pipe, &code, 1) == 1)
-                {
-                    if (code == CMD_BREAK_LOOP)
-                    {
-                        do_break = true;
-                    }
-                    else if (code == CMD_UPDATE_SETS){}
-                    else
-                        do_trigger = true;
-                }
+                read(pipe, &dummy, 1);
 
                 // Initialize the values for the next select() call
                 FD_ZERO(&watch_pipe);
@@ -332,9 +354,24 @@ void FileDescriptorActivity::loop()
                 timeout.tv_usec = 0;
             }
             while(select(pipe + 1, &watch_pipe, NULL, NULL, &timeout) > 0);
+        }
 
-            if (do_break)
+        // We check the flags after the command queue was emptied as we could miss commands otherwise:
+        bool do_trigger = true;
+        { RTT::os::MutexLock lock(m_command_mutex);
+            // This section should be really fast to not block threads calling trigger(), breakLoop() or watch().
+            if (m_trigger) {
+                do_trigger = true;
+                m_trigger = false;
+            }
+            if (m_update_sets) {
+                m_update_sets = false;
+                do_trigger = false;
+            }
+            if (m_break_loop) {
+                m_break_loop = false;
                 break;
+            }
         }
 
         if (do_trigger)
@@ -356,12 +393,10 @@ void FileDescriptorActivity::loop()
 
 bool FileDescriptorActivity::breakLoop()
 {
-    if (write(m_interrupt_pipe[1], &CMD_BREAK_LOOP, 1) != 1)
-        return false;
-
-    // either OS::SingleThread properly waits for loop() to return, or we are
-    // called from within loop() [for instance because updateHook() called
-    // fatal()]. In both cases, just return.
+    { RTT::os::MutexLock lock(m_command_mutex);
+        m_break_loop = true;
+    }
+    write(m_interrupt_pipe[1], &CMD_ANY_COMMAND, 1);
     return true;
 }
 

--- a/rtt/extras/FileDescriptorActivity.hpp
+++ b/rtt/extras/FileDescriptorActivity.hpp
@@ -114,9 +114,11 @@ namespace RTT { namespace extras {
         bool m_has_error;
         bool m_has_timeout;
 
-        static const char CMD_BREAK_LOOP  = 0;
-        static const char CMD_TRIGGER     = 1;
-        static const char CMD_UPDATE_SETS = 2;
+        static const char CMD_ANY_COMMAND = 0;
+        RTT::os::Mutex m_command_mutex;
+        bool m_break_loop;
+        bool m_trigger;
+        bool m_update_sets;
 
         /** Internal method that makes sure loop() takes into account
          * modifications in the set of watched FDs


### PR DESCRIPTION
A pipe in Linux seems to have a limited buffer size of 65536 bytes. Every trigger() has written a command byte to the pipe to wake up the thread and the loop() function empties the command before each step() invocation. For the case the step takes too long, commands could queue up and after the pipe is full the write() system call has blocked the thread that triggered the FileDescriptorActivity.

This patches makes the command pipe non-blocking and adds additional flags to the FileDescriptorActivity to make sure that we never miss a command event even if the queue was full.

The patch does not support Windows as it requires the fcntl  system call setting the `O_NONBLOCK` flag for the command pipe. In Windows the behavior is unchanged.