### PR TITLE
cmake: also export the package install prefix

### DIFF
--- a/UseOROCOS-RTT-helpers.cmake
+++ b/UseOROCOS-RTT-helpers.cmake
@@ -201,6 +201,7 @@ macro( orocos_find_package PACKAGE )
       # The flags are space separated, so no need to quote here:
       set(${PACKAGE}_CFLAGS_OTHER ${${PACKAGE}_COMP_${OROCOS_TARGET}_CFLAGS_OTHER})
       set(${PACKAGE}_LDFLAGS_OTHER ${${PACKAGE}_COMP_${OROCOS_TARGET}_LDFLAGS_OTHER})
+      set(${PACKAGE}_PREFIX ${${PACKAGE}_COMP_${OROCOS_TARGET}_PREFIX})
 
     else()
       if(ORO_FIND_REQUIRED)


### PR DESCRIPTION
Use case: to build CORBA typekits you need the full path to the /include/orocos//transports/corba,
as the include_dirs might consist of multiple paths, include_dirs cannot be used for this purpose. The prefix path can
be used instead in this use-case.

Signed-off-by: Ruben Smits <ruben.smits@intermodalics.eu>