### PR TITLE
cmake: add SOVERSION for typekits and plugins

### DIFF
--- a/config/rtt_macros.cmake
+++ b/config/rtt_macros.cmake
@@ -41,8 +41,13 @@ ENDMACRO( GLOBAL_ADD_SRC )
 #
 macro(ADD_RTT_TYPEKIT name version)
   ADD_LIBRARY(${name}-${OROCOS_TARGET}_plugin SHARED ${ARGN})
+  STRING( REGEX MATCHALL "[0-9]+" versions ${version} )
+  LIST( GET versions 0 version_major)
+  LIST( GET versions 1 version_minor)
+  LIST( GET versions 2 version_patch)
   SET_TARGET_PROPERTIES( ${name}-${OROCOS_TARGET}_plugin PROPERTIES
     VERSION "${version}"
+    SOVERSION "${version_major}.${version_minor}"
     OUTPUT_NAME ${name}-${OROCOS_TARGET}
     COMPILE_DEFINITIONS "${RTT_DEFINITIONS}"
     COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD}"
@@ -110,8 +115,13 @@ endmacro(ADD_RTT_TYPEKIT name)
 #
 macro(ADD_RTT_PLUGIN name version)
   ADD_LIBRARY(${name}-${OROCOS_TARGET}_plugin SHARED ${ARGN})
+  STRING( REGEX MATCHALL "[0-9]+" versions ${version} )
+  LIST( GET versions 0 version_major)
+  LIST( GET versions 1 version_minor)
+  LIST( GET versions 2 version_patch)
   SET_TARGET_PROPERTIES( ${name}-${OROCOS_TARGET}_plugin PROPERTIES
     VERSION "${version}"
+    SOVERSION "${version_major}.${version_minor}"
     OUTPUT_NAME ${name}-${OROCOS_TARGET}
     COMPILE_DEFINITIONS "${RTT_DEFINITIONS}"
     COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD}"


### PR DESCRIPTION
This makes sure that depending projects link with the major.minor version instead of the full version typekit/plugin.

E.g.
````
 ldd bin/deployer-gnulinux 
	...
	liborocos-rtt-gnulinux.so.2.8 => /home/rsmits/orocos_ws/install_isolated/lib/liborocos-rtt-gnulinux.so.2.8 (0x00007f05daa7d000)
	liborocos-ocl-log4cpp-gnulinux.so.2.8.0 => /home/rsmits/orocos_ws/install_isolated/lib/liborocos-ocl-log4cpp-gnulinux.so.2.8.0 (0x00007f05da9f6000)
	liborocos-ocl-taskbrowser-gnulinux.so.2.8.0 => /home/rsmits/orocos_ws/install_isolated/lib/liborocos-ocl-taskbrowser-gnulinux.so.2.8.0 (0x00007f05da9be000)
	liborocos-ocl-deployment-gnulinux.so.2.8.0 => /home/rsmits/orocos_ws/install_isolated/lib/liborocos-ocl-deployment-gnulinux.so.2.8.0 (0x00007f05da7be000)
	...
	librtt-scripting-gnulinux.so.2.8.0 => /home/rsmits/orocos_ws/install_isolated/lib/orocos/gnulinux/plugins/librtt-scripting-gnulinux.so.2.8.0 (0x00007f05d85b2000)
	librtt-marshalling-gnulinux.so.2.8.0 => /home/rsmits/orocos_ws/install_isolated/lib/orocos/gnulinux/plugins/librtt-marshalling-gnulinux.so.2.8.0 (0x00007f05d84d9000)
	...
````
becomes
````
linux-vdso.so.1 =>  (0x00007ffc9ff6d000)
	liborocos-rtt-gnulinux.so.2.8 => /home/rsmits/orocos_ws/install_isolated/lib/liborocos-rtt-gnulinux.so.2.8 (0x00007fe404837000)
	liborocos-ocl-log4cpp-gnulinux.so.2.8.0 => /home/rsmits/orocos_ws/install_isolated/lib/liborocos-ocl-log4cpp-gnulinux.so.2.8.0 (0x00007fe4047b0000)
	liborocos-ocl-taskbrowser-gnulinux.so.2.8.0 => /home/rsmits/orocos_ws/install_isolated/lib/liborocos-ocl-taskbrowser-gnulinux.so.2.8.0 (0x00007fe404778000)
	liborocos-ocl-deployment-gnulinux.so.2.8.0 => /home/rsmits/orocos_ws/install_isolated/lib/liborocos-ocl-deployment-gnulinux.so.2.8.0 (0x00007fe404578000)
	...
	librtt-scripting-gnulinux.so.2.8 => /home/rsmits/orocos_ws/install_isolated/lib/orocos/gnulinux/plugins/librtt-scripting-gnulinux.so.2.8 (0x00007fe40236c000)
	librtt-marshalling-gnulinux.so.2.8 => /home/rsmits/orocos_ws/install_isolated/lib/orocos/gnulinux/plugins/librtt-marshalling-gnulinux.so.2.8 (0x00007fe402293000)
	....
````