### PR TITLE
Extended DESTDIR support for packages built in the same workspace

### DIFF
--- a/UseOROCOS-RTT-helpers.cmake
+++ b/UseOROCOS-RTT-helpers.cmake
@@ -156,23 +156,15 @@ macro( orocos_find_package PACKAGE )
 
     pkg_search_module(${PACKAGE}_COMP_${OROCOS_TARGET} ${MODULE_NAMES})
     if (${PACKAGE}_COMP_${OROCOS_TARGET}_FOUND)
-      # Add DESTDIR to INCLUDE_DIRS and LIBRARY_DIRS if DESTDIR environment variable is defined
+      # Add DESTDIR to INCLUDE_DIRS and set CMAKE_FIND_ROOT_PATH if the DESTDIR environment variable is defined
       if(DEFINED ENV{DESTDIR})
-        set(${PACKAGE}_COMP_${OROCOS_TARGET}_INCLUDE_DIRS_WITH_DESTDIR)
-        set(${PACKAGE}_COMP_${OROCOS_TARGET}_INCLUDE_DIRS_WITHOUT_DESTDIR)
-        foreach(dir ${${PACKAGE}_COMP_${OROCOS_TARGET}_INCLUDE_DIRS})
-          list(APPEND ${PACKAGE}_COMP_${OROCOS_TARGET}_INCLUDE_DIRS_WITH_DESTDIR "$ENV{DESTDIR}/${dir};${dir}")
-          list(APPEND ${PACKAGE}_COMP_${OROCOS_TARGET}_INCLUDE_DIRS_WITHOUT_DESTDIR "${dir}")
+        set(${PACKAGE}_COMP_${OROCOS_TARGET}_INCLUDE_DIRS_WITHOUT_DESTDIR ${${PACKAGE}_COMP_${OROCOS_TARGET}_INCLUDE_DIRS})
+        set(${PACKAGE}_COMP_${OROCOS_TARGET}_INCLUDE_DIRS)
+        foreach(dir ${${PACKAGE}_COMP_${OROCOS_TARGET}_INCLUDE_DIRS_WITHOUT_DESTDIR})
+          list(APPEND ${PACKAGE}_COMP_${OROCOS_TARGET}_INCLUDE_DIRS "$ENV{DESTDIR}${dir};${dir}")
         endforeach()
-        set(${PACKAGE}_COMP_${OROCOS_TARGET}_INCLUDE_DIRS ${${PACKAGE}_COMP_${OROCOS_TARGET}_INCLUDE_DIRS_WITH_DESTDIR})
 
-        set(${PACKAGE}_COMP_${OROCOS_TARGET}_LIBRARY_DIRS_WITH_DESTDIR)
-        set(${PACKAGE}_COMP_${OROCOS_TARGET}_LIBRARY_DIRS_WITHOUT_DESTDIR)
-        foreach(dir ${${PACKAGE}_COMP_${OROCOS_TARGET}_LIBRARY_DIRS})
-          list(APPEND ${PACKAGE}_COMP_${OROCOS_TARGET}_LIBRARY_DIRS_WITH_DESTDIR "$ENV{DESTDIR}/${dir};${dir}")
-          list(APPEND ${PACKAGE}_COMP_${OROCOS_TARGET}_LIBRARY_DIRS_WITHOUT_DESTDIR "${dir}")
-        endforeach()
-        set(${PACKAGE}_COMP_${OROCOS_TARGET}_LIBRARY_DIRS ${${PACKAGE}_COMP_${OROCOS_TARGET}_LIBRARY_DIRS_WITH_DESTDIR})
+        set(CMAKE_FIND_ROOT_PATH "$ENV{DESTDIR}")
       endif()
 
       # Use find_libraries to find each library:
@@ -209,14 +201,6 @@ macro( orocos_find_package PACKAGE )
       # The flags are space separated, so no need to quote here:
       set(${PACKAGE}_CFLAGS_OTHER ${${PACKAGE}_COMP_${OROCOS_TARGET}_CFLAGS_OTHER})
       set(${PACKAGE}_LDFLAGS_OTHER ${${PACKAGE}_COMP_${OROCOS_TARGET}_LDFLAGS_OTHER})
-
-      if(NOT DEFINED ENV{DESTDIR})
-        set(${PACKAGE}_INCLUDE_DIRS_WITHOUT_DESTDIR ${${PACKAGE}_COMP_${OROCOS_TARGET}_INCLUDE_DIRS})
-        set(${PACKAGE}_LIBRARY_DIRS_WITHOUT_DESTDIR ${${PACKAGE}_COMP_${OROCOS_TARGET}_LIBRARY_DIRS})
-      else()
-        set(${PACKAGE}_INCLUDE_DIRS_WITHOUT_DESTDIR ${${PACKAGE}_COMP_${OROCOS_TARGET}_INCLUDE_DIRS_WITHOUT_DESTDIR})
-        set(${PACKAGE}_LIBRARY_DIRS_WITHOUT_DESTDIR ${${PACKAGE}_COMP_${OROCOS_TARGET}_LIBRARY_DIRS_WITHOUT_DESTDIR})
-      endif()
 
     else()
       if(ORO_FIND_REQUIRED)
@@ -279,7 +263,7 @@ macro( orocos_use_package PACKAGE )
       set(ORO_${PACKAGE}_FOUND True)
       set(${PACKAGE}_FOUND True)
       set(${PACKAGE}_INCLUDE_DIRS ${${PACKAGE}_EXPORTED_OROCOS_INCLUDE_DIRS} ${${PACKAGE}-${OROCOS_TARGET}_EXPORTED_OROCOS_INCLUDE_DIRS})
-      set(${PACKAGE}_LIBRARY_DIRS "")
+      set(${PACKAGE}_LIBRARY_DIRS ${${PACKAGE}_EXPORTED_OROCOS_LIBRARY_DIRS} ${${PACKAGE}-${OROCOS_TARGET}_EXPORTED_OROCOS_LIBRARY_DIRS})
       set(${PACKAGE}_LIBRARIES ${${PACKAGE}_EXPORTED_OROCOS_LIBRARIES} ${${PACKAGE}-${OROCOS_TARGET}_EXPORTED_OROCOS_LIBRARIES})
 
       # Use add_dependencies(target ${USE_OROCOS_EXPORTED_TARGETS}) to make sure that a target is built AFTER
@@ -317,10 +301,8 @@ macro( orocos_use_package PACKAGE )
       # Store aggregated variables
       list(APPEND USE_OROCOS_PACKAGES "${PACKAGE}")
       list(APPEND USE_OROCOS_INCLUDE_DIRS "${${PACKAGE}_INCLUDE_DIRS}")
-      list(APPEND USE_OROCOS_INCLUDE_DIRS_WITHOUT_DESTDIR ${${PACKAGE}_INCLUDE_DIRS_WITHOUT_DESTDIR})
       list(APPEND USE_OROCOS_LIBRARIES "${${PACKAGE}_LIBRARIES}")
       list(APPEND USE_OROCOS_LIBRARY_DIRS "${${PACKAGE}_LIBRARY_DIRS}")
-      list(APPEND USE_OROCOS_LIBRARY_DIRS_WITHOUT_DESTDIR ${${PACKAGE}_LIBRARY_DIRS_WITHOUT_DESTDIR})
       list(APPEND USE_OROCOS_CFLAGS_OTHER "${${PACKAGE}_CFLAGS_OTHER}")
       list(APPEND USE_OROCOS_LDFLAGS_OTHER "${${PACKAGE}_LDFLAGS_OTHER}")
 
@@ -328,17 +310,11 @@ macro( orocos_use_package PACKAGE )
       if(DEFINED USE_OROCOS_INCLUDE_DIRS)
         list(REMOVE_DUPLICATES USE_OROCOS_INCLUDE_DIRS)
       endif()
-      if(DEFINED USE_OROCOS_INCLUDE_DIRS_WITHOUT_DESTDIR)
-        list(REMOVE_DUPLICATES USE_OROCOS_INCLUDE_DIRS_WITHOUT_DESTDIR)
-      endif()
       if(DEFINED USE_OROCOS_LIBRARIES)
         list(REMOVE_DUPLICATES USE_OROCOS_LIBRARIES)
       endif()
       if(DEFINED USE_OROCOS_LIBRARY_DIRS)
         list(REMOVE_DUPLICATES USE_OROCOS_LIBRARY_DIRS)
-      endif()
-      if(DEFINED USE_OROCOS_LIBRARY_DIRS_WITHOUT_DESTDIR)
-        list(REMOVE_DUPLICATES USE_OROCOS_LIBRARY_DIRS_WITHOUT_DESTDIR)
       endif()
       if(DEFINED USE_OROCOS_CFLAGS_OTHER)
         list(REMOVE_DUPLICATES USE_OROCOS_CFLAGS_OTHER)
@@ -405,4 +381,37 @@ macro(orocos_add_link_flags target)
   set_target_properties(${target} PROPERTIES
                         LINK_FLAGS "${_flags_str}")
 endmacro(orocos_add_link_flags)
+
+macro(orocos_set_install_rpath target)
+  set(_install_rpath ${ARGN} "${OROCOS-RTT_LIBRARY_DIRS};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/types;${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/plugins;${CMAKE_INSTALL_PREFIX}/lib")
+
+  # strip DESTDIR from all RPATH entries...
+  if(DEFINED ENV{DESTDIR})
+    string(REPLACE "$ENV{DESTDIR}" "" _install_rpath "${_install_rpath}")
+  endif()
+
+  # ... and remove duplicates
+  if(DEFINED _install_rpath)
+    list(REMOVE_DUPLICATES _install_rpath)
+  endif()
+
+  set_target_properties(${target} PROPERTIES
+                        INSTALL_RPATH "${_install_rpath}")
+
+  if(APPLE)
+    if (CMAKE_VERSION VERSION_LESS "3.0.0")
+      SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
+        INSTALL_NAME_DIR "@rpath"
+        )
+    else()
+      # cope with CMake 3.x
+      SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
+        MACOSX_RPATH ON)
+    endif()
+  endif()
+
+  if("$ENV{VERBOSE}" OR ORO_USE_VERBOSE)
+    message(STATUS "[UseOrocos] Setting RPATH of target '${target}' to '${_install_rpath}'.")
+  endif()
+endmacro(orocos_set_install_rpath)
 

--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -189,14 +189,6 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
     set(ORO_TYPEKIT_OUTPUT_DIRECTORY   ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/types)
     set(ORO_PLUGIN_OUTPUT_DIRECTORY    ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/plugins)
 
-    # Make sure a devel prefix's pkgconfig path is available if it hasn't already been source'd
-    if (NOT $ENV{PKG_CONFIG_PATH} MATCHES "${CATKIN_DEVEL_PREFIX}/lib/pkgconfig")
-      set(ENV{PKG_CONFIG_PATH} "${CATKIN_DEVEL_PREFIX}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
-    endif()
-    if("$ENV{VERBOSE}")
-      message(STATUS "[UseOrocos] PKG_CONFIG_PATH: $ENV{PKG_CONFIG_PATH}")
-    endif()
-
     # Get catkin build_depend dependencies
     foreach(DEP ${${PROJECT_NAME}_BUILD_DEPENDS})
       # We use OROCOS_ONLY so that we only find .pc files with the orocos target on them

--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -292,22 +292,11 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       LIBRARY_OUTPUT_DIRECTORY ${ORO_COMPONENT_OUTPUT_DIRECTORY}
       DEFINE_SYMBOL "RTT_COMPONENT"
       ${LIB_COMPONENT_VERSION}
-      INSTALL_RPATH "${USE_OROCOS_LIBRARY_DIRS_WITHOUT_DESTDIR};${OROCOS-RTT_LIBRARY_DIRS};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/types;${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/plugins;${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}"
       )
-    if(APPLE)
-      if (CMAKE_VERSION VERSION_LESS "3.0.0")
-        SET_TARGET_PROPERTIES( ${COMPONENT_NAME} PROPERTIES
-          INSTALL_NAME_DIR "@rpath"
-          )
-      else()
-        # cope with CMake 3.x
-        SET_TARGET_PROPERTIES( ${COMPONENT_NAME} PROPERTIES
-          MACOSX_RPATH ON)
-      endif()
-    endif()
 
     orocos_add_compile_flags( ${COMPONENT_NAME} ${USE_OROCOS_CFLAGS_OTHER})
     orocos_add_link_flags( ${COMPONENT_NAME} ${USE_OROCOS_LDFLAGS_OTHER})
+    orocos_set_install_rpath( ${COMPONENT_NAME} ${USE_OROCOS_LIBRARY_DIRS})
 
     TARGET_LINK_LIBRARIES( ${COMPONENT_NAME}
       ${OROCOS-RTT_LIBRARIES} 
@@ -333,6 +322,7 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
     # Necessary for .pc file generation
     list(APPEND OROCOS_DEFINED_COMPS " -l${COMPONENT_LIB_NAME}")
     list(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS "${COMPONENT_NAME}")
+    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS "${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
   endmacro( orocos_component )
 
 # Utility libraries should add themselves by calling 'orocos_library()' 
@@ -386,22 +376,11 @@ macro( orocos_library LIB_TARGET_NAME )
     SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
       OUTPUT_NAME ${LIB_NAME}
       ${LIB_COMPONENT_VERSION}
-      INSTALL_RPATH "${USE_OROCOS_LIBRARY_DIRS_WITHOUT_DESTDIR};${OROCOS-RTT_LIBRARY_DIRS};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/types;${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/plugins;${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}"
       )
-    if(APPLE)
-      if (CMAKE_VERSION VERSION_LESS "3.0.0")
-        SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
-          INSTALL_NAME_DIR "@rpath"
-          )
-      else()
-        # cope with CMake 3.x
-        SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
-          MACOSX_RPATH ON)
-      endif()
-    endif()
 
     orocos_add_compile_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_CFLAGS_OTHER} )
     orocos_add_link_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_LDFLAGS_OTHER} )
+    orocos_set_install_rpath( ${LIB_TARGET_NAME} "${USE_OROCOS_LIBRARY_DIRS};${OROCOS-RTT_LIBRARY_DIRS};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/types;${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/plugins;${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}" )
 
     TARGET_LINK_LIBRARIES( ${LIB_TARGET_NAME} 
       ${OROCOS-RTT_LIBRARIES} 
@@ -421,6 +400,7 @@ macro( orocos_library LIB_TARGET_NAME )
     # Necessary for .pc file generation
     list(APPEND OROCOS_DEFINED_LIBS " -l${LIB_NAME}")
     list(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS "${LIB_TARGET_NAME}")
+    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS "${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
   endmacro( orocos_library )
 
   # Executables should add themselves by calling 'orocos_executable()'
@@ -460,19 +440,7 @@ macro( orocos_library LIB_TARGET_NAME )
 
     SET_TARGET_PROPERTIES( ${EXE_TARGET_NAME} PROPERTIES
       OUTPUT_NAME ${EXE_NAME}
-      INSTALL_RPATH "${USE_OROCOS_LIBRARY_DIRS_WITHOUT_DESTDIR};${OROCOS-RTT_LIBRARY_DIRS};${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/types;${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/plugins;${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}"
       )
-    if(APPLE)
-      if (CMAKE_VERSION VERSION_LESS "3.0.0")
-        SET_TARGET_PROPERTIES( ${EXE_TARGET_NAME} PROPERTIES
-          INSTALL_NAME_DIR "@rpath"
-          )
-      else()
-        # cope with CMake 3.x
-        SET_TARGET_PROPERTIES( ${EXE_TARGET_NAME} PROPERTIES
-          MACOSX_RPATH ON)
-      endif()
-    endif()
 
     if(CMAKE_DEBUG_POSTFIX)
       set_target_properties( ${EXE_TARGET_NAME} PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX} )
@@ -480,6 +448,7 @@ macro( orocos_library LIB_TARGET_NAME )
 
     orocos_add_compile_flags(${EXE_TARGET_NAME} ${USE_OROCOS_CFLAGS_OTHER})
     orocos_add_link_flags(${EXE_TARGET_NAME} ${USE_OROCOS_LDFLAGS_OTHER})
+    orocos_set_install_rpath( ${EXE_TARGET_NAME} ${USE_OROCOS_LIBRARY_DIRS})
 
     TARGET_LINK_LIBRARIES( ${EXE_TARGET_NAME} 
       ${OROCOS-RTT_LIBRARIES} 
@@ -529,19 +498,7 @@ macro( orocos_library LIB_TARGET_NAME )
 
     SET_TARGET_PROPERTIES( ${EXE_TARGET_NAME} PROPERTIES
       OUTPUT_NAME ${EXE_TARGET_NAME}
-      INSTALL_RPATH "${USE_OROCOS_LIBRARY_DIRS_WITHOUT_DESTDIR};${OROCOS-RTT_LIBRARY_DIRS};${CMAKE_INSTALL_PREFIX}/bin;${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/types;${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/plugins;${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}"
       )
-    if(APPLE)
-      if (CMAKE_VERSION VERSION_LESS "3.0.0")
-        SET_TARGET_PROPERTIES( ${EXE_TARGET_NAME} PROPERTIES
-          INSTALL_NAME_DIR "@rpath"
-          )
-      else()
-        # cope with CMake 3.x
-        SET_TARGET_PROPERTIES( ${EXE_TARGET_NAME} PROPERTIES
-          MACOSX_RPATH ON)
-      endif()
-    endif()
 
     if(CMAKE_DEBUG_POSTFIX)
       set_target_properties( ${EXE_TARGET_NAME} PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX} )
@@ -549,6 +506,7 @@ macro( orocos_library LIB_TARGET_NAME )
 
     orocos_add_compile_flags(${EXE_TARGET_NAME} ${USE_OROCOS_CFLAGS_OTHER})
     orocos_add_link_flags(${EXE_TARGET_NAME} ${USE_OROCOS_LDFLAGS_OTHER})
+    orocos_set_install_rpath( ${EXE_TARGET_NAME} ${USE_OROCOS_LIBRARY_DIRS})
 
     TARGET_LINK_LIBRARIES( ${EXE_TARGET_NAME}
       ${OROCOS-RTT_LIBRARIES}
@@ -612,6 +570,7 @@ macro( orocos_library LIB_TARGET_NAME )
       list(APPEND OROCOS_DEFINED_TYPES " -l${PROJECT_NAME}-typekit-${OROCOS_TARGET}")
       list(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS "${PROJECT_NAME}-typekit")
       list(APPEND ${PROJECT_NAME}_EXPORTED_INCLUDE_DIRS "${PROJECT_BINARY_DIR}/typekit")
+      list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS "${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/types")
     endif (NOT TYPEGEN_EXE)
   endmacro( orocos_typegen_headers )
 
@@ -664,22 +623,11 @@ macro( orocos_library LIB_TARGET_NAME )
       OUTPUT_NAME ${LIB_NAME}
       LIBRARY_OUTPUT_DIRECTORY ${ORO_TYPEKIT_OUTPUT_DIRECTORY}
       ${LIB_COMPONENT_VERSION}
-      INSTALL_RPATH "${USE_OROCOS_LIBRARY_DIRS_WITHOUT_DESTDIR};${OROCOS-RTT_LIBRARY_DIRS};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/types;${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/plugins;${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}"
       )
-    if(APPLE)
-      if (CMAKE_VERSION VERSION_LESS "3.0.0")
-        SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
-          INSTALL_NAME_DIR "@rpath"
-          )
-      else()
-        # cope with CMake 3.x
-        SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
-          MACOSX_RPATH ON)
-      endif()
-    endif()
 
     orocos_add_compile_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_CFLAGS_OTHER})
     orocos_add_link_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_LDFLAGS_OTHER})
+    orocos_set_install_rpath( ${LIB_TARGET_NAME} ${USE_OROCOS_LIBRARY_DIRS})
 
     TARGET_LINK_LIBRARIES( ${LIB_TARGET_NAME}
       ${OROCOS-RTT_LIBRARIES} 
@@ -703,6 +651,7 @@ macro( orocos_library LIB_TARGET_NAME )
     # Necessary for .pc file generation
     list(APPEND OROCOS_DEFINED_TYPES " -l${LIB_NAME}")
     list(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS "${LIB_TARGET_NAME}")
+    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS "${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
   endmacro( orocos_typekit )
 
   # plugin libraries should add themselves by calling 'orocos_plugin()' 
@@ -756,22 +705,11 @@ macro( orocos_library LIB_TARGET_NAME )
       OUTPUT_NAME ${LIB_NAME}
       LIBRARY_OUTPUT_DIRECTORY ${ORO_PLUGIN_OUTPUT_DIRECTORY}
       ${LIB_COMPONENT_VERSION}
-      INSTALL_RPATH "${USE_OROCOS_LIBRARY_DIRS_WITHOUT_DESTDIR};${OROCOS-RTT_LIBRARY_DIRS};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/types;${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/plugins;${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}"
       )
-    if(APPLE)
-      if (CMAKE_VERSION VERSION_LESS "3.0.0")
-        SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
-          INSTALL_NAME_DIR "@rpath"
-          )
-      else()
-        # cope with CMake 3.x
-        SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
-          MACOSX_RPATH ON)
-      endif()
-    endif()
 
     orocos_add_compile_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_CFLAGS_OTHER})
     orocos_add_link_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_LDFLAGS_OTHER})
+    orocos_set_install_rpath( ${LIB_TARGET_NAME} ${USE_OROCOS_LIBRARY_DIRS})
 
     TARGET_LINK_LIBRARIES( ${LIB_TARGET_NAME} 
       ${OROCOS-RTT_LIBRARIES}
@@ -796,6 +734,7 @@ macro( orocos_library LIB_TARGET_NAME )
     # Necessary for .pc file generation
     list(APPEND OROCOS_DEFINED_PLUGINS " -l${LIB_NAME}")
     list(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS "${LIB_TARGET_NAME}")
+    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS "${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
   endmacro( orocos_plugin )
 
   # service libraries should add themselves by calling 'orocos_service()' 
@@ -1036,6 +975,7 @@ Cflags: -I\${includedir} \@PC_EXTRA_INCLUDE_DIRS\@
       list(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS      ${${_depend}_EXPORTED_TARGETS})
       list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARIES    ${${_depend}_LIBRARIES})
       list(APPEND ${PROJECT_NAME}_EXPORTED_INCLUDE_DIRS ${${_depend}_INCLUDE_DIRS})
+      list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS ${${_depend}_LIBRARY_DIRS})
     endforeach()
 
     if(${PROJECT_NAME}_EXPORTED_TARGETS)
@@ -1046,6 +986,9 @@ Cflags: -I\${includedir} \@PC_EXTRA_INCLUDE_DIRS\@
     endif()
     if(${PROJECT_NAME}_EXPORTED_INCLUDE_DIRS)
       list(REMOVE_DUPLICATES ${PROJECT_NAME}_EXPORTED_INCLUDE_DIRS)
+    endif()
+    if(${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS)
+      list(REMOVE_DUPLICATES ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS)
     endif()
 
     # Store a list of exported targets, libraries and include directories on the cache so that other packages within the same workspace can use them.
@@ -1061,6 +1004,10 @@ Cflags: -I\${includedir} \@PC_EXTRA_INCLUDE_DIRS\@
     if(${PROJECT_NAME}_EXPORTED_INCLUDE_DIRS)
       message(STATUS "[UseOrocos] Exporting include directories ${${PROJECT_NAME}_EXPORTED_INCLUDE_DIRS}.")
       set(${PC_NAME}_EXPORTED_OROCOS_INCLUDE_DIRS ${${PROJECT_NAME}_EXPORTED_INCLUDE_DIRS} CACHE INTERNAL "Include directories exported by package ${PC_NAME}")
+    endif()
+    if(${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS)
+      message(STATUS "[UseOrocos] Exporting library directories ${${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS}.")
+      set(${PC_NAME}_EXPORTED_OROCOS_LIBRARY_DIRS ${${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS} CACHE INTERNAL "Library directories exported by package ${PC_NAME}")
     endif()
 
     # Also set the uninstall target:


### PR DESCRIPTION
The first patch extends and simplifies the DESTDIR support introduced in 85fc9d3. It should have no effect on normal builds where the DESTDIR environment variable is not set.

The original patch assumed that DESTDIR is already set during the configure step, like with
```
DESTDIR=/tmp/destdir catkin_make_isolated --install ...
```

In a pure catkin workspace, packages can be built for a whole workspace with a standard debian/rules file and debhelper's support for the cmake build system. In this case DESTDIR is only set during the install step
and the previous patch was not effective, causing RPATH-related errors during runtime.

The INSTALL_RPATH is still constructed based on the information from the pkg-config files for packages in *overlayed* workspaces or system packages. Additionally, libraries built in the *same* workspace will now export their library dirs in the *install-space* via the cmake cache so that other targets that link to it can already set their RPATH correctly.

In order to make sure that no paths within DESTDIR end up in the installed RPATH of any library, a new cmake macro `orocos_set_install_rpath(target rpath)` has been introduced that cleans up all entries in the rpath list and removes duplicates. This could be an issue if RTT itself is installed in DESTDIR together with other packages, as `OROCOS-RTT_LIBRARY_DIRS` would have the DESTDIR prefix.

The second patch reverts @jbohren's 40bbd08 (UseOrocos: adding pkg-config path for catkin workspaces which have yet to be source'd).
It should not be required anymore to add the pkg-config folder in the devel-space to the `PKG_CONFIG_PATH` as packages in the same cmake workspace are found by the `${PACKAGE}_EXPORTED_OROCOS_*` cmake variables now. I removed it because it also breaks DESTDIR builds as packages might be found in the build folder. If it is still required for some reason that I am currently not aware of we could at least add a check if `CATKIN_DEVEL_PREFIX` is within the build directory.