### PR TITLE
Slight optimization of reader channel selection for input ports

### DIFF
--- a/rtt/internal/ConnectionManager.hpp
+++ b/rtt/internal/ConnectionManager.hpp
@@ -167,9 +167,11 @@ namespace RTT
                         return std::make_pair(true, channel);
 
                 std::list<ChannelDescriptor>::iterator result;
-                for (result = connections.begin(); result != connections.end(); ++result)
+                for (result = connections.begin(); result != connections.end(); ++result) {
+                    if (result->get<1>() == cur_channel.get<1>()) continue;
                     if ( pred(false, *result) == true)
                         return std::make_pair(true, *result);
+                }
                 return std::make_pair(false, ChannelDescriptor());
             }
 


### PR DESCRIPTION
This is a slight optimization of reader channel selection in class ConnectionManager, avoiding to read from the current channel twice.

Reading from a channel might be expensive, e.g. for remote connections. The reader channel selection always tries to read from the current channel (the one with the last successful read) first. There is no need to read that channel again while iterating over all channels for the case that first read did not return new data.

If have not tested this very carefully yet, but at least all the tests succeed. I do not see any use case where this patch would break things. On the other hand it is certainly an improvement when reading from input ports connected to remote output ports with a pull policy.