### PR TITLE
Configuration of Orocos include directories and definitions per target instead of per directory

### DIFF
--- a/UseOROCOS-RTT-helpers.cmake
+++ b/UseOROCOS-RTT-helpers.cmake
@@ -293,7 +293,12 @@ macro( orocos_use_package PACKAGE )
       endif()
 
       # Include the aggregated include directories
-      include_directories(${${PACKAGE}_INCLUDE_DIRS})
+      # CMake 2.8.8 added support for per-target INCLUDE_DIRECTORIES. The include directories will only be added to targets created
+      # with the orocos_*() macros. For older versions we have to set INCLUDE_DIRECTORIES per-directory.
+      # See https://github.com/orocos-toolchain/rtt/pull/85 for details.
+      if(CMAKE_VERSION VERSION_LESS 2.8.8)
+        include_directories(${${PACKAGE}_INCLUDE_DIRS})
+      endif()
 
       # Set a flag so we don't over-link (Don't cache this, it should remain per project)
       set(${PACKAGE}_${OROCOS_TARGET}_USED true)
@@ -349,6 +354,26 @@ macro(_orocos_list_to_string _string _list)
         endif(${_len} GREATER 0)
     endforeach(_item)
 endmacro(_orocos_list_to_string)
+
+macro(orocos_add_include_directories target)
+  if(CMAKE_VERSION VERSION_LESS 2.8.8)
+    #message(WARNING "Per-target INCLUDE_DIRECTORIES are not supported in CMake ${CMAKE_VERSION}.")
+  else()
+    get_target_property(_${target}_INCLUDE_DIRS ${target} INCLUDE_DIRECTORIES)
+    if(NOT _${target}_INCLUDE_DIRS)
+      set(_${target}_INCLUDE_DIRS ${ARGN})
+    else()
+      list(APPEND _${target}_INCLUDE_DIRS ${ARGN})
+    endif()
+
+    if("$ENV{VERBOSE}" OR ORO_USE_VERBOSE)
+      message(STATUS "[UseOrocos] Include directories for target '${target}': ${_${target}_INCLUDE_DIRS}")
+    endif()
+
+    set_target_properties(${target} PROPERTIES
+                          INCLUDE_DIRECTORIES "${_${target}_INCLUDE_DIRS}")
+  endif()
+endmacro(orocos_add_include_directories)
 
 macro(orocos_add_compile_flags target)
   set(args ${ARGN})

--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -15,8 +15,13 @@ cmake_minimum_required(VERSION 2.8.3)
 if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
   include(FindPkgConfig)
   include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT-helpers.cmake)
-  # Include directories
-  include_directories(${OROCOS-RTT_INCLUDE_DIRS})
+
+  # CMake 2.8.8 added support for per-target INCLUDE_DIRECTORIES. The include directories will only be added to targets created
+  # with the orocos_*() macros. For older versions we have to set INCLUDE_DIRECTORIES per-directory.
+  # See https://github.com/orocos-toolchain/rtt/pull/85 for details.
+  if(CMAKE_VERSION VERSION_LESS 2.8.8)
+    include_directories(${OROCOS-RTT_INCLUDE_DIRS})
+  endif()
 
   # Preprocessor definitions
   add_definitions(${OROCOS-RTT_DEFINITIONS})
@@ -286,6 +291,7 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       ${LIB_COMPONENT_VERSION}
       )
 
+    orocos_add_include_directories( ${COMPONENT_NAME} ${OROCOS-RTT_INCLUDE_DIRS} ${USE_OROCOS_INCLUDE_DIRS})
     orocos_add_compile_flags( ${COMPONENT_NAME} ${USE_OROCOS_CFLAGS_OTHER})
     orocos_add_link_flags( ${COMPONENT_NAME} ${USE_OROCOS_LDFLAGS_OTHER})
     orocos_set_install_rpath( ${COMPONENT_NAME} ${USE_OROCOS_LIBRARY_DIRS})
@@ -370,6 +376,7 @@ macro( orocos_library LIB_TARGET_NAME )
       ${LIB_COMPONENT_VERSION}
       )
 
+    orocos_add_include_directories( ${LIB_TARGET_NAME} ${OROCOS-RTT_INCLUDE_DIRS} ${USE_OROCOS_INCLUDE_DIRS})
     orocos_add_compile_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_CFLAGS_OTHER} )
     orocos_add_link_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_LDFLAGS_OTHER} )
     orocos_set_install_rpath( ${LIB_TARGET_NAME} "${USE_OROCOS_LIBRARY_DIRS};${OROCOS-RTT_LIBRARY_DIRS};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME};${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/types;${CMAKE_INSTALL_PREFIX}/lib/orocos${OROCOS_SUFFIX}/${PROJECT_NAME}/plugins;${CMAKE_INSTALL_PREFIX}/lib;${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}" )
@@ -438,6 +445,7 @@ macro( orocos_library LIB_TARGET_NAME )
       set_target_properties( ${EXE_TARGET_NAME} PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX} )
     endif(CMAKE_DEBUG_POSTFIX)
 
+    orocos_add_include_directories( ${EXE_TARGET_NAME} ${OROCOS-RTT_INCLUDE_DIRS} ${USE_OROCOS_INCLUDE_DIRS})
     orocos_add_compile_flags(${EXE_TARGET_NAME} ${USE_OROCOS_CFLAGS_OTHER})
     orocos_add_link_flags(${EXE_TARGET_NAME} ${USE_OROCOS_LDFLAGS_OTHER})
     orocos_set_install_rpath( ${EXE_TARGET_NAME} ${USE_OROCOS_LIBRARY_DIRS})
@@ -496,6 +504,7 @@ macro( orocos_library LIB_TARGET_NAME )
       set_target_properties( ${EXE_TARGET_NAME} PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX} )
     endif(CMAKE_DEBUG_POSTFIX)
 
+    orocos_add_include_directories( ${EXE_TARGET_NAME} ${OROCOS-RTT_INCLUDE_DIRS} ${USE_OROCOS_INCLUDE_DIRS})
     orocos_add_compile_flags(${EXE_TARGET_NAME} ${USE_OROCOS_CFLAGS_OTHER})
     orocos_add_link_flags(${EXE_TARGET_NAME} ${USE_OROCOS_LDFLAGS_OTHER})
     orocos_set_install_rpath( ${EXE_TARGET_NAME} ${USE_OROCOS_LIBRARY_DIRS})
@@ -617,6 +626,7 @@ macro( orocos_library LIB_TARGET_NAME )
       ${LIB_COMPONENT_VERSION}
       )
 
+    orocos_add_include_directories( ${LIB_TARGET_NAME} ${OROCOS-RTT_INCLUDE_DIRS} ${USE_OROCOS_INCLUDE_DIRS})
     orocos_add_compile_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_CFLAGS_OTHER})
     orocos_add_link_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_LDFLAGS_OTHER})
     orocos_set_install_rpath( ${LIB_TARGET_NAME} ${USE_OROCOS_LIBRARY_DIRS})
@@ -699,6 +709,7 @@ macro( orocos_library LIB_TARGET_NAME )
       ${LIB_COMPONENT_VERSION}
       )
 
+    orocos_add_include_directories( ${LIB_TARGET_NAME} ${OROCOS-RTT_INCLUDE_DIRS} ${USE_OROCOS_INCLUDE_DIRS})
     orocos_add_compile_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_CFLAGS_OTHER})
     orocos_add_link_flags( ${LIB_TARGET_NAME} ${USE_OROCOS_LDFLAGS_OTHER})
     orocos_set_install_rpath( ${LIB_TARGET_NAME} ${USE_OROCOS_LIBRARY_DIRS})


### PR DESCRIPTION
This pull requests solves the problem that if a package `b` is installed in the same folder than RTT or another package `a` which is used by `b`, the include directories of the shared install-space have been added to the compiler command line before the package-local include directories specified with `include_directories()`. This is typically the case if a catkin workspace is built with `catkin_make_isolated --install`. As a consequence of this, the install-space has to be cleaned before rebuilding whenever a header in the source folder has been changed.

Example CMakeLists.txt:

``` cmake
project(b)

find_package(Orocos-RTT REQUIRED)
include(${OROCOS-RTT_USE_FILE})

# a is installed in the same install-space than b (CMAKE_INSTALL_PREFIX)
orocos_use_package(a)

include_directories(include/headers/of/b)
orocos_library(b_library src/b.cpp)
orocos_install_headers(include/headers/of/b)
```

Resulting include directories order for `b_library` without this patch:
1. `${OROCOS-RTT_INCLUDE_DIRS}` added by `include(${OROCOS-RTT_USE_FILE})`
2. `${CMAKE_INSTALL_PREFIX}/include/orocos` added by `orocos_use_package(a)`
3. `${b_SOURCE_DIR}/include/b/headers` added by `include_directories(include/headers/of/b)`

Include directories order for `b_library` with this patch:
1. `${b_SOURCE_DIR}/include/b/headers` added by `include_directories(include/headers/of/b)`
2. `${OROCOS-RTT_INCLUDE_DIRS}` and `${CMAKE_INSTALL_PREFIX}/include/orocos` added by `orocos_library(b_library)`

It should be noted that the same result can be achieved without the patch by changing the order of the `include(${OROCOS-RTT_USE_FILE})`, `orocos_use_package(a)`, `include_directories(include/b/headers)` lines in `CMakeLists.txt` or by replacing the latter with `include_directories(BEFORE include/b/headers)`.

Unfortunately the per-target INCLUDE_DIRECTORIES property is only supported by CMake version 2.8.8 and newer (see http://www.cmake.org/Wiki/CMake_Version_Compatibility_Matrix/Properties_on_Targets). For older versions the previous include directories order is preserved. Ubuntu 12.04LTS ships with CMake 2.8.7. I am not very happy with this version-dependent differences, but I have not found a simple workaround for older versions.

`include(${OROCOS-RTT_USE_FILE})` alone does not modify the include directories for non-Orocos targets anymore if CMake version 2.8.8 or newer is used.
To restore the old behavior where every target sees the RTT include directories simply add

```
include_directories(${${OROCOS-RTT_INCLUDE_DIRS} ${USE_OROCOS_INCLUDE_DIRS})
```

to your CMakeLists.txt after having included the `${OROCOS-RTT_USE_FILE}`.
