### PR TITLE
Second Introspection implementation

### DIFF
--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -239,7 +239,7 @@ namespace RTT
     
     bool TaskContext::loadPlugin(const string& pluginPath)
     {
-        return PluginLoader::Instance()->loadLibrary(pluginPath);
+        return PluginLoader::Instance()->loadPlugin(pluginPath, "");
     }
 
 

--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -118,6 +118,7 @@ namespace RTT
 
         this->addOperation("trigger", &TaskContext::trigger, this, ClientThread).doc("Trigger the update method for execution in the thread of this task.\n Only succeeds if the task isRunning() and allowed by the Activity executing this task.");
         this->addOperation("loadService", &TaskContext::loadService, this, ClientThread).doc("Loads a service known to RTT into this component.").arg("service_name","The name with which the service is registered by in the PluginLoader.");
+        this->addOperation("loadPlugin", &TaskContext::loadPlugin, this, ClientThread).doc("Loads a RTT plugin.").arg("plugin_path","The path to the shared library containing the plugin.");
         // activity runs from the start.
         if (our_act)
             our_act->start();
@@ -235,6 +236,12 @@ namespace RTT
             return true;
         return PluginLoader::Instance()->loadService(service_name, this);
     }
+    
+    bool TaskContext::loadPlugin(const string& pluginPath)
+    {
+        return PluginLoader::Instance()->loadLibrary(pluginPath);
+    }
+
 
     void TaskContext::addUser( TaskContext* peer )
     {

--- a/rtt/TaskContext.hpp
+++ b/rtt/TaskContext.hpp
@@ -325,6 +325,13 @@ namespace RTT
          */
         bool loadService(const std::string& service_name);
 
+        /**
+         * Use this method to load a plugin.
+         * @param pluginPath The path to the shared library containing the plugin.
+         * @return true if the plugin was present already or could be loaded.
+         */
+        bool loadPlugin(const std::string& pluginPath);
+        
         /** @} */
 
         /**

--- a/rtt/base/BufferBase.hpp
+++ b/rtt/base/BufferBase.hpp
@@ -98,6 +98,11 @@ namespace RTT
          * @rt
          */
         virtual void clear() = 0;
+        
+        /**
+         * Returns the number of dropped samples, because the buffer was full
+         * */
+        virtual size_type dropped() const = 0;
     };
 }}
 

--- a/rtt/base/BufferLocked.hpp
+++ b/rtt/base/BufferLocked.hpp
@@ -75,7 +75,7 @@ namespace RTT
          * @param circular Set flag to true to make this buffer circular. If not circular, new values are discarded on full.
          */
         BufferLocked( size_type size, const T& initial_value = T(), bool circular = false )
-            : cap(size), buf(), mcircular(circular)
+            : cap(size), buf(), mcircular(circular), droppedSamples(0)
         {
             data_sample(initial_value);
         }
@@ -101,8 +101,12 @@ namespace RTT
         {
             os::MutexLock locker(lock);
             if ( cap == (size_type)buf.size() ) {
+                //buffer is full, we either overwrite a sample, or drop the given one
+                droppedSamples++;
                 if (!mcircular)
+                {
                     return false;
+                }
                 else
                     buf.pop_front();
             }
@@ -117,12 +121,17 @@ namespace RTT
             if (mcircular && (size_type)items.size() >= cap ) {
                 // clear out current data and reset iterator to first element we're going to take.
                 buf.clear();
+                //note the ignored samples are added below to the dropped samples.
+                droppedSamples += cap;
                 itl = items.begin() + ( items.size() - cap );
             } else if ( mcircular && (size_type)(buf.size() + items.size()) > cap) {
                 // drop excess elements from front
                 assert( (size_type)items.size() < cap );
                 while ( (size_type)(buf.size() + items.size()) > cap )
+                {
+                    droppedSamples++;
                     buf.pop_front();
+                }
                 // itl still points at first element of items.
             }
             while ( ((size_type)buf.size() != cap) && (itl != items.end()) ) {
@@ -130,10 +139,14 @@ namespace RTT
                 ++itl;
             }
             // this is in any case the number of elements taken from items.
+            size_t writtenSamples = itl - items.begin(); 
+            
             if (mcircular)
-                assert( (size_type)(itl - items.begin() ) == (size_type)items.size() );
-            return (itl - items.begin());
-
+                assert( writtenSamples == (size_type)items.size() );
+            
+            droppedSamples += items.size() - writtenSamples;
+            
+            return writtenSamples;
         }
         bool Pop( reference_t item )
         {
@@ -204,12 +217,18 @@ namespace RTT
             os::MutexLock locker(lock);
             return (size_type)buf.size() ==  cap;
         }
+        
+        size_type dropped() const
+        {
+            return droppedSamples;
+        }
     private:
         size_type cap;
         std::deque<T> buf;
         value_t lastSample;
         mutable os::Mutex lock;
         const bool mcircular;
+        size_type droppedSamples;
     };
 }}
 

--- a/rtt/base/ChannelElementBase.hpp
+++ b/rtt/base/ChannelElementBase.hpp
@@ -176,6 +176,44 @@ namespace RTT { namespace base {
          * @return null if no ConnID is associated with this element.
          */
         virtual internal::ConnID* getConnID() const;
+        
+        /**
+         * This function may be used to identify, 
+         * if the current element uses a network
+         * transport, to send the data to the next
+         * Element in the logical chain.
+         * 
+         * @return true if a network transport is used.
+         * */
+        virtual bool isRemoteElement() const;
+        
+        /**
+         * This function returns the URI of the
+         * next channel element in the logical
+         * chain. The URI must be unique.
+         * E.g: In the local case output->getLocalURI()
+         * In the remote case the URI of the remote
+         * channel element.
+         * 
+         * @return URI of the next element.
+         * */
+        virtual std::string getRemoteURI() const;
+        
+        /**
+         * This function return the URI of this
+         * element. The URI must be unique.
+         * @return URI of this element.
+         * */
+        virtual std::string getLocalURI() const;
+        
+        /**
+         * Returns the class name of this
+         * element. This is primary useful 
+         * for special case handling in the
+         * connection tracking.
+         * @return The name of the class of the ChannelElement
+         * */
+        virtual std::string getElementName() const;
     };
 
     void RTT_API intrusive_ptr_add_ref( ChannelElementBase* e );

--- a/rtt/base/ChannelInterface.cpp
+++ b/rtt/base/ChannelInterface.cpp
@@ -39,6 +39,7 @@
 #include "../internal/Channels.hpp"
 #include "../os/Atomic.hpp"
 #include "../os/MutexLock.hpp"
+#include <boost/lexical_cast.hpp>
 
 using namespace RTT;
 using namespace RTT::detail;
@@ -134,6 +135,26 @@ PortInterface* ChannelElementBase::getPort() const {
 
 internal::ConnID* ChannelElementBase::getConnID() const {
     return 0;
+}
+
+bool ChannelElementBase::isRemoteElement() const {
+    return false;
+}
+
+std::string ChannelElementBase::getRemoteURI() const {
+    if(!output)
+    {
+        return std::string();
+    }
+    return output->getLocalURI();
+}
+
+std::string ChannelElementBase::getLocalURI() const {
+    return std::string(boost::lexical_cast<std::string>(this));
+}
+
+std::string ChannelElementBase::getElementName() const {
+    return std::string("ChannelElementBase");
 }
 
 void ChannelElementBase::ref()

--- a/rtt/internal/ChannelBufferElement.hpp
+++ b/rtt/internal/ChannelBufferElement.hpp
@@ -54,7 +54,7 @@ namespace RTT { namespace internal {
     /** A connection element that can store a fixed number of data samples.
      */
     template<typename T>
-    class ChannelBufferElement : public base::ChannelElement<T>, ChannelBufferElementBase
+    class ChannelBufferElement : public base::ChannelElement<T>, public ChannelBufferElementBase
     {
         typename base::BufferInterface<T>::shared_ptr buffer;
         typename base::ChannelElement<T>::value_t *last_sample_p;

--- a/rtt/internal/ChannelBufferElement.hpp
+++ b/rtt/internal/ChannelBufferElement.hpp
@@ -122,6 +122,11 @@ namespace RTT { namespace internal {
         {
             return buffer->data_sample();
         }
+        
+        virtual std::string getElementName() const 
+        {
+            return "ChannelBufferElement";
+        }
     };
 }}
 

--- a/rtt/internal/ChannelBufferElement.hpp
+++ b/rtt/internal/ChannelBufferElement.hpp
@@ -49,6 +49,7 @@ namespace RTT { namespace internal {
     public:
         virtual size_t getBufferSize() const = 0;
         virtual size_t getBufferFillSize() const = 0;
+        virtual size_t getNumDroppedSamples() const = 0;
     };
     
     /** A connection element that can store a fixed number of data samples.
@@ -80,6 +81,11 @@ namespace RTT { namespace internal {
         virtual size_t getBufferFillSize() const
         {
             return buffer->size();
+        }
+        
+        virtual size_t getNumDroppedSamples() const
+        {
+            return buffer->dropped();
         }
         
         /** Appends a sample at the end of the FIFO

--- a/rtt/internal/ChannelBufferElement.hpp
+++ b/rtt/internal/ChannelBufferElement.hpp
@@ -44,10 +44,17 @@
 
 namespace RTT { namespace internal {
 
+    class ChannelBufferElementBase
+    {
+    public:
+        virtual size_t getBufferSize() const = 0;
+        virtual size_t getBufferFillSize() const = 0;
+    };
+    
     /** A connection element that can store a fixed number of data samples.
      */
     template<typename T>
-    class ChannelBufferElement : public base::ChannelElement<T>
+    class ChannelBufferElement : public base::ChannelElement<T>, ChannelBufferElementBase
     {
         typename base::BufferInterface<T>::shared_ptr buffer;
         typename base::ChannelElement<T>::value_t *last_sample_p;
@@ -65,6 +72,16 @@ namespace RTT { namespace internal {
 		buffer->Release(last_sample_p);
 	}
  
+        virtual size_t getBufferSize() const
+        {
+            return buffer->capacity();
+        }
+        
+        virtual size_t getBufferFillSize() const
+        {
+            return buffer->size();
+        }
+        
         /** Appends a sample at the end of the FIFO
          *
          * @return true if there was room in the FIFO for the new sample, and false otherwise.

--- a/rtt/internal/ChannelDataElement.hpp
+++ b/rtt/internal/ChannelDataElement.hpp
@@ -112,6 +112,10 @@ namespace RTT { namespace internal {
             return data->Get();
         }
 
+        virtual std::string getElementName() const
+        {
+            return "ChannelDataElement";
+        };
     };
 }}
 

--- a/rtt/internal/ConnInputEndPoint.hpp
+++ b/rtt/internal/ConnInputEndPoint.hpp
@@ -96,6 +96,10 @@ namespace RTT
             return this->cid; 
         }
 
+        std::string getElementName() const {
+            return std::string("ConnInputEndpoint");
+        }
+
     };
 
 }}

--- a/rtt/internal/ConnOutputEndPoint.hpp
+++ b/rtt/internal/ConnOutputEndPoint.hpp
@@ -135,6 +135,11 @@ namespace RTT
         virtual ConnID* getConnID() const { 
             return this->cid; 
         }
+        
+        std::string getElementName() const {
+            return std::string("ConnOutputEndpoint");
+        }
+        
     };
 
 }}

--- a/rtt/internal/ConnectionManager.hpp
+++ b/rtt/internal/ConnectionManager.hpp
@@ -203,14 +203,14 @@ namespace RTT
             /**
              * Locks the mutex protecting the channel element list.
              * */
-            void lock() {
+            void lock() const {
                 connection_lock.lock();
             };
 
             /**
              * Unlocks the mutex protecting the channel element list.
              * */
-            void unlock() {
+            void unlock() const {
                 connection_lock.unlock();
             }
         protected:
@@ -256,7 +256,7 @@ namespace RTT
              * Lock that should be taken before the list of connections is
              * accessed or modified
              */
-            RTT::os::Mutex connection_lock;
+            mutable RTT::os::Mutex connection_lock;
         };
 
     }

--- a/rtt/internal/ConnectionManager.hpp
+++ b/rtt/internal/ConnectionManager.hpp
@@ -200,6 +200,19 @@ namespace RTT
              */
             void clear();
 
+            /**
+             * Locks the mutex protecting the channel element list.
+             * */
+            void lock() {
+                connection_lock.lock();
+            };
+
+            /**
+             * Unlocks the mutex protecting the channel element list.
+             * */
+            void unlock() {
+                connection_lock.unlock();
+            }
         protected:
 
             void updateCurrentChannel(bool reset_current);

--- a/rtt/transports/corba/RemoteChannelElement.hpp
+++ b/rtt/transports/corba/RemoteChannelElement.hpp
@@ -377,15 +377,24 @@ namespace RTT {
                 return true;
             }
             
-            
             virtual std::string getRemoteURI() const
             {
+                //check for output element case
+                RTT::base::ChannelElementBase *base = const_cast<RemoteChannelElement<T> *>(this);
+                if(base->getOutput())
+                    return RTT::base::ChannelElementBase::getRemoteURI();
+                
                 std::string uri = ApplicationServer::orb->object_to_string(remote_side);
                 return uri;
             }
             
             virtual std::string getLocalURI() const
             {
+                //check for input element case
+                RTT::base::ChannelElementBase *base = const_cast<RemoteChannelElement<T> *>(this);
+                if(base->getInput())
+                    return RTT::base::ChannelElementBase::getLocalURI();
+                
                 return localUri;
             }
             

--- a/rtt/transports/corba/RemoteChannelElement.hpp
+++ b/rtt/transports/corba/RemoteChannelElement.hpp
@@ -42,6 +42,7 @@
 #include "DataFlowI.h"
 #include "CorbaTypeTransporter.hpp"
 #include "CorbaDispatcher.hpp"
+#include "ApplicationServer.hpp"
 
 namespace RTT {
 
@@ -73,6 +74,7 @@ namespace RTT {
 
             PortableServer::ObjectId_var oid;
 
+            std::string localUri;
 	public:
 	    /**
 	     * Create a channel element for remote data exchange.
@@ -93,6 +95,8 @@ namespace RTT {
                 oid = mpoa->activate_object(this);
                 // Force creation of dispatcher.
                 CorbaDispatcher::Instance(msender);
+                
+                localUri = ApplicationServer::orb->object_to_string(_this());
             }
 
             ~RemoteChannelElement()
@@ -368,6 +372,27 @@ namespace RTT {
                 return true;
             }
 
+            virtual bool isRemoteElement() const
+            {
+                return true;
+            }
+            
+            
+            virtual std::string getRemoteURI() const
+            {
+                std::string uri = ApplicationServer::orb->object_to_string(remote_side);
+                return uri;
+            }
+            
+            virtual std::string getLocalURI() const
+            {
+                return localUri;
+            }
+            
+            virtual std::string getElementName() const
+            {
+                return "CorbaRemoteChannelElement";
+            }
         };
     }
 }

--- a/rtt/transports/mqueue/MQChannelElement.hpp
+++ b/rtt/transports/mqueue/MQChannelElement.hpp
@@ -176,11 +176,21 @@ namespace RTT
             
             virtual std::string getRemoteURI() const
             {
+                //check for output element case
+                RTT::base::ChannelElementBase *base = const_cast<MQChannelElement<T> *>(this);
+                if(base->getOutput())
+                    return RTT::base::ChannelElementBase::getRemoteURI();
+                
                 return mqname;
             }
 
             virtual std::string getLocalURI() const
             {
+                //check for input element case
+                RTT::base::ChannelElementBase *base = const_cast<MQChannelElement<T> *>(this);
+                if(base->getInput())
+                    return RTT::base::ChannelElementBase::getLocalURI();
+
                 return mqname;
             }
 

--- a/rtt/transports/mqueue/MQChannelElement.hpp
+++ b/rtt/transports/mqueue/MQChannelElement.hpp
@@ -169,6 +169,25 @@ namespace RTT
                 return mqWrite(write_sample);
             }
 
+            virtual bool isRemoteElement() const
+            {
+                return true;
+            }
+            
+            virtual std::string getRemoteURI() const
+            {
+                return mqname;
+            }
+
+            virtual std::string getLocalURI() const
+            {
+                return mqname;
+            }
+
+            virtual std::string getElementName() const
+            {
+                return "MQChannelElement";
+            }
         };
     }
 }


### PR DESCRIPTION
Hey, 
I did a proof of concept implementation of the concept we talked
about on the mailing list. These are the modification to rtt that are 
needed to implement the Introspection ability. Please note, that
we would also need to patch the RosPubChannelElement in order
to make it work with the ROS transport. 

Note, this is a POC, it is not intended for direct merging.

I also have a client side implementation for this, which can be found
here :
https://github.com/jmachowinski/rtt_introspection
https://github.com/jmachowinski/rtt_introspection_typekit
As it is still a proof of concept it is not tidied up and hacky....

The output of it looks like this :
Task task2
Output Ports : 
    output2 :
        Connections
            ConnInputEndpoint(0x7fe53800b7f0)->ChannelDataElement(0x7fe53800b780)->CorbaRemoteChannelElement(0x7fe53800af68)->CorbaRemoteChannelElement(IOR:010000002800000049444c3a5254542f636f7262612f4352656d6f74654368616e6e656c456c656d656e743a312e3000010000000000000064000000010102000c00000031302e3235302e332e31300024dc00000e000000feed8b1a5500007f0a000000000900000200000000000000080000000100000000545441010000001c00000001000000010001000100000001000105090101000100000009010100)->ChannelDataElement(0x7f948c0055a0)->ConnOutputEndpoint(0x7f948c004cc0)->input->task1
            ConnInputEndpoint(0x7fe53800d910)->ChannelDataElement(0x7fe53800d8a0)->CorbaRemoteChannelElement(0x7fe53800d088)->CorbaRemoteChannelElement(IOR:010000002800000049444c3a5254542f636f7262612f4352656d6f74654368616e6e656c456c656d656e743a312e3000010000000000000064000000010102000c00000031302e3235302e332e31300024dc00000e000000feed8b1a5500007f0a000000000f00000200000000000000080000000100000000545441010000001c00000001000000010001000100000001000105090101000100000009010100)->ChannelDataElement(0x7f948c0062a0)->ConnOutputEndpoint(0x7f948c005900)->input->task1
