### PR TITLE
Added version comparison macro

### DIFF
--- a/rtt/rtt-config.h.in
+++ b/rtt/rtt-config.h.in
@@ -6,6 +6,11 @@
 #define RTT_VERSION_MINOR @RTT_VERSION_MINOR@
 #define RTT_VERSION_PATCH @RTT_VERSION_PATCH@
 
+#define RTT_VERSION_GTE(major,minor,patch) \
+    ((RTT_VERSION_MAJOR > major) || (RTT_VERSION_MAJOR == major && \
+     (RTT_VERSION_MINOR > minor) || (RTT_VERSION_MINOR == minor && \
+     (RTT_VERSION_PATCH >= patch))))
+
 #cmakedefine ORO_DISABLE_PORT_DATA_SCRIPTING
 
 // if not defined, show an error


### PR DESCRIPTION
This pull request is part of a bigger effort to add support for new connection semantics to RTT (see #114).

The version comparison macro allows dependees to add sections that are compiled conditionally based on the RTT version used. Unfortunately this cannot be avoided in same cases, primarily for custom transport implementations like [rtt_roscomm](https://github.com/orocos/rtt_ros_integration/tree/HEAD/rtt_roscomm).

As the updated dataflow implementation is targeted for an RTT 2.9 release and the intermediate version number has already been increased to 2.8.99, the typical use case of this macro would be like:

```cpp
#include <rtt/rtt-config.h>

#ifdef RTT_VERSION_GTE(2,8,99)
  // code that requires the new dataflow implementation
#else
  // backwards compatible code for older versions of RTT
#endif
```