### PR TITLE
Can't deterministically control execution of components in a unit test that explicit depend on FileDescriptorActivity.

### DIFF
--- a/rtt/extras/FileDescriptorActivity.hpp
+++ b/rtt/extras/FileDescriptorActivity.hpp
@@ -39,6 +39,7 @@
 #ifndef FILEDESCRIPTOR_ACTIVITY_HPP
 #define FILEDESCRIPTOR_ACTIVITY_HPP
 
+#include "FileDescriptorActivityInterface.hpp"
 #include "../Activity.hpp"
 #include <set>
 
@@ -100,7 +101,8 @@ namespace RTT { namespace extras {
      * }
      * </code>
      */
-    class RTT_API FileDescriptorActivity : public Activity
+    class RTT_API FileDescriptorActivity : public extras::FileDescriptorActivityInterface,
+                                           public Activity
     {
         std::set<int> m_watched_fds;
         bool m_running;

--- a/rtt/extras/FileDescriptorActivity.hpp
+++ b/rtt/extras/FileDescriptorActivity.hpp
@@ -190,20 +190,18 @@ namespace RTT { namespace extras {
         virtual bool setPeriod(Seconds period);
 
         /** Sets the file descriptor the activity should be listening to.
-         * @arg close_on_stop { if true, the file descriptor will be closed by the
-         * activity when stop() is called. Otherwise, the file descriptor is
-         * left as-is.}
          *
          * This method is thread-safe, i.e. it can be called from any thread
          *
          * @param fd the file descriptor
-         * @param close_on_stop if true, the FD will be closed automatically when the activity is stopped
          */
         void watch(int fd);
 
         /** Removes a file descriptor from the set of watched FDs
          *
          * This method is thread-safe, i.e. it can be called from any thread
+         *
+         * @param fd the file descriptor
          */
         void unwatch(int fd);
 
@@ -211,6 +209,8 @@ namespace RTT { namespace extras {
         void clearAllWatches();
 
         /** True if this specific FD is being watched by the activity
+         *
+         * @param fd the file descriptor
          */
         bool isWatched(int fd) const;
 
@@ -219,6 +219,8 @@ namespace RTT { namespace extras {
          * This should only be used from within the base::RunnableInterface this
          * activity is driving, i.e. in TaskContext::updateHook() or
          * TaskContext::errorHook().
+         *
+         * @param fd the file descriptor
          */
         bool isUpdated(int fd) const;
 
@@ -244,6 +246,8 @@ namespace RTT { namespace extras {
          * for blocking behaviour (no timeout).
 		 * @pre 0 <= timeout (otherwise an error is logged and \a timeout
 		 * is ignored)
+         *
+         * @param timeout The timeout (milliseconds)
          */
         void setTimeout(int timeout);
 
@@ -251,16 +255,22 @@ namespace RTT { namespace extras {
          * for blocking behaviour (no timeout).
 		 * @pre 0 <= timeout (otherwise an error is logged and \a timeout_us
 		 * is ignored)
+         *
+         * @param timeout The timeout (microseconds)
          */
         void setTimeout_us(int timeout_us);
 
         /** Get the timeout, in milliseconds, for waiting on the IO. Set to 0
          * for blocking behaviour (no timeout).
+         *
+         * @return The timeout (milliseconds)
          */
         int getTimeout() const;
 
         /** Get the timeout, in microseconds, for waiting on the IO. Set to 0
          * for blocking behaviour (no timeout).
+         *
+         * @return The timeout (microseconds)
          */
         int getTimeout_us() const;
 

--- a/rtt/extras/FileDescriptorActivityInterface.hpp
+++ b/rtt/extras/FileDescriptorActivityInterface.hpp
@@ -1,0 +1,177 @@
+/***************************************************************************
+
+ ***************************************************************************
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU General Public                   *
+ *   License as published by the Free Software Foundation;                 *
+ *   version 2 of the License.                                             *
+ *                                                                         *
+ *   As a special exception, you may use this file as part of a free       *
+ *   software library without restriction.  Specifically, if other files   *
+ *   instantiate templates or use macros or inline functions from this     *
+ *   file, or you compile this file and link it with other files to        *
+ *   produce an executable, this file does not by itself cause the         *
+ *   resulting executable to be covered by the GNU General Public          *
+ *   License.  This exception does not however invalidate any other        *
+ *   reasons why the executable file might be covered by the GNU General   *
+ *   Public License.                                                       *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public             *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 59 Temple Place,                                    *
+ *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef FILEDESCRIPTOR_ACTIVITY_INTERFACE_HPP
+#define FILEDESCRIPTOR_ACTIVITY_INTERFACE_HPP
+
+#include "../Activity.hpp"
+#include <set>
+
+namespace RTT { namespace extras {
+
+    /** An activity which is triggered by the availability of data on a set of
+     * file descriptors. step() (and hence the base::RunnableInterface's step()
+     * method) is called when data is available or when an error is encountered
+     * on the file descriptor.
+     *
+     * To use it, one must add the file descriptors to watch in the task's
+     * configureHook()
+     *
+     * <code>
+     *   FileDescriptorActivity* fd_activity =
+     *      dynamic_cast<FileDescriptorActivity*>(getActivity().get());
+     *   if (fd_activity)
+     *   {
+     *      fd_activity->watch(device_fd);
+     *      // optional, set a timeout in milliseconds
+     *      fd_activity->setTimeout(1000);
+     *      // or in microseconds
+     *      fd_activity->setTimeout_us(1000);
+     *   }
+     * </code>
+     *
+     * Then, updateHook() and -- when in ERROR state -- errorHook() will be
+     * called when one of these three events happen:
+     * <ul>
+     *      <li>new data is available on one of the watched FDs
+     *      <li>an error happens on one of the watched FDs
+     *      <li>the timeout is reached
+     * </ul>
+     *
+     * The different cases can be tested in updateHook() as follows:
+     *
+     * <code>
+     * FileDescriptorActivity* fd_activity =
+     *    dynamic_cast<FileDescriptorActivity*>(getActivity().get());
+     * if (fd_activity)
+     * {
+     *   if (fd_activity->hasError())
+     *   {
+     *   }
+     *   else if (fd_activity->hasTimeout())
+     *   {
+     *   }
+     *   else
+     *   {
+     *     // If there is more than one FD, discriminate. Otherwise,
+     *     // we don't need to use isUpdated
+     *     if (fd_activity->isUpdated(device_fd))
+     *     {
+     *     }
+     *     else if (fd_activity->isUpdated(another_fd))
+     *     {
+     *     }
+     *   }
+     * }
+     * </code>
+     */
+    class RTT_API FileDescriptorActivityInterface
+    {
+    public:
+        virtual ~FileDescriptorActivityInterface() {};
+
+        /** Sets the file descriptor the activity should be listening to.
+         * @arg close_on_stop { if true, the file descriptor will be closed by the
+         * activity when stop() is called. Otherwise, the file descriptor is
+         * left as-is.}
+         *
+         * This method is thread-safe, i.e. it can be called from any thread
+         *
+         * @param fd the file descriptor
+         * @param close_on_stop if true, the FD will be closed automatically when the activity is stopped
+         */
+        virtual void watch(int fd) = 0;
+
+        /** Removes a file descriptor from the set of watched FDs
+         *
+         * This method is thread-safe, i.e. it can be called from any thread
+         */
+        virtual void unwatch(int fd) = 0;
+
+        /** Remove all FDs that are currently being watched */
+        virtual void clearAllWatches() = 0;
+
+        /** True if this specific FD is being watched by the activity
+         */
+        virtual bool isWatched(int fd) const = 0;
+
+        /** True if this specific FD has new data.
+         *
+         * This should only be used from within the base::RunnableInterface this
+         * activity is driving, i.e. in TaskContext::updateHook() or
+         * TaskContext::errorHook().
+         */
+        virtual bool isUpdated(int fd) const = 0;
+
+        /** True if the base::RunnableInterface has been triggered because of a
+         * timeout, instead of because of new data is available.
+         *
+         * This should only be used from within the base::RunnableInterface this
+         * activity is driving, i.e. in TaskContext::updateHook() or
+         * TaskContext::errorHook().
+         */
+        virtual bool hasTimeout() const = 0;
+
+        /** True if one of the file descriptors has a problem (for instance it
+         * has been closed)
+         *
+         * This should only be used from within the base::RunnableInterface this
+         * activity is driving, i.e. in TaskContext::updateHook() or
+         * TaskContext::errorHook().
+         */
+        virtual bool hasError() const = 0;
+
+        /** Sets the timeout, in milliseconds, for waiting on the IO. Set to 0
+         * for blocking behaviour (no timeout).
+		 * @pre 0 <= timeout (otherwise an error is logged and \a timeout
+		 * is ignored)
+         */
+        virtual void setTimeout(int timeout) = 0;
+
+        /** Sets the timeout, in microseconds, for waiting on the IO. Set to 0
+         * for blocking behaviour (no timeout).
+		 * @pre 0 <= timeout (otherwise an error is logged and \a timeout_us
+		 * is ignored)
+         */
+        virtual void setTimeout_us(int timeout_us) = 0;
+
+        /** Get the timeout, in milliseconds, for waiting on the IO. Set to 0
+         * for blocking behaviour (no timeout).
+         */
+        virtual int getTimeout() const = 0;
+
+        /** Get the timeout, in microseconds, for waiting on the IO. Set to 0
+         * for blocking behaviour (no timeout).
+         */
+        virtual int getTimeout_us() const = 0;
+    };
+}}
+
+#endif

--- a/rtt/extras/FileDescriptorActivityInterface.hpp
+++ b/rtt/extras/FileDescriptorActivityInterface.hpp
@@ -98,20 +98,18 @@ namespace RTT { namespace extras {
         virtual ~FileDescriptorActivityInterface() {};
 
         /** Sets the file descriptor the activity should be listening to.
-         * @arg close_on_stop { if true, the file descriptor will be closed by the
-         * activity when stop() is called. Otherwise, the file descriptor is
-         * left as-is.}
          *
          * This method is thread-safe, i.e. it can be called from any thread
          *
          * @param fd the file descriptor
-         * @param close_on_stop if true, the FD will be closed automatically when the activity is stopped
          */
         virtual void watch(int fd) = 0;
 
         /** Removes a file descriptor from the set of watched FDs
          *
          * This method is thread-safe, i.e. it can be called from any thread
+         *
+         * @param fd the file descriptor
          */
         virtual void unwatch(int fd) = 0;
 
@@ -119,6 +117,8 @@ namespace RTT { namespace extras {
         virtual void clearAllWatches() = 0;
 
         /** True if this specific FD is being watched by the activity
+         *
+         * @param fd the file descriptor
          */
         virtual bool isWatched(int fd) const = 0;
 
@@ -127,6 +127,8 @@ namespace RTT { namespace extras {
          * This should only be used from within the base::RunnableInterface this
          * activity is driving, i.e. in TaskContext::updateHook() or
          * TaskContext::errorHook().
+         *
+         * @param fd the file descriptor
          */
         virtual bool isUpdated(int fd) const = 0;
 
@@ -152,6 +154,8 @@ namespace RTT { namespace extras {
          * for blocking behaviour (no timeout).
 		 * @pre 0 <= timeout (otherwise an error is logged and \a timeout
 		 * is ignored)
+         *
+         * @param timeout The timeout (milliseconds)
          */
         virtual void setTimeout(int timeout) = 0;
 
@@ -159,16 +163,22 @@ namespace RTT { namespace extras {
          * for blocking behaviour (no timeout).
 		 * @pre 0 <= timeout (otherwise an error is logged and \a timeout_us
 		 * is ignored)
+         *
+         * @param timeout The timeout (microseconds)
          */
         virtual void setTimeout_us(int timeout_us) = 0;
 
         /** Get the timeout, in milliseconds, for waiting on the IO. Set to 0
          * for blocking behaviour (no timeout).
+         *
+         * @return The timeout (milliseconds)
          */
         virtual int getTimeout() const = 0;
 
         /** Get the timeout, in microseconds, for waiting on the IO. Set to 0
          * for blocking behaviour (no timeout).
+         *
+         * @return The timeout (microseconds)
          */
         virtual int getTimeout_us() const = 0;
     };

--- a/rtt/extras/FileDescriptorSimulationActivity.cpp
+++ b/rtt/extras/FileDescriptorSimulationActivity.cpp
@@ -39,8 +39,7 @@ FileDescriptorSimulationActivity::FileDescriptorSimulationActivity(int priority,
                                                                    const std::string& name) :
     base::ActivityInterface(_r),
     period(0),
-    running(false),
-    lastReason(base::RunnableInterface::TimeOut)
+    running(false)
 {
     // prevent compiler warnings
     (void)priority;
@@ -53,8 +52,7 @@ FileDescriptorSimulationActivity::FileDescriptorSimulationActivity(int scheduler
                                                                    const std::string& name) :
     base::ActivityInterface(_r),
     period(0),
-    running(false),
-    lastReason(base::RunnableInterface::TimeOut)
+    running(false)
 {
     // prevent compiler warnings
     (void)priority;
@@ -68,8 +66,7 @@ FileDescriptorSimulationActivity::FileDescriptorSimulationActivity(int scheduler
                                                                    const std::string& name) :
     base::ActivityInterface(_r),
     period(_p >= 0.0 ? _p : 0.0),
-    running(false),
-    lastReason(base::RunnableInterface::TimeOut)
+    running(false)
 {
     // prevent compiler warnings
     (void)scheduler;
@@ -85,8 +82,7 @@ FileDescriptorSimulationActivity::FileDescriptorSimulationActivity(int scheduler
                                                                    const std::string& name) :
     base::ActivityInterface(_r),
     period(_p >= 0.0 ? _p : 0.0),
-    running(false),
-    lastReason(base::RunnableInterface::TimeOut)
+    running(false)
 {
     // prevent compiler warnings
     (void)scheduler;
@@ -126,12 +122,12 @@ bool FileDescriptorSimulationActivity::isWatched(int fd) const
 
 bool FileDescriptorSimulationActivity::isUpdated(int fd) const
 {
-    return (base::RunnableInterface::IOReady == lastReason);
+    return false;
 }
 
 bool FileDescriptorSimulationActivity::hasTimeout() const
 {
-    return (base::RunnableInterface::TimeOut == lastReason);
+    return false;
 }
 
 bool FileDescriptorSimulationActivity::hasError() const
@@ -232,20 +228,7 @@ bool FileDescriptorSimulationActivity::trigger()
     return true;
 }
 
-bool FileDescriptorSimulationActivity::timeout()
-{
-    return true;
-}
-
 os::ThreadInterface* FileDescriptorSimulationActivity::thread()
 {
     return os::MainThread::Instance();
-}
-
-void FileDescriptorSimulationActivity::work(base::RunnableInterface::WorkReason reason)
-{
-    if (0 != runner) {
-        runner->work(reason);
-        lastReason = reason;
-    }
 }

--- a/rtt/extras/FileDescriptorSimulationActivity.cpp
+++ b/rtt/extras/FileDescriptorSimulationActivity.cpp
@@ -1,0 +1,251 @@
+/***************************************************************************
+
+ ***************************************************************************
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU General Public                   *
+ *   License as published by the Free Software Foundation;                 *
+ *   version 2 of the License.                                             *
+ *                                                                         *
+ *   As a special exception, you may use this file as part of a free       *
+ *   software library without restriction.  Specifically, if other files   *
+ *   instantiate templates or use macros or inline functions from this     *
+ *   file, or you compile this file and link it with other files to        *
+ *   produce an executable, this file does not by itself cause the         *
+ *   resulting executable to be covered by the GNU General Public          *
+ *   License.  This exception does not however invalidate any other        *
+ *   reasons why the executable file might be covered by the GNU General   *
+ *   Public License.                                                       *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public             *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 59 Temple Place,                                    *
+ *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "FileDescriptorSimulationActivity.hpp"
+#include "os/MainThread.hpp"
+
+using namespace RTT;
+using namespace extras;
+
+FileDescriptorSimulationActivity::FileDescriptorSimulationActivity(int priority,
+                                                                   base::RunnableInterface* _r,
+                                                                   const std::string& name) :
+    base::ActivityInterface(_r),
+    period(0),
+    running(false),
+    lastReason(base::RunnableInterface::TimeOut)
+{
+    // prevent compiler warnings
+    (void)priority;
+    (void)name;
+}
+
+FileDescriptorSimulationActivity::FileDescriptorSimulationActivity(int scheduler,
+                                                                   int priority,
+                                                                   base::RunnableInterface* _r,
+                                                                   const std::string& name) :
+    base::ActivityInterface(_r),
+    period(0),
+    running(false),
+    lastReason(base::RunnableInterface::TimeOut)
+{
+    // prevent compiler warnings
+    (void)priority;
+    (void)name;
+}
+
+FileDescriptorSimulationActivity::FileDescriptorSimulationActivity(int scheduler,
+                                                                   int priority,
+                                                                   Seconds _p,
+                                                                   base::RunnableInterface* _r,
+                                                                   const std::string& name) :
+    base::ActivityInterface(_r),
+    period(_p >= 0.0 ? _p : 0.0),
+    running(false),
+    lastReason(base::RunnableInterface::TimeOut)
+{
+    // prevent compiler warnings
+    (void)scheduler;
+    (void)priority;
+    (void)name;
+}
+
+FileDescriptorSimulationActivity::FileDescriptorSimulationActivity(int scheduler,
+                                                                   int priority,
+                                                                   Seconds _p,
+                                                                   unsigned cpu_affinity,
+                                                                   base::RunnableInterface* _r,
+                                                                   const std::string& name) :
+    base::ActivityInterface(_r),
+    period(_p >= 0.0 ? _p : 0.0),
+    running(false),
+    lastReason(base::RunnableInterface::TimeOut)
+{
+    // prevent compiler warnings
+    (void)scheduler;
+    (void)priority;
+    (void)cpu_affinity;
+    (void)name;
+}
+
+FileDescriptorSimulationActivity::~FileDescriptorSimulationActivity()
+{
+    stop();
+}
+
+/***************************************************************************
+ * FDAInterface functions
+ ***************************************************************************/
+
+void FileDescriptorSimulationActivity::watch(int fd)
+{
+    (void)fd;           // prevent compiler warning
+}
+
+void FileDescriptorSimulationActivity::unwatch(int fd)
+{
+    (void)fd;           // prevent compiler warning
+}
+
+void FileDescriptorSimulationActivity::clearAllWatches()
+{
+}
+
+bool FileDescriptorSimulationActivity::isWatched(int fd) const
+{
+    (void)fd;           // prevent compiler warning
+    return false;
+}
+
+bool FileDescriptorSimulationActivity::isUpdated(int fd) const
+{
+    return (base::RunnableInterface::IOReady == lastReason);
+}
+
+bool FileDescriptorSimulationActivity::hasTimeout() const
+{
+    return (base::RunnableInterface::TimeOut == lastReason);
+}
+
+bool FileDescriptorSimulationActivity::hasError() const
+{
+    return false;
+}
+
+void FileDescriptorSimulationActivity::setTimeout(int timeout)
+{
+    (void)timeout;       // prevent compiler warning
+}
+
+void FileDescriptorSimulationActivity::setTimeout_us(int timeout_us)
+{
+    (void)timeout_us;    // prevent compiler warning
+}
+
+int FileDescriptorSimulationActivity::getTimeout() const
+{
+    return 0;
+}
+
+int FileDescriptorSimulationActivity::getTimeout_us() const
+{
+    return 0;
+}
+
+/***************************************************************************
+ * ActivityInterface functions
+ ***************************************************************************/
+
+
+bool FileDescriptorSimulationActivity::start()
+{
+    if (running) {
+        return false;
+    }
+    running = true;
+    return true;
+}
+
+bool FileDescriptorSimulationActivity::stop()
+{
+    if (!running) {
+        return false;
+    }
+    running = false;
+    return true;
+}
+
+bool FileDescriptorSimulationActivity::isRunning() const
+{
+    return running;
+}
+
+bool FileDescriptorSimulationActivity::isActive() const
+{
+    return running;
+}
+
+Seconds FileDescriptorSimulationActivity::getPeriod() const
+{
+    return period;
+}
+
+bool FileDescriptorSimulationActivity::isPeriodic() const
+{
+    return (0 != period);
+}
+
+bool FileDescriptorSimulationActivity::setPeriod(Seconds s)
+{
+	if (s < 0) {
+        return false;
+    }
+    period = s;
+    return true;
+}
+
+unsigned FileDescriptorSimulationActivity::getCpuAffinity() const
+{
+    return 0;
+}
+
+bool FileDescriptorSimulationActivity::setCpuAffinity(unsigned cpu)
+{
+    (void)cpu;      // prevent compiler warning
+    return true;
+}
+
+bool FileDescriptorSimulationActivity::execute()
+{
+    return true;
+}
+
+bool FileDescriptorSimulationActivity::trigger()
+{
+    return true;
+}
+
+bool FileDescriptorSimulationActivity::timeout()
+{
+    return true;
+}
+
+os::ThreadInterface* FileDescriptorSimulationActivity::thread()
+{
+    return os::MainThread::Instance();
+}
+
+void FileDescriptorSimulationActivity::work(base::RunnableInterface::WorkReason reason)
+{
+    if (0 != runner) {
+        runner->work(reason);
+        lastReason = reason;
+    }
+}

--- a/rtt/extras/FileDescriptorSimulationActivity.hpp
+++ b/rtt/extras/FileDescriptorSimulationActivity.hpp
@@ -1,0 +1,176 @@
+/***************************************************************************
+
+ ***************************************************************************
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU General Public                   *
+ *   License as published by the Free Software Foundation;                 *
+ *   version 2 of the License.                                             *
+ *                                                                         *
+ *   As a special exception, you may use this file as part of a free       *
+ *   software library without restriction.  Specifically, if other files   *
+ *   instantiate templates or use macros or inline functions from this     *
+ *   file, or you compile this file and link it with other files to        *
+ *   produce an executable, this file does not by itself cause the         *
+ *   resulting executable to be covered by the GNU General Public          *
+ *   License.  This exception does not however invalidate any other        *
+ *   reasons why the executable file might be covered by the GNU General   *
+ *   Public License.                                                       *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public             *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 59 Temple Place,                                    *
+ *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef FILEDESCRIPTORSIMULATION_ACTIVITY_HPP
+#define FILEDESCRIPTORSIMULATION_ACTIVITY_HPP
+
+#include "../base/ActivityInterface.hpp"
+#include "../base/RunnableInterface.hpp"
+#include "../extras/FileDescriptorActivityInterface.hpp"
+
+namespace RTT { namespace extras {
+
+    /** Simulate a FileDescriptorActivity (FDA)
+        Primarily this is designed for unit tests that are testing components
+        that require a FDA. This implementation allows deterministic cycling of
+        such a component.
+
+        The intended use case is a component that is woken up by its FDA and
+        then the component determines why it was woken up by calling
+        \a isUpdated(), \a hasTimeout(), and \a hasError(). The unit test code
+        should call \a work() with an appropriate reason, which will end up
+        being returned to the component through the above calls. So a unit test
+        call of \a work(IOReady) will result in \a isUpdated() returning true to
+        the component, and similarly for \a work(TimeOut) and \a hasTimeout().
+        Currently \a hasError() always returns false - there is no way to
+        simulate this with the current implementation.
+     
+        \note Component OwnThread operations are executed by the MainThread,
+        which is correct for a unit test case that is directly executing.
+     */
+    class RTT_API FileDescriptorSimulationActivity : public extras::FileDescriptorActivityInterface,
+                                                     public base::ActivityInterface
+    {
+    public:
+        // priority and name are ignored
+        FileDescriptorSimulationActivity(int priority,
+                                         base::RunnableInterface* _r = 0,
+                                         const std::string& name ="FileDescriptorSimulationActivity" );
+
+        // scheduler, priority, and name, are ignored
+        FileDescriptorSimulationActivity(int scheduler,
+                                         int priority,
+                                         base::RunnableInterface* _r = 0,
+                                         const std::string& name ="FileDescriptorSimulationActivity" );
+
+        // scheduler, priority, and name, are ignored
+        FileDescriptorSimulationActivity(int scheduler,
+                                         int priority,
+                                         Seconds period,
+                                         base::RunnableInterface* _r = 0,
+                                         const std::string& name ="FileDescriptorSimulationActivity" );
+
+        // scheduler, priority, cpu_affinity, and name, are ignored
+        FileDescriptorSimulationActivity(int scheduler,
+                                         int priority,
+                                         Seconds period,
+                                         unsigned cpu_affinity,
+                                         base::RunnableInterface* _r = 0,
+                                         const std::string& name ="FileDescriptorSimulationActivity" );
+
+        /**
+         * Cleanup and notify the base::RunnableInterface that we are gone.
+         */
+        virtual ~FileDescriptorSimulationActivity();
+
+        /**********************************************************************
+         * FDAInterface functions
+         **********************************************************************/
+
+        /// Does nothing
+        void watch(int fd);
+
+        /// Does nothing
+        void unwatch(int fd);
+
+        /// Does nothing
+        void clearAllWatches();
+
+        /// Returns false always
+        bool isWatched(int fd) const;
+
+        /// Return (IOReady == lastReason)
+        /// \sa work()
+        bool isUpdated(int fd) const;
+
+        /// Return (Timeout == lastReason)
+        /// \sa work()
+        bool hasTimeout() const;
+
+        bool hasError() const;
+
+        /// Does nothing
+        void setTimeout(int timeout);
+
+        /// Does nothing
+        void setTimeout_us(int timeout_us);
+
+        /// Return 0
+        int getTimeout() const;
+
+        /// Returns 0
+        int getTimeout_us() const;
+
+        /**********************************************************************
+         * ActivityInterface functions
+         **********************************************************************/
+
+        /// Returns true
+        virtual bool start();
+        /// Returns true
+        virtual bool stop();
+        /// Returns true
+        virtual bool isRunning() const;
+        /// Returns true
+        virtual bool isActive() const;
+        /// Returns \a period
+        virtual Seconds getPeriod() const;
+        /// Returns true iff (0 != period)
+        virtual bool isPeriodic() const;
+        /// If s>0 then returns true and \a period == \a s, otherwise returns false
+        virtual bool setPeriod(Seconds s) ;
+        /// Returns 0
+        virtual unsigned getCpuAffinity() const;
+        /// Returns true
+        virtual bool setCpuAffinity(unsigned cpu) ;
+        /// Returns true
+        virtual bool execute();
+        /// Returns true
+        virtual bool trigger();
+        /// Returns true
+        virtual bool timeout() ;
+        /// Returns os::MainThread::Instance()
+        virtual os::ThreadInterface* thread();
+
+        /// If have a runner then pass the reason to the runner and store in lastReason
+        virtual void work(base::RunnableInterface::WorkReason reason);
+    protected:
+        /// Fake period - some classes require period!=0.
+        /// Is initialized to 0
+        Seconds                                 period;
+        //// Must model running - simply is true after start() and before stop()
+        bool                                    running;
+        /// Value passed to last work() call
+        /// Used to determine the return from isUpdated() and hasTimeout()
+        base::RunnableInterface::WorkReason     lastReason;
+    };
+}}
+
+#endif

--- a/rtt/extras/FileDescriptorSimulationActivity.hpp
+++ b/rtt/extras/FileDescriptorSimulationActivity.hpp
@@ -106,11 +106,11 @@ namespace RTT { namespace extras {
         /// Returns false always
         bool isWatched(int fd) const;
 
-        /// Return (IOReady == lastReason)
+        /// Return false
         /// \sa work()
         bool isUpdated(int fd) const;
 
-        /// Return (Timeout == lastReason)
+        /// Return false
         /// \sa work()
         bool hasTimeout() const;
 
@@ -154,22 +154,15 @@ namespace RTT { namespace extras {
         virtual bool execute();
         /// Returns true
         virtual bool trigger();
-        /// Returns true
-        virtual bool timeout() ;
         /// Returns os::MainThread::Instance()
         virtual os::ThreadInterface* thread();
 
-        /// If have a runner then pass the reason to the runner and store in lastReason
-        virtual void work(base::RunnableInterface::WorkReason reason);
     protected:
         /// Fake period - some classes require period!=0.
         /// Is initialized to 0
         Seconds                                 period;
         //// Must model running - simply is true after start() and before stop()
         bool                                    running;
-        /// Value passed to last work() call
-        /// Used to determine the return from isUpdated() and hasTimeout()
-        base::RunnableInterface::WorkReason     lastReason;
     };
 }}
 


### PR DESCRIPTION
Any component using an FDA is explicitly coupled to the FDA activity type (i.e. it can't use Activity) as the component has to know why it was woken up, which means querying the activity object directly (for example, being woken up by a signal causes the component to process data, but being woken by a timeout causes the component to take some safety action). Because the FDA has to be queried, this creates a run-time type dependency of the component on its Activity (i.e. it *requires* an FDA as its activity as it needs to query the FDA interface - these functions (e.g. hasTimeout()) are not present in the base Activity class). Hence the component can only be instantiated with an FDA - it won't accept any other Activity type.

Our unit test cases do cycle-by-cycle checks of such component's behavior, and so they need to be able to deterministically cycle the component. But the component-under-test is explicitly coupled to, and requires an associated instance of, an FDA activity at runtime. And the FDA object itself runs a thread which is woken up by time outs or activity on its underlying file descriptor (FD) object. So for the unit test to cycle the component-under-test, it has to instantiate an FDA and associate that with the component (due to the coupling requirement), and then write to the underlying FD object *and* put the main thread (i.e. the unit test executable) to sleep to allow the FDA to pop on the CPU and wake up due to the write to the FD object. There's a very obvious race condition here - depending on how loaded the CPU(s) are, the amount of time that the main thread has to sleep to let the FDA run is non-deterministic, to say nothing of any timeout set on the FDA.

DISCARDED SOLUTIONS

You can't just swap out an FDA for something else - it must have the same interface.

You can't decouple the component-under-test from the FDA behavior (and hence use a different activity in the test case), as the component-under-test *must* know why it was woken up to be able to decide what to do.

You can't derive a new activity from FDA and instantiate the derived class, as the dynamic_cast used inside the component-under-test component will quietly provide you with the base FDA instead of the derived FDA (AFAICT by reading the C++ spec, though Peter disagrees).

You can't modify the signal pipe reading side of things to attempt determinism there, as you are still limited by the "background" thread that the FDA is running and the associated non-determinism there.

You can't use some combination of step() or trigger() within the existing FDA implementation, as you still end up with the background thread non-determinism issue, to say nothing of the timeout being involved.

We don't want to pollute our components-under-test to have them run with a FDA for hardware, and some other Activity type for unit tests. This also would prevent testing behavioral reactions to the FDA (i.e. does the component react correctly to a timeout).

PROPOSED SOLUTION

Ideally you want a method to wake the component-under-test up via a direct call from the unit test, and for the unit test to be able to explicitly indicate why the component was woken up (eg. timeout vs signal). I propose providing a new "interface" class within RTT for the FDA (e.g. RTT::FDAI), and use the existing FDA implementation as a derived class of that the FDA interface to implement the current semantics (e.g. RTT::FDA). Then you derive a new "simulated" FDA implementation (e.g. RTT::FDASimulated or similar) from RTT::FDAI that supports the needs of unit tests, and which doesn't use an actual background thread (it'd look a lot like how unit tests use a SlaveActivity, but without the master/slave relationship). Now the unit test instantiates the FDA-simulated class and associates that with the component-under-test, and that simulated FDA class provides deterministic "wake up" by cycle (and also wakeup due to data vs timeout).
