### PR TITLE
Allow the construction of an uninitialized TaskContextProxy

### DIFF
--- a/rtt/transports/corba/TaskContextProxy.cpp
+++ b/rtt/transports/corba/TaskContextProxy.cpp
@@ -94,6 +94,16 @@ namespace RTT
     TaskContextProxy::TaskContextProxy(std::string name, bool is_ior)
         : TaskContext("NotFound")
     {
+        initFromURIOrTaskname(name, is_ior);
+    }
+
+    TaskContextProxy::TaskContextProxy(): TaskContext("NotFound")
+    {
+
+    }
+
+    void TaskContextProxy::initFromURIOrTaskname(string name, bool is_ior)
+    {
         Logger::In in("TaskContextProxy");
         this->clear();
         this->setActivity( new SequentialActivity() );
@@ -158,7 +168,7 @@ namespace RTT
 
         this->synchronize();
     }
-
+    
     TaskContextProxy::TaskContextProxy( ::RTT::corba::CTaskContext_ptr taskc)
         : TaskContext("CORBAProxy"), mtask( corba::CTaskContext::_duplicate(taskc) )
     {

--- a/rtt/transports/corba/TaskContextProxy.hpp
+++ b/rtt/transports/corba/TaskContextProxy.hpp
@@ -95,6 +95,11 @@ namespace RTT
         TaskContextProxy(std::string location, bool is_ior);
 
         /**
+         * A Private constructor which does nothing       
+         * */
+        TaskContextProxy();
+        
+        /**
          * Private constructor which creates a new connection to
          * a corba object
          */
@@ -108,6 +113,11 @@ namespace RTT
          */
         std::list<base::PortInterface*> port_proxies;
 
+        /**
+         * initializes the class from a stringified ior or taskname in NameServer.
+         * */
+        void initFromURIOrTaskname(std::string location, bool is_ior);
+        
         void synchronize();
 
         mutable corba::CTaskContext_var mtask;


### PR DESCRIPTION
This is useful if a derived class wants to initialize the
typekits, before initializing the proxy itself.

The current usecase is the orogen cpp proxy layer, were
proxies for tasks are generated. In this case we want to
initialize the typekit for the task in the constructor of the 
orogen-proxy before synchronizing. 