### PR TITLE
logger: use const reference for templated streaming operator

### DIFF
--- a/rtt/Logger.hpp
+++ b/rtt/Logger.hpp
@@ -253,7 +253,7 @@ namespace RTT
          * end with std::endl to get the log's output in your file or display.
          */
         template< class T>
-        Logger& operator<<( T t );
+        Logger& operator<<( const T &t );
 
         /**
          * Set the loglevel of the incomming messages.

--- a/rtt/Logger.inl
+++ b/rtt/Logger.inl
@@ -12,7 +12,7 @@
 namespace RTT
 {
     template< class T>
-    Logger& Logger::operator<<( T t ) {
+    Logger& Logger::operator<<( const T &t ) {
 #ifndef OROBLD_DISABLE_LOGGING
         if ( !mayLog() )
             return *this;


### PR DESCRIPTION
This pull request is part of a bigger effort to add support for new connection semantics to RTT (see #114).

There is not much to be said about this one. The const reference variant is more efficient when the RTT::Logger is used for instances of complex data types that implement their own streaming operators.
