### PR TITLE
tests: fixed typos in corba and mqueue ipc tests that caused segfaults

### DIFF
--- a/tests/corba_ipc_server.cpp
+++ b/tests/corba_ipc_server.cpp
@@ -99,7 +99,7 @@ public:
 
 int ORO_main(int argc, char** argv)
 {
-#ifdef OR_RT_MALLOC
+#ifdef OS_RT_MALLOC
 	void*   rtMem=0;
 	size_t  freeMem=0;
 

--- a/tests/corba_mqueue_ipc_server.cpp
+++ b/tests/corba_mqueue_ipc_server.cpp
@@ -62,7 +62,7 @@ public:
 
 int ORO_main(int argc, char** argv)
 {
-#ifdef OR_RT_MALLOC
+#ifdef OS_RT_MALLOC
 	void*   rtMem=0;
 	size_t  freeMem=0;
 


### PR DESCRIPTION
This is a regression from 180e6905c43cb23a76f588783179e14ff5071caf that causes the corba-ipc-server and corba-mqueue-ipc-server processes to segfault if real-time memory allocation is enabled (the default if TLSF is available).