### PR TITLE
corba: Optionally support not emitting IORs if name service not used

### DIFF
--- a/config/check_depend.cmake
+++ b/config/check_depend.cmake
@@ -44,6 +44,8 @@ endif()
 OPTION(PLUGINS_ENABLE "Enable plugins" ON)
 OPTION(PLUGINS_STD_TYPES_SUPPORT "Enable support for the std::string and std::vector<double> types in the RTT typekit & transports." ON)
     
+OPTION(ORO_NO_EMIT_CORBA_IOR "Do not emit CORBA IORs if name service not used" OFF)
+
 ###########################################################
 #                                                         #
 # Look for dependencies required by individual components #

--- a/rtt/os/targets/target-config.h.in
+++ b/rtt/os/targets/target-config.h.in
@@ -64,6 +64,8 @@
 
 #cmakedefine ORO_REMOTING
 
+#cmakedefine ORO_NO_EMIT_CORBA_IOR
+
 #cmakedefine OROBLD_DISABLE_LOGGING
 #cmakedefine OROSEM_PRINTF_LOGGING
 #cmakedefine OROSEM_FILE_LOGGING

--- a/rtt/transports/corba/TaskContextServer.cpp
+++ b/rtt/transports/corba/TaskContextServer.cpp
@@ -171,6 +171,7 @@ namespace RTT
                     else
                     {
                         log(Warning) << err << endlog();
+#ifndef ORO_NO_EMIT_CORBA_IOR
                         log() <<"Writing IOR to 'std::cerr' and file '" << taskc->getName() <<".ior'"<<endlog();
 
                         // this part only publishes the IOR to a file.
@@ -183,6 +184,7 @@ namespace RTT
                             std::ofstream file_ior( iorname.c_str() );
                             file_ior << ior.in() <<std::endl;
                         }
+#endif
                         return;
                     }
                 }
@@ -220,6 +222,7 @@ namespace RTT
             } // use_naming
             else {
                 log(Info) <<"CTaskContext '"<< taskc->getName() << "' is not using the CORBA Naming Service."<<endlog();
+#ifndef ORO_NO_EMIT_CORBA_IOR
                 log() <<"Writing IOR to 'std::cerr' and file '" << taskc->getName() <<".ior'"<<endlog();
 
                 // this part only publishes the IOR to a file.
@@ -232,6 +235,7 @@ namespace RTT
                     std::ofstream file_ior( iorname.c_str() );
                     file_ior << ior.in() <<std::endl;
                 }
+#endif
                 return;
             }
         }


### PR DESCRIPTION
A component that acts as a COBRA server, but that is not registering with the name
service, will cause an IOR to be output to the deployer console and the IOR to
be written to a file in PWD. This behaviour is not desirable in all applications.

This patch makes the behaviour optional in RTT, by providing a global option to
disable the IOR emission (defaults to OFF, to keep backwards compatibility).
When not emitting then the IOR is not written to stdout nor to file.