### PR TITLE
Add connection introspection ability

### DIFF
--- a/rtt/base/ChannelElementBase.hpp
+++ b/rtt/base/ChannelElementBase.hpp
@@ -70,6 +70,11 @@ namespace RTT { namespace base {
         shared_ptr input;
         shared_ptr output;
 
+        std::string inputPortName;
+        std::string inputTaskName;
+        std::string outputPortName;
+        std::string outputTaskName;
+        
         RTT::os::Mutex inout_lock;
 
     protected:
@@ -88,6 +93,40 @@ namespace RTT { namespace base {
         ChannelElementBase();
         virtual ~ChannelElementBase();
 
+        void setInputPortName(const std::string &name)
+        {
+            inputPortName = name;
+        };
+        void setInputTaskName(const std::string &name)
+        {
+            inputTaskName = name;
+        };
+        void setOutputPortName(const std::string &name)
+        {
+            outputPortName = name;
+        };
+        void setOutputTaskName(const std::string &name)
+        {
+            outputTaskName = name;
+        };
+        
+        const std::string &getInputPortName() const
+        {
+            return inputPortName;
+        };
+        const std::string &getInputTaskName() const
+        {
+            return inputTaskName;
+        };
+        const std::string &getOutputPortName() const
+        {
+            return outputPortName;
+        };
+        const std::string &getOutputTaskName() const
+        {
+            return outputTaskName;
+        };
+        
         /**
          * Removes the input channel (if any).
          * This call may delete channels from memory.

--- a/rtt/base/ChannelElementBase.hpp
+++ b/rtt/base/ChannelElementBase.hpp
@@ -47,6 +47,7 @@
 #include <rtt/os/Mutex.hpp>
 #include "rtt-base-fwd.hpp"
 #include "../internal/rtt-internal-fwd.hpp"
+#include <string>
 
 namespace RTT { namespace base {
 

--- a/rtt/base/InputPortInterface.cpp
+++ b/rtt/base/InputPortInterface.cpp
@@ -109,6 +109,10 @@ bool InputPortInterface::channelReady(ChannelElementBase::shared_ptr channel, RT
     // cid is deleted/owned by the ConnectionManager.
     if ( channel ) {
         internal::ConnID* cid = channel->getConnID();
+        cid->setOutputPortName(channel->getOutputPortName());
+        cid->setOutputTaskName(channel->getOutputTaskName());
+        cid->setInputPortName(channel->getInputPortName());
+        cid->setInputTaskName(channel->getInputTaskName());
         if (cid ) {
             this->addConnection(cid, channel, policy);
             if ( channel->inputReady() )

--- a/rtt/base/PortInterface.cpp
+++ b/rtt/base/PortInterface.cpp
@@ -40,6 +40,7 @@
 #include "../Service.hpp"
 #include "../OperationCaller.hpp"
 #include "../internal/ConnFactory.hpp"
+#include "../TaskContext.hpp"
 
 using namespace RTT;
 using namespace RTT::detail;
@@ -56,6 +57,16 @@ bool PortInterface::setName(const std::string& name)
     }
     return false;
 }
+
+const string& base::PortInterface::getOwnerName() const
+{
+    if(isLocal() && ownerName.empty() && iface)
+    {
+        return iface->getOwner()->getName();
+    }
+    return ownerName;
+}
+
 
 PortInterface& PortInterface::doc(const std::string& desc) {
     mdesc = desc;

--- a/rtt/base/PortInterface.hpp
+++ b/rtt/base/PortInterface.hpp
@@ -58,6 +58,14 @@ namespace RTT
     {
         std::string name;
         std::string mdesc;
+
+        /**
+         * Name of the owning TaskContext of the Port. 
+         * In case of a non local port, this should 
+         * contain the name of the remote task.
+         * */
+        std::string ownerName;
+        
     protected:
         DataFlowInterface* iface;
 
@@ -84,6 +92,21 @@ namespace RTT
          */
         bool setName(const std::string& name);
 
+        /**
+         * Returns the name of the owning TaskContext of this interface.
+         * In case of a non local port this returns the name of the
+         * remote task context.
+         * */
+        const std::string &getOwnerName() const;
+        
+        /**
+         * Sets the name of the owning TaskContext of this interface.
+         * */
+        void setOwnerName(const std::string &name) 
+        {
+            ownerName = name;
+        }
+        
         /**
          * Get the documentation of this port.
          * @return A description.

--- a/rtt/internal/ConnFactory.cpp
+++ b/rtt/internal/ConnFactory.cpp
@@ -97,9 +97,21 @@ base::ChannelElementBase::shared_ptr RTT::internal::ConnFactory::createRemoteCon
     return base::ChannelElementBase::shared_ptr();
 }
 
+void ConnFactory::fillConnId(ConnID* connId, base::OutputPortInterface& output_port, base::InputPortInterface& input_port)
+{
+    connId->setInputPortName(input_port.getName());
+    connId->setInputTaskName(input_port.getOwnerName());
+    connId->setOutputPortName(output_port.getName());
+    connId->setOutputTaskName(output_port.getOwnerName());
+}
+
+
 bool ConnFactory::createAndCheckConnection(base::OutputPortInterface& output_port, base::InputPortInterface& input_port, base::ChannelElementBase::shared_ptr channel_input, ConnPolicy policy) {
+    ConnID *connId = input_port.getPortID();
+    fillConnId(connId, output_port, input_port);
+    
     // Register the channel's input to the output port.
-    if ( output_port.addConnection( input_port.getPortID(), channel_input, policy ) ) {
+    if ( output_port.addConnection( connId, channel_input, policy ) ) {
         // notify input that the connection is now complete.
         if ( input_port.channelReady( channel_input->getOutputEndPoint(), policy ) == false ) {
             output_port.disconnect( &input_port );
@@ -206,6 +218,7 @@ base::ChannelElementBase::shared_ptr ConnFactory::createAndCheckOutOfBandConnect
     ConnPolicy policy2 = policy;
     policy2.pull = false;
     conn_id->name_id = policy2.name_id;
+    fillConnId(conn_id, output_port, input_port);
 
     // check if marshaller supports size hints:
     types::TypeMarshaller* ttt = dynamic_cast<types::TypeMarshaller*>( type->getProtocol(policy.transport) );

--- a/rtt/internal/ConnFactory.hpp
+++ b/rtt/internal/ConnFactory.hpp
@@ -261,6 +261,8 @@ namespace RTT
             return data_object;
         }
 
+        static void fillConnId(ConnID *connId, base::OutputPortInterface& output_port, base::InputPortInterface& input_port);
+        
         /**
          * Creates a connection from a local output_port to a local or remote input_port.
          * This function contains all logic to decide on how connections must be created to
@@ -290,8 +292,11 @@ namespace RTT
                     log(Error) << "Port " << input_port.getName() << " is not compatible with " << output_port.getName() << endlog();
                     return false;
                 }
+                ConnID *id = output_port.getPortID();
+                fillConnId(id, output_port, input_port);
+                
                 // local ports, create buffer here.
-                output_half = buildBufferedChannelOutput<T>(*input_p, output_port.getPortID(), policy, output_port.getLastWrittenValue());
+                output_half = buildBufferedChannelOutput<T>(*input_p, id, policy, output_port.getLastWrittenValue());
             }
             else
             {
@@ -308,10 +313,13 @@ namespace RTT
             if (!output_half)
                 return false;
 
+            ConnID *id = input_port.getPortID();
+            fillConnId(id, output_port, input_port);
+
             // Since output is local, buildChannelInput is local as well.
             // This this the input channel element of the whole connection
             base::ChannelElementBase::shared_ptr channel_input =
-                buildChannelInput<T>(output_port, input_port.getPortID(), output_half);
+                buildChannelInput<T>(output_port, id, output_half);
 
             return createAndCheckConnection(output_port, input_port, channel_input, policy );
         }

--- a/rtt/internal/ConnID.hpp
+++ b/rtt/internal/ConnID.hpp
@@ -47,6 +47,7 @@
 #define ORO_CONNID_HPP_
 
 #include "../rtt-config.h"
+#include <string>
 
 namespace RTT
 {
@@ -57,7 +58,46 @@ namespace RTT
          */
         class RTT_API ConnID
         {
+            std::string inputTaskName;
+            std::string inputPortName;
+            std::string outputTaskName;
+            std::string outputPortName;
+            
         public:
+            void setInputTaskName(const std::string &name)
+            {
+                inputTaskName = name;
+            };
+            void setOutputTaskName(const std::string &name)
+            {
+                outputTaskName = name;
+            };
+            void setInputPortName(const std::string &name)
+            {
+                inputPortName = name;
+            };
+            void setOutputPortName(const std::string &name)
+            {
+                outputPortName = name;
+            };
+            
+            const std::string &getInputTaskName() const
+            {
+                return inputTaskName;
+            };
+            const std::string &getOutputTaskName() const
+            {
+                return outputTaskName;
+            };
+            const std::string &getInputPortName() const
+            {
+                return inputPortName;
+            };
+            const std::string &getOutputPortName() const
+            {
+                return outputPortName;
+            };
+            
             virtual bool isSameID(ConnID const& id) const = 0;
             virtual ConnID* clone() const = 0;
             virtual ~ConnID() {}

--- a/rtt/transports/corba/DataFlow.idl
+++ b/rtt/transports/corba/DataFlow.idl
@@ -122,6 +122,11 @@ module RTT
       typedef sequence<CPortDescription> CPortDescriptions;
 
       /**
+      * Return the name of the instance that owns this interface.
+      */
+      string getOwnerName();
+      
+      /**
        * Returns the names of the ports of this component.
        */
       CPortNames getPorts();

--- a/rtt/transports/corba/DataFlow.idl
+++ b/rtt/transports/corba/DataFlow.idl
@@ -170,7 +170,7 @@ module RTT
        * The returned channel element will not be functional until
        * channelReady() has been called for it
        */
-      CChannelElement buildChannelOutput(in string input_port, inout CConnPolicy policy)
+      CChannelElement buildChannelOutput(in string input_port, in string output_port_name, in string output_task_name, inout CConnPolicy policy)
             raises(CNoCorbaTransport,CNoSuchPortException);
 
       /**
@@ -179,7 +179,7 @@ module RTT
        * Some protocols may adjust the policy, or pass additional information
        * into the policy, such as the name of the newly created connection.
        */
-      CChannelElement buildChannelInput(in string output_port, inout CConnPolicy policy)
+      CChannelElement buildChannelInput(in string output_port, in string input_port_name, in string input_task_name, inout CConnPolicy policy)
             raises(CNoCorbaTransport,CNoSuchPortException);
 
       /**

--- a/rtt/transports/corba/DataFlowI.h
+++ b/rtt/transports/corba/DataFlowI.h
@@ -113,6 +113,7 @@ namespace RTT {
         {
             DataFlowInterface* mdf;
             PortableServer::POA_var mpoa;
+            std::string ownerName;
 
             /** Keeps track of servants, such that we can dispose them
              * at the end.
@@ -136,9 +137,11 @@ namespace RTT {
             RTT::os::Mutex channel_list_mtx;
         public:
             // standard constructor
-            CDataFlowInterface_i(DataFlowInterface* interface, PortableServer::POA_ptr poa);
+            CDataFlowInterface_i(DataFlowInterface* interface, PortableServer::POA_ptr poa, const std::string &ownerName);
             virtual ~CDataFlowInterface_i();
 
+            virtual char* getOwnerName();
+            
             DataFlowInterface* getDataFlowInterface() const;
 
             static void registerServant(CDataFlowInterface_ptr objref, CDataFlowInterface_i* servant);

--- a/rtt/transports/corba/DataFlowI.h
+++ b/rtt/transports/corba/DataFlowI.h
@@ -75,6 +75,9 @@ namespace RTT {
             RTT::corba::CorbaTypeTransporter const& transport;
             PortableServer::POA_var mpoa;
             CDataFlowInterface_i* mdataflow;
+            
+            std::string remotePortName;
+            std::string remoteTaskName;
 
         public:
             // standard constructor
@@ -82,6 +85,9 @@ namespace RTT {
 			  PortableServer::POA_ptr poa);
             virtual ~CRemoteChannelElement_i();
 
+            const std::string &getRemotePortName() const;
+            const std::string &getRemoteTaskName() const;
+            
             virtual RTT::corba::CRemoteChannelElement_ptr activate_this() {
                 PortableServer::ObjectId_var oid = mpoa->activate_object(this); // ref count=2
                 _remove_ref(); // ref count=1
@@ -194,12 +200,12 @@ namespace RTT {
             	      ,::RTT::corba::CNoSuchPortException
             	    ));
 
-            CChannelElement_ptr buildChannelOutput(const char* reader_port, RTT::corba::CConnPolicy& policy) ACE_THROW_SPEC ((
+            CChannelElement_ptr buildChannelOutput(const char* input_port, const char* output_port_name, const char* output_task_name, CConnPolicy& policy) ACE_THROW_SPEC ((
             	      CORBA::SystemException
             	      ,::RTT::corba::CNoCorbaTransport
                       ,::RTT::corba::CNoSuchPortException
             	    ));
-            CChannelElement_ptr buildChannelInput(const char* writer_port, RTT::corba::CConnPolicy& policy) ACE_THROW_SPEC ((
+            CChannelElement_ptr buildChannelInput(const char* writer_port, const char* input_port_name, const char* input_task_name, RTT::corba::CConnPolicy& policy) ACE_THROW_SPEC ((
           	      CORBA::SystemException
           	      ,::RTT::corba::CNoCorbaTransport
                   ,::RTT::corba::CNoSuchPortException

--- a/rtt/transports/corba/RemotePorts.cpp
+++ b/rtt/transports/corba/RemotePorts.cpp
@@ -137,7 +137,7 @@ RTT::base::ChannelElementBase::shared_ptr RemoteInputPort::buildRemoteChannelOut
     RTT::base::ChannelElementBase::shared_ptr buf;
     try {
         CConnPolicy cpolicy = toCORBA(policy);
-        CChannelElement_var ret = dataflow->buildChannelOutput(getName().c_str(), cpolicy);
+        CChannelElement_var ret = dataflow->buildChannelOutput(getName().c_str(), output_port.getName().c_str(), output_port.getOwnerName().c_str(), cpolicy);
         if ( CORBA::is_nil(ret) ) {
             return 0;
         }

--- a/rtt/transports/corba/RemotePorts.cpp
+++ b/rtt/transports/corba/RemotePorts.cpp
@@ -55,11 +55,15 @@ template<typename BaseClass>
 RemotePort<BaseClass>::RemotePort(RTT::types::TypeInfo const* type_info,
         CDataFlowInterface_ptr dataflow,
         std::string const& name,
-        PortableServer::POA_ptr poa)
+        PortableServer::POA_ptr poa,
+        std::string const& ownerName)
     : BaseClass(name)
     , type_info(type_info)
     , dataflow(CDataFlowInterface::_duplicate(dataflow))
-    , mpoa(PortableServer::POA::_duplicate(poa)) { }
+    , mpoa(PortableServer::POA::_duplicate(poa)) 
+    { 
+        BaseClass::setOwnerName(ownerName);
+    }
 
 template<typename BaseClass>
 CDataFlowInterface_ptr RemotePort<BaseClass>::getDataFlowInterface() const
@@ -110,8 +114,9 @@ bool RemotePort<BaseClass>::addConnection(RTT::internal::ConnID* port_id, Channe
 
 RemoteInputPort::RemoteInputPort(RTT::types::TypeInfo const* type_info,
         CDataFlowInterface_ptr dataflow, std::string const& reader_port,
-        PortableServer::POA_ptr poa)
-    : RemotePort< RTT::base::InputPortInterface >(type_info, dataflow, reader_port, poa)
+        PortableServer::POA_ptr poa,
+        std::string const& ownerName)
+    : RemotePort< RTT::base::InputPortInterface >(type_info, dataflow, reader_port, poa, ownerName)
 {}
 
 RTT::base::DataSourceBase* RemoteInputPort::getDataSource()
@@ -222,8 +227,9 @@ bool RemoteInputPort::channelReady(RTT::base::ChannelElementBase::shared_ptr cha
 
 RemoteOutputPort::RemoteOutputPort(RTT::types::TypeInfo const* type_info,
         CDataFlowInterface_ptr dataflow, std::string const& reader_port,
-        PortableServer::POA_ptr poa)
-    : RemotePort< RTT::base::OutputPortInterface >(type_info, dataflow, reader_port, poa)
+        PortableServer::POA_ptr poa,
+        std::string const& ownerName)
+    : RemotePort< RTT::base::OutputPortInterface >(type_info, dataflow, reader_port, poa, ownerName)
 {}
 
 bool RemoteOutputPort::keepsLastWrittenValue() const

--- a/rtt/transports/corba/RemotePorts.hpp
+++ b/rtt/transports/corba/RemotePorts.hpp
@@ -72,7 +72,8 @@ namespace RTT {
             RemotePort(types::TypeInfo const* type_info,
                     CDataFlowInterface_ptr dataflow,
                     std::string const& name,
-                    PortableServer::POA_ptr poa);
+                    PortableServer::POA_ptr poa,
+                    std::string const& ownerName);
 
             PortableServer::POA_ptr _default_POA();
             CDataFlowInterface_ptr getDataFlowInterface() const;
@@ -100,7 +101,8 @@ namespace RTT {
             RemoteOutputPort(types::TypeInfo const* type_info,
                     CDataFlowInterface_ptr dataflow,
                     std::string const& name,
-                    PortableServer::POA_ptr poa);
+                    PortableServer::POA_ptr poa,
+                    std::string const& ownerName);
 
             bool keepsLastWrittenValue() const;
             void keepLastWrittenValue(bool new_flag);
@@ -138,7 +140,8 @@ namespace RTT {
             RemoteInputPort(types::TypeInfo const* type_info,
                     CDataFlowInterface_ptr dataflow,
                     std::string const& name,
-                    PortableServer::POA_ptr poa);
+                    PortableServer::POA_ptr poa,
+                    std::string const& ownerName);
 
             /**
              * This method will do more than just building the output half, it

--- a/rtt/transports/corba/ServiceI.cpp
+++ b/rtt/transports/corba/ServiceI.cpp
@@ -72,10 +72,10 @@ using namespace RTT;
 using namespace RTT::detail;
 
 // Implementation skeleton constructor
-RTT_corba_CService_i::RTT_corba_CService_i ( RTT::Service::shared_ptr service, PortableServer::POA_ptr poa)
+RTT_corba_CService_i::RTT_corba_CService_i ( RTT::Service::shared_ptr service, PortableServer::POA_ptr poa, const std::string &oName )
     : RTT_corba_CConfigurationInterface_i( service.get(), PortableServer::POA::_duplicate( poa) ), 
       RTT_corba_COperationInterface_i( service.get(), PortableServer::POA::_duplicate( poa) ),
-      RTT::corba::CDataFlowInterface_i( service.get(), PortableServer::POA::_duplicate( poa) ),
+      RTT::corba::CDataFlowInterface_i( service.get(), PortableServer::POA::_duplicate( poa), oName ),
       mpoa(poa), mservice(service)
 {
 }
@@ -131,7 +131,7 @@ char * RTT_corba_CService_i::getServiceDescription (
     
     RTT_corba_CService_i* serv_i;
     RTT::corba::CService_var serv;
-    serv_i = new RTT_corba_CService_i( provider, mpoa );
+    serv_i = new RTT_corba_CService_i( provider, mpoa , getOwnerName());
     serv = serv_i->activate_this();
     mservs.push_back( std::pair<RTT::corba::CService_var,PortableServer::ServantBase_var>( RTT::corba::CService::_duplicate(serv.in()), serv_i ) );
     //CService_i::registerServant(serv, mtask->provides(service_name));

--- a/rtt/transports/corba/ServiceI.h
+++ b/rtt/transports/corba/ServiceI.h
@@ -99,7 +99,7 @@ protected:
     Servants mservs;
 public:
   // Constructor 
-    RTT_corba_CService_i ( RTT::ServicePtr service, PortableServer::POA_ptr poa);
+    RTT_corba_CService_i ( RTT::Service::shared_ptr service, PortableServer::POA_ptr poa, const std::string& ownerName);
   
   // Destructor 
   virtual ~RTT_corba_CService_i (void);

--- a/rtt/transports/corba/TaskContextI.cpp
+++ b/rtt/transports/corba/TaskContextI.cpp
@@ -200,7 +200,7 @@ char * RTT_corba_CTaskContext_i::getDescription (
     if ( CORBA::is_nil( mService ) ) {
         log(Debug) << "Creating CService for "<< mtask->getName()<<endlog();
         RTT_corba_CService_i* mserv;
-        mService_i = mserv = new RTT_corba_CService_i( mtask->provides(), mpoa );
+        mService_i = mserv = new RTT_corba_CService_i( mtask->provides(), mpoa , mtask->getName());
         mService = mserv->activate_this();
         CDataFlowInterface_i::registerServant(CDataFlowInterface::_narrow(mService), mserv);
     }

--- a/rtt/transports/corba/TaskContextProxy.cpp
+++ b/rtt/transports/corba/TaskContextProxy.cpp
@@ -94,6 +94,16 @@ namespace RTT
     TaskContextProxy::TaskContextProxy(std::string name, bool is_ior)
         : TaskContext("NotFound")
     {
+        initFromURIOrTaskname(name, is_ior);
+    }
+
+    TaskContextProxy::TaskContextProxy(): TaskContext("NotFound")
+    {
+
+    }
+
+    void TaskContextProxy::initFromURIOrTaskname(string name, bool is_ior)
+    {
         Logger::In in("TaskContextProxy");
         this->clear();
         this->setActivity( new SequentialActivity() );
@@ -158,7 +168,7 @@ namespace RTT
 
         this->synchronize();
     }
-
+    
     TaskContextProxy::TaskContextProxy( ::RTT::corba::CTaskContext_ptr taskc)
         : TaskContext("CORBAProxy"), mtask( corba::CTaskContext::_duplicate(taskc) )
     {

--- a/rtt/transports/corba/TaskContextProxy.cpp
+++ b/rtt/transports/corba/TaskContextProxy.cpp
@@ -364,9 +364,9 @@ namespace RTT
                 {
                     PortInterface* new_port;
                     if (port.type == RTT::corba::CInput)
-                        new_port = new RemoteInputPort( type_info, dfact, port.name.in(), ProxyPOA() );
+                        new_port = new RemoteInputPort( type_info, dfact, port.name.in(), ProxyPOA(), mtask->getName() );
                     else
-                        new_port = new RemoteOutputPort( type_info, dfact, port.name.in(), ProxyPOA() );
+                        new_port = new RemoteOutputPort( type_info, dfact, port.name.in(), ProxyPOA(), mtask->getName() );
 
                     parent->addPort(*new_port);
                     port_proxies.push_back(new_port); // see comment in definition of port_proxies

--- a/rtt/transports/corba/TaskContextProxy.hpp
+++ b/rtt/transports/corba/TaskContextProxy.hpp
@@ -95,6 +95,11 @@ namespace RTT
         TaskContextProxy(std::string location, bool is_ior);
 
         /**
+         * A Private constructor which does nothing       
+         * */
+        TaskContextProxy();
+        
+        /**
          * Private constructor which creates a new connection to
          * a corba object
          */
@@ -108,6 +113,11 @@ namespace RTT
          */
         std::list<base::PortInterface*> port_proxies;
 
+        /**
+         * initializes the class from a stringified ior or taskname in NameServer.
+         * */
+        void initFromURIOrTaskname(std::string location, bool is_ior);
+        
         void synchronize();
 
         mutable corba::CTaskContext_var mtask;


### PR DESCRIPTION
Hi, 
this patch set adds the ability to introspect the connections that are active.
This feature is mainly useful for debugging. For now it is based on the 
rock1408 branch and SHOULD NOT BE MERGED.

Feel free to give feedback, if everyone is fine with this, I will rebase the
code on the current master and recreate a pull request.

By the way, it seems as  CDataFlowInterface_i::buildChannelInput is dead code.
Greetings
   Janosch