### PR TITLE
Added ORO_WAIT_ABS and ORO_WAIT_ABS constants for all targets

### DIFF
--- a/rtt/os/ecos/fosi.h
+++ b/rtt/os/ecos/fosi.h
@@ -49,6 +49,9 @@ extern "C"
 #define ORO_SCHED_RT    0
 #define ORO_SCHED_OTHER 0
 
+#define ORO_WAIT_ABS 0 /** Not supported for the ecos target */
+#define ORO_WAIT_REL 1 /** Not supported for the ecos target */
+
     typedef long long NANO_TIME;
     typedef cyg_tick_count_t TICK_TIME;
 

--- a/rtt/os/lxrt/fosi.h
+++ b/rtt/os/lxrt/fosi.h
@@ -126,6 +126,8 @@ extern "C" {
 #define ORO_SCHED_RT    0 /** LXRT Hard real-time */
 #define ORO_SCHED_OTHER 1 /** LXRT Soft real-time */
 
+#define ORO_WAIT_ABS 0 /** Not supported for the lxrt target */
+#define ORO_WAIT_REL 1 /** Not supported for the lxrt target */
 
 
 

--- a/rtt/os/xenomai/fosi.h
+++ b/rtt/os/xenomai/fosi.h
@@ -119,6 +119,9 @@ extern "C" {
 #define ORO_SCHED_RT    0 /** Hard real-time */
 #define ORO_SCHED_OTHER 1 /** Soft real-time */
 
+#define ORO_WAIT_ABS 0 /** Not supported for the xenomai target */
+#define ORO_WAIT_REL 1 /** Not supported for the xenomai target */
+
 	// hrt is in ticks
 static inline TIME_SPEC ticks2timespec(TICK_TIME hrt)
 {


### PR DESCRIPTION
Fix for #106.

The constants `ORO_WAIT_REL` and `ORO_WAIT_ABS` are not available if RTT is compiled for the Xenomai target.