### PR TITLE
Fixed FlowStatus race condition in ChannelDataElement and fixed BufferLockFree implementation for the circular buffer case

### DIFF
--- a/rtt/base/BufferBase.hpp
+++ b/rtt/base/BufferBase.hpp
@@ -40,6 +40,7 @@
 
 #include <boost/shared_ptr.hpp>
 #include "../rtt-config.h"
+#include "../rtt-fwd.hpp"
 
 namespace RTT
 { namespace base {
@@ -53,8 +54,27 @@ namespace RTT
     {
     public:
         typedef int size_type;
-
         typedef boost::shared_ptr< BufferBase > shared_ptr;
+
+        class Options {
+        private:
+            bool circular_;
+            int max_threads_;
+            bool multiple_writers_;
+            bool multiple_readers_;
+        public:
+            Options();
+            Options(bool circular); // implicit conversion from bool for backwards-compatibility only
+            Options(const ConnPolicy &policy);
+            bool circular() const { return circular_; }
+            Options &circular(bool value) { circular_ = value; return *this; }
+            unsigned int max_threads() const { return max_threads_; }
+            Options &max_threads(unsigned int value) { max_threads_ = value; return *this; }
+            bool multiple_writers() const { return multiple_writers_; }
+            Options &multiple_writers(bool value) { multiple_writers_ = value; return *this; }
+            bool multiple_readers() const { return multiple_readers_; }
+            Options &multiple_readers(bool value) { multiple_readers_ = value; return *this; }
+        };
 
         virtual ~BufferBase();
 

--- a/rtt/base/BufferInterface.hpp
+++ b/rtt/base/BufferInterface.hpp
@@ -134,12 +134,12 @@ namespace RTT
          * @nts
          * @nrt
          */
-        virtual bool data_sample( const T& sample, bool reset = true ) = 0;
+        virtual bool data_sample( param_t sample, bool reset = true ) = 0;
 
         /**
          * Reads back a data sample.
          */
-        virtual T data_sample() const = 0;
+        virtual value_t data_sample() const = 0;
     };
 }}
 

--- a/rtt/base/BufferInterface.hpp
+++ b/rtt/base/BufferInterface.hpp
@@ -39,6 +39,7 @@
 #define ORO_CORELIB_BUFFERINTERFACE_HPP
 
 #include "BufferBase.hpp"
+#include "../FlowStatus.hpp"
 #include <boost/shared_ptr.hpp>
 #include <boost/call_traits.hpp>
 #include <vector>
@@ -73,7 +74,7 @@ namespace RTT
          * @cts
          * @rt
          */
-        virtual bool Pop( reference_t item) = 0;
+        virtual FlowStatus Pop( reference_t item) = 0;
 
         /**
          * Read the whole buffer.
@@ -85,23 +86,23 @@ namespace RTT
          */
         virtual size_type Pop( std::vector<value_t>& items ) = 0;
 
-	/**
-	 * Returns a pointer to the first element in the buffer.
-	 * The pointer is only garanteed to stay valid until 
-	 * the next pop operation. 
-	 * 
-	 * Note the pointer needs the be released by calling Release
-	 * on the buffer.
-	 * 
-	 * @return a pointer to a sample or Zero if buffer is empty
-	 **/
-	virtual value_t* PopWithoutRelease() = 0;
+        /**
+         * Returns a pointer to the first element in the buffer.
+         * The pointer is only garanteed to stay valid until
+         * the next pop operation.
+         *
+         * Note the pointer needs the be released by calling Release
+         * on the buffer.
+         *
+         * @return a pointer to a sample or Zero if buffer is empty
+         **/
+        virtual value_t* PopWithoutRelease() = 0;
 
-	/**
-	 *  Releases the pointer
-	 * @param item pointer aquired using PopWithoutRelease()
-	 **/
-	virtual void Release(value_t *item) = 0;
+        /**
+         * Releases the pointer
+         * @param item pointer aquired using PopWithoutRelease()
+         **/
+        virtual void Release(value_t *item) = 0;
 	
         /**
          * Write a single value to the buffer.
@@ -125,12 +126,15 @@ namespace RTT
          * Initializes this buffer with a data sample, such that for
          * dynamical allocated types T, the buffer can reserve place
          * to hold these elements.
+         * @param sample the data sample
+         * @param reset enforce reinitialization even if this operation clears all data.
+         * @return true if the buffer was successfully (re)initialized.
          * @post Calling this function causes all data in the buffer
          * to be lost and the size being reset to zero.
          * @nts
          * @nrt
          */
-        virtual void data_sample( const T& sample ) = 0;
+        virtual bool data_sample( const T& sample, bool reset = true ) = 0;
 
         /**
          * Reads back a data sample.

--- a/rtt/base/BufferLockFree.hpp
+++ b/rtt/base/BufferLockFree.hpp
@@ -83,7 +83,7 @@ namespace RTT
         const unsigned int MAX_THREADS;
 
     private:
-        typedef T Item;
+        typedef value_t Item;
         const bool mcircular;
         bool initialized;
 
@@ -113,7 +113,7 @@ namespace RTT
          * @param bufsize the capacity of the buffer.
          * @param initial_value A data sample with which each preallocated data element is initialized.
          */
-        BufferLockFree( unsigned int bufsize, const T& initial_value, const Options &options = Options() )
+        BufferLockFree( unsigned int bufsize, param_t initial_value, const Options &options = Options() )
             : MAX_THREADS(options.max_threads())
             , mcircular(options.circular()), initialized(false)
             , bufs((!options.circular() && !options.multiple_readers()) ?
@@ -133,7 +133,7 @@ namespace RTT
             delete bufs;
         }
 
-        virtual bool data_sample( const T& sample, bool reset = true )
+        virtual bool data_sample( param_t sample, bool reset = true )
         {
             if (!initialized || reset) {
                 mpool->data_sample(sample);
@@ -145,9 +145,9 @@ namespace RTT
 
         }
 
-        virtual T data_sample() const
+        virtual value_t data_sample() const
         {
-            T result = T();
+            value_t result = value_t();
             Item* mitem = mpool->allocate();
             if (mitem != 0) {
                 result = *mitem;
@@ -243,12 +243,12 @@ namespace RTT
             return true;
         }
 
-        size_type Push(const std::vector<T>& items)
+        size_type Push(const std::vector<value_t>& items)
         {
             // @todo Make this function more efficient as in BufferLocked.
             int towrite  = items.size();
             size_type written = 0;
-            typename std::vector<T>::const_iterator it;
+            typename std::vector<value_t>::const_iterator it;
             for(  it = items.begin(); it != items.end(); ++it) {
                 if ( this->Push( *it ) == false ) {
                     break; // will only happen in non-circular case !
@@ -271,7 +271,7 @@ namespace RTT
             return NewData;
         }
 
-        size_type Pop(std::vector<T>& items )
+        size_type Pop(std::vector<value_t>& items )
         {
             Item* ipop;
             items.clear();

--- a/rtt/base/BufferLockFree.hpp
+++ b/rtt/base/BufferLockFree.hpp
@@ -69,7 +69,7 @@ namespace RTT
         : public BufferInterface<T>
     {
     public:
-        using typename BufferBase::Options;
+        typedef typename BufferBase::Options Options;
         typedef typename BufferInterface<T>::reference_t reference_t;
         typedef typename BufferInterface<T>::param_t param_t;
         typedef typename BufferInterface<T>::size_type size_type;

--- a/rtt/base/BufferLockFree.hpp
+++ b/rtt/base/BufferLockFree.hpp
@@ -39,9 +39,9 @@
 #define ORO_BUFFER_LOCK_FREE_HPP
 
 #include "../os/oro_arch.h"
-#include "../os/CAS.hpp"
 #include "BufferInterface.hpp"
 #include "../internal/AtomicMWSRQueue.hpp"
+#include "../internal/AtomicMWMRQueue.hpp"
 #include "../internal/TsPool.hpp"
 #include <vector>
 
@@ -53,60 +53,99 @@ namespace RTT
 { namespace base {
 
 
-    using os::CAS;
-
     /**
      * A Lock-free buffer implementation to read and write
      * data of type \a T in a FIFO way.
      * No memory allocation is done during read or write.
-     * One thread may read and any number of threads may write this buffer.
+     * One thread may read this buffer, unless the multiple_readers flag
+     * in the \ref base::BufferBase::Options struct is set.
+     * Any number of threads may write this buffer.
      * @param T The value type to be stored in the Buffer.
      * Example : BufferLockFree<A> is a buffer which holds values of type A.
      * @ingroup PortBuffers
      */
-    template< class T>
+    template<class T>
     class BufferLockFree
         : public BufferInterface<T>
     {
     public:
+        using typename BufferBase::Options;
         typedef typename BufferInterface<T>::reference_t reference_t;
         typedef typename BufferInterface<T>::param_t param_t;
         typedef typename BufferInterface<T>::size_type size_type;
         typedef T value_t;
+
+        /**
+         * @brief The maximum number of threads.
+         */
+        const unsigned int MAX_THREADS;
+
     private:
         typedef T Item;
-        internal::AtomicMWSRQueue<Item*> bufs;
-        // is mutable because of reference counting.
-        mutable internal::TsPool<Item> mpool;
         const bool mcircular;
+        bool initialized;
+
+        internal::AtomicQueue<Item*> *const bufs;
+        internal::TsPool<Item> *const mpool;
+
     public:
         /**
-         * Create a lock-free buffer wich can store \a bufsize elements.
+         * Create an uninitialized lock-free buffer which can store \a bufsize elements.
          * @param bufsize the capacity of the buffer.
 '         */
-        BufferLockFree( unsigned int bufsize, const T& initial_value = T(), bool circular = false)
-            : bufs( bufsize ), mpool(bufsize + 1), mcircular(circular)
+        BufferLockFree( unsigned int bufsize, const Options &options = Options() )
+            : MAX_THREADS(options.max_threads())
+            , mcircular(options.circular()), initialized(false)
+            , bufs((!options.circular() && !options.multiple_readers()) ?
+                       static_cast<internal::AtomicQueue<Item*> *>(new internal::AtomicMWSRQueue<Item*>(bufsize)) :
+                       static_cast<internal::AtomicQueue<Item*> *>(new internal::AtomicMWMRQueue<Item*>(bufsize)))
+            , mpool(new internal::TsPool<Item>(bufsize + options.max_threads()))
         {
-            mpool.data_sample( initial_value );
+        }
+
+        /**
+         * Create a lock-free buffer which can store \a bufsize elements.
+         * @param bufsize the capacity of the buffer.
+         * @param initial_value A data sample with which each preallocated data element is initialized.
+         */
+        BufferLockFree( unsigned int bufsize, const T& initial_value, const Options &options = Options() )
+            : MAX_THREADS(options.max_threads())
+            , mcircular(options.circular()), initialized(false)
+            , bufs((!options.circular() && !options.multiple_readers()) ?
+                       static_cast<internal::AtomicQueue<Item*> *>(new internal::AtomicMWSRQueue<Item*>(bufsize)) :
+                       static_cast<internal::AtomicQueue<Item*> *>(new internal::AtomicMWMRQueue<Item*>(bufsize)))
+            , mpool(new internal::TsPool<Item>(bufsize + options.max_threads()))
+        {
+            data_sample( initial_value );
         }
 
         ~BufferLockFree() {
             // free all items still in the buffer.
             clear();
+
+            delete mpool;
+            delete bufs;
         }
 
-        virtual void data_sample( const T& sample )
+        virtual bool data_sample( const T& sample, bool reset = true )
         {
-            mpool.data_sample(sample);
+            if (!initialized || reset) {
+                mpool->data_sample(sample);
+                initialized = true;
+                return true;
+            } else {
+                return initialized;
+            }
+
         }
 
         virtual T data_sample() const
         {
             T result = T();
-            Item* mitem = mpool.allocate();
+            Item* mitem = mpool->allocate();
             if (mitem != 0) {
                 result = *mitem;
-                mpool.deallocate( mitem );
+                mpool->deallocate( mitem );
             }
             return result;
         }
@@ -114,44 +153,44 @@ namespace RTT
 
         size_type capacity() const
         {
-            return bufs.capacity();
+            return bufs->capacity();
         }
 
         size_type size() const
         {
-            return bufs.size();
+            return bufs->size();
         }
 
         bool empty() const
         {
-            return bufs.isEmpty();
+            return bufs->isEmpty();
         }
 
         bool full() const
         {
-            return bufs.isFull();
+            return bufs->isFull();
         }
 
         void clear()
         {
             Item* item;
-            while ( bufs.dequeue(item) )
-                mpool.deallocate( item );
+            while ( bufs->dequeue(item) )
+                mpool->deallocate( item );
         }
 
         bool Push( param_t item)
         {
-            if ( capacity() == (size_type)bufs.size() ) {
+            if ( capacity() == (size_type)bufs->size() ) {
                 if (!mcircular)
                     return false;
                 // we will recover below in case of circular
             }
-            Item* mitem = mpool.allocate();
+            Item* mitem = mpool->allocate();
             if ( mitem == 0 ) { // queue full ( rare but possible in race with PopWithoutRelease )
                 if (!mcircular)
                     return false;
                 else {
-                    if (bufs.dequeue( mitem ) == false )
+                    if (bufs->dequeue( mitem ) == false )
                         return false; // assert(false) ???
                     // we keep mitem to write item to next
                 }
@@ -159,20 +198,20 @@ namespace RTT
 
             // copy over.
             *mitem = item;
-            if (bufs.enqueue( mitem ) == false ) {
+            if (bufs->enqueue( mitem ) == false ) {
                 //got memory, but buffer is full
                 //this can happen, as the memory pool is
                 //bigger than the buffer
                 if (!mcircular) {
-                    mpool.deallocate( mitem );
+                    mpool->deallocate( mitem );
                     return false;
                 } else {
                     // pop & deallocate until we have free space.
                     Item* itmp = 0;
                     do {
-                        bufs.dequeue( itmp );
-                        mpool.deallocate( itmp );
-                    } while ( bufs.enqueue( mitem ) == false );
+                        bufs->dequeue( itmp );
+                        mpool->deallocate( itmp );
+                    } while ( bufs->enqueue( mitem ) == false );
                 }
             }
             return true;
@@ -191,42 +230,42 @@ namespace RTT
         }
 
 
-        bool Pop( reference_t item )
+        FlowStatus Pop( reference_t item )
         {
             Item* ipop;
-            if (bufs.dequeue( ipop ) == false )
-                return false;
+            if (bufs->dequeue( ipop ) == false )
+                return NoData;
             item = *ipop;
-            if (mpool.deallocate( ipop ) == false )
+            if (mpool->deallocate( ipop ) == false )
                 assert(false);
-            return true;
+            return NewData;
         }
 
         size_type Pop(std::vector<T>& items )
         {
             Item* ipop;
             items.clear();
-            while( bufs.dequeue(ipop) ) {
+            while( bufs->dequeue(ipop) ) {
                 items.push_back( *ipop );
-                if (mpool.deallocate(ipop) == false)
+                if (mpool->deallocate(ipop) == false)
                     assert(false);
             }
             return items.size();
         }
         
         value_t* PopWithoutRelease()
-	{
+        {
             Item* ipop;
-            if (bufs.dequeue( ipop ) == false )
+            if (bufs->dequeue( ipop ) == false )
                 return 0;
-	    return ipop;
-	}
+            return ipop;
+        }
 
-	void Release(value_t *item) 
-	{
-            if (mpool.deallocate( item ) == false )
-                assert(false);  
-	}
+        void Release(value_t *item)
+        {
+            if (mpool->deallocate( item ) == false )
+                assert(false);
+        }
     };
 }}
 

--- a/rtt/base/BufferLocked.hpp
+++ b/rtt/base/BufferLocked.hpp
@@ -82,13 +82,13 @@ namespace RTT
          * @param size The number of elements this buffer can hold.
          * @param initial_value A data sample with which each preallocated data element is initialized.
          */
-        BufferLocked( size_type size, const T& initial_value, const Options &options = Options() )
+        BufferLocked( size_type size, param_t initial_value, const Options &options = Options() )
             : cap(size), buf(), mcircular(options.circular()), droppedSamples(0)
         {
             data_sample(initial_value);
         }
 
-        virtual bool data_sample( const T& sample, bool reset = true )
+        virtual bool data_sample( param_t sample, bool reset = true )
         {
             os::MutexLock locker(lock);
             if (!initialized || reset) {
@@ -102,7 +102,7 @@ namespace RTT
             }
         }
 
-        virtual T data_sample() const
+        virtual value_t data_sample() const
         {
             return lastSample;
         }
@@ -129,10 +129,10 @@ namespace RTT
             return true;
         }
 
-        size_type Push(const std::vector<T>& items)
+        size_type Push(const std::vector<value_t>& items)
         {
             os::MutexLock locker(lock);
-            typename std::vector<T>::const_iterator itl( items.begin() );
+            typename std::vector<value_t>::const_iterator itl( items.begin() );
             if (mcircular && (size_type)items.size() >= cap ) {
                 // clear out current data and reset iterator to first element we're going to take.
                 buf.clear();
@@ -175,7 +175,7 @@ namespace RTT
             return NewData;
         }
 
-        size_type Pop(std::vector<T>& items )
+        size_type Pop(std::vector<value_t>& items )
         {
             os::MutexLock locker(lock);
             int quant = 0;
@@ -240,7 +240,7 @@ namespace RTT
         }
     private:
         size_type cap;
-        std::deque<T> buf;
+        std::deque<value_t> buf;
         value_t lastSample;
         mutable os::Mutex lock;
         const bool mcircular;

--- a/rtt/base/BufferLocked.hpp
+++ b/rtt/base/BufferLocked.hpp
@@ -62,7 +62,7 @@ namespace RTT
         :public BufferInterface<T>
     {
     public:
-        using typename BufferBase::Options;
+        typedef typename BufferBase::Options Options;
         typedef typename BufferInterface<T>::reference_t reference_t;
         typedef typename BufferInterface<T>::param_t param_t;
         typedef typename BufferInterface<T>::size_type size_type;

--- a/rtt/base/BufferLocked.hpp
+++ b/rtt/base/BufferLocked.hpp
@@ -62,29 +62,44 @@ namespace RTT
         :public BufferInterface<T>
     {
     public:
-
+        using typename BufferBase::Options;
         typedef typename BufferInterface<T>::reference_t reference_t;
         typedef typename BufferInterface<T>::param_t param_t;
         typedef typename BufferInterface<T>::size_type size_type;
         typedef T value_t;
 
         /**
+         * Create an unitialized buffer of size \a size, with preallocated data storage.
+         * @param size The number of elements this buffer can hold.
+         */
+        BufferLocked( size_type size, const Options &options = Options() )
+            : cap(size), buf(), mcircular(options.circular()), initialized(false)
+        {
+        }
+
+        /**
          * Create a buffer of size \a size, with preallocated data storage.
          * @param size The number of elements this buffer can hold.
          * @param initial_value A data sample with which each preallocated data element is initialized.
-         * @param circular Set flag to true to make this buffer circular. If not circular, new values are discarded on full.
          */
-        BufferLocked( size_type size, const T& initial_value = T(), bool circular = false )
-            : cap(size), buf(), mcircular(circular)
+        BufferLocked( size_type size, const T& initial_value, const Options &options = Options() )
+            : cap(size), buf(), mcircular(options.circular())
         {
             data_sample(initial_value);
         }
 
-        virtual void data_sample( const T& sample )
+        virtual bool data_sample( const T& sample, bool reset = true )
         {
-            buf.resize(cap, sample);
-            buf.resize(0);
-            lastSample = sample;
+            os::MutexLock locker(lock);
+            if (!initialized || reset) {
+                buf.resize(cap, sample);
+                buf.resize(0);
+                lastSample = sample;
+                initialized = true;
+                return true;
+            } else {
+                return initialized;
+            }
         }
 
         virtual T data_sample() const
@@ -133,17 +148,17 @@ namespace RTT
             if (mcircular)
                 assert( (size_type)(itl - items.begin() ) == (size_type)items.size() );
             return (itl - items.begin());
-
         }
-        bool Pop( reference_t item )
+
+        FlowStatus Pop( reference_t item )
         {
             os::MutexLock locker(lock);
             if ( buf.empty() ) {
-                return false;
+                return NoData;
             }
             item = buf.front();
             buf.pop_front();
-            return true;
+            return NewData;
         }
 
         size_type Pop(std::vector<T>& items )
@@ -159,26 +174,26 @@ namespace RTT
             return quant;
         }
 
-	value_t* PopWithoutRelease()
-	{
+        value_t* PopWithoutRelease()
+        {
             os::MutexLock locker(lock);
-	    if(buf.empty())
-		return 0;
-	    
-	    //note we need to copy the sample, as 
-	    //front is not garanteed to be valid after
-	    //any other operation on the deque
-	    lastSample = buf.front();
-	    buf.pop_front();
-	    return &lastSample;
-	}
-	
-	void Release(value_t *item)
-	{
-	    //we do not need to release any memory, but we can check
-	    //if the other side messed up
-	    assert(item == &lastSample && "Wrong pointer given back to buffer");
-	}
+            if(buf.empty())
+                return 0;
+
+            //note we need to copy the sample, as
+            //front is not garanteed to be valid after
+            //any other operation on the deque
+            lastSample = buf.front();
+            buf.pop_front();
+            return &lastSample;
+        }
+
+        void Release(value_t *item)
+        {
+            //we do not need to release any memory, but we can check
+            //if the other side messed up
+            assert(item == &lastSample && "Wrong pointer given back to buffer");
+        }
 
         size_type capacity() const {
             os::MutexLock locker(lock);
@@ -202,14 +217,16 @@ namespace RTT
 
         bool full() const {
             os::MutexLock locker(lock);
-            return (size_type)buf.size() ==  cap;
+            return (size_type)buf.size() == cap;
         }
+
     private:
         size_type cap;
         std::deque<T> buf;
         value_t lastSample;
         mutable os::Mutex lock;
         const bool mcircular;
+        bool initialized;
     };
 }}
 

--- a/rtt/base/BufferUnSync.hpp
+++ b/rtt/base/BufferUnSync.hpp
@@ -76,13 +76,13 @@ namespace RTT
         /**
          * Create a buffer of size \a size.
          */
-        BufferUnSync( size_type size, const T& initial_value, const Options &options = Options() )
+        BufferUnSync( size_type size, param_t initial_value, const Options &options = Options() )
             : cap(size), buf(), mcircular(options.circular()), initialized(false), droppedSamples(0)
         {
             data_sample(initial_value);
         }
 
-        virtual bool data_sample( const T& sample, bool reset = true )
+        virtual bool data_sample( param_t sample, bool reset = true )
         {
             if (!initialized || reset) {
                 buf.resize(cap, sample);
@@ -93,7 +93,7 @@ namespace RTT
             }
         }
 
-        virtual T data_sample() const
+        virtual value_t data_sample() const
         {
             return lastSample;
         }
@@ -121,9 +121,9 @@ namespace RTT
             return true;
         }
 
-        size_type Push(const std::vector<T>& items)
+        size_type Push(const std::vector<value_t>& items)
         {
-            typename std::vector<T>::const_iterator itl( items.begin() );
+            typename std::vector<value_t>::const_iterator itl( items.begin() );
             if (mcircular && (size_type)items.size() >= cap ) {
                 // clear out current data and reset iterator to first element we're going to take.
                 buf.clear();
@@ -162,7 +162,7 @@ namespace RTT
             return NewData;
         }
 
-        size_type Pop(std::vector<T>& items )
+        size_type Pop(std::vector<value_t>& items )
         {
             int quant = 0;
             items.clear();
@@ -220,7 +220,7 @@ namespace RTT
         }
     private:
         size_type cap;
-        std::deque<T> buf;
+        std::deque<value_t> buf;
         value_t lastSample;
         const bool mcircular;
         bool initialized;

--- a/rtt/base/BufferUnSync.hpp
+++ b/rtt/base/BufferUnSync.hpp
@@ -59,7 +59,7 @@ namespace RTT
         :public BufferInterface<T>
     {
     public:
-        using typename BufferBase::Options;
+        typedef typename BufferBase::Options Options;
         typedef typename BufferInterface<T>::reference_t reference_t;
         typedef typename BufferInterface<T>::param_t param_t;
         typedef typename BufferInterface<T>::size_type size_type;

--- a/rtt/base/BufferUnSync.hpp
+++ b/rtt/base/BufferUnSync.hpp
@@ -59,24 +59,38 @@ namespace RTT
         :public BufferInterface<T>
     {
     public:
+        using typename BufferBase::Options;
         typedef typename BufferInterface<T>::reference_t reference_t;
         typedef typename BufferInterface<T>::param_t param_t;
         typedef typename BufferInterface<T>::size_type size_type;
         typedef T value_t;
 
         /**
+         * Create an uninitialized buffer of size \a size.
+         */
+        BufferUnSync( size_type size, const Options &options = Options() )
+            : cap(size), buf(), mcircular(options.circular()), initialized(false)
+        {
+        }
+
+        /**
          * Create a buffer of size \a size.
          */
-        BufferUnSync( size_type size, const T& initial_value = T(), bool circular = false )
-            : cap(size), buf(), mcircular(circular)
+        BufferUnSync( size_type size, const T& initial_value, const Options &options = Options() )
+            : cap(size), buf(), mcircular(options.circular()), initialized(false)
         {
             data_sample(initial_value);
         }
 
-        virtual void data_sample( const T& sample )
+        virtual bool data_sample( const T& sample, bool reset = true )
         {
-            buf.resize(cap, sample);
-            buf.resize(0);
+            if (!initialized || reset) {
+                buf.resize(cap, sample);
+                buf.resize(0);
+                return true;
+            } else {
+                return initialized;
+            }
         }
 
         virtual T data_sample() const
@@ -122,14 +136,14 @@ namespace RTT
             return (itl - items.begin());
         }
 
-        bool Pop( reference_t item )
+        FlowStatus Pop( reference_t item )
         {
             if ( buf.empty() ) {
-                return false;
+                return NoData;
             }
             item = buf.front();
             buf.pop_front();
-            return true;
+            return NewData;
         }
 
         size_type Pop(std::vector<T>& items )
@@ -144,27 +158,25 @@ namespace RTT
             return quant;
         }
 
-	value_t* PopWithoutRelease()
-	{
-	    if(buf.empty())
-		return 0;
-	    
-	    //note we need to copy the sample, as 
-	    //front is not garanteed to be valid after
-	    //any other operation on the deque
-	    lastSample = buf.front();
-	    buf.pop_front();
-	    return &lastSample;
+        value_t* PopWithoutRelease()
+        {
+            if(buf.empty())
+                return 0;
 
-	    return 0;
-	}
-	
-	void Release(value_t *item)
-	{
-	    //we do not need to release any memory, but we can check
-	    //if the other side messed up
-	    assert(item == &lastSample && "Wrong pointer given back to buffer");
-	}
+            //note we need to copy the sample, as
+            //front is not garanteed to be valid after
+            //any other operation on the deque
+            lastSample = buf.front();
+            buf.pop_front();
+            return &lastSample;
+        }
+
+        void Release(value_t *item)
+        {
+            //we do not need to release any memory, but we can check
+            //if the other side messed up
+            assert(item == &lastSample && "Wrong pointer given back to buffer");
+        }
 	
         size_type capacity() const {
             return cap;
@@ -185,11 +197,13 @@ namespace RTT
         bool full() const {
             return (size_type)buf.size() ==  cap;
         }
+
     private:
         size_type cap;
         std::deque<T> buf;
         value_t lastSample;
         const bool mcircular;
+        bool initialized;
     };
 }}
 

--- a/rtt/base/DataObjectBase.cpp
+++ b/rtt/base/DataObjectBase.cpp
@@ -1,13 +1,4 @@
 /***************************************************************************
-  tag: The SourceWorks  Tue Sep 7 00:55:18 CEST 2010  BufferBase.cpp
-
-                        BufferBase.cpp -  description
-                           -------------------
-    begin                : Tue September 07 2010
-    copyright            : (C) 2010 The SourceWorks
-    email                : peter@thesourceworks.com
-
- ***************************************************************************
  *   This library is free software; you can redistribute it and/or         *
  *   modify it under the terms of the GNU General Public                   *
  *   License as published by the Free Software Foundation;                 *
@@ -36,36 +27,30 @@
  ***************************************************************************/
 
 
-
-#include "BufferBase.hpp"
+#include "DataObjectBase.hpp"
 #include "../ConnPolicy.hpp"
 
 using namespace RTT;
 using namespace RTT::base;
 
-BufferBase::~BufferBase() {}
-
-BufferBase::Options::Options()
-    : circular_(false)
-    , max_threads_(2)
+DataObjectBase::Options::Options()
+    : max_threads_(2)
     , multiple_writers_(false)
     , multiple_readers_(false)
 {}
 
-BufferBase::Options::Options(bool circular)
-    : circular_(circular)
-    , max_threads_(2)
+DataObjectBase::Options::Options(unsigned int max_threads)
+    : max_threads_(max_threads)
     , multiple_writers_(false)
-    , multiple_readers_(false)
+    , multiple_readers_(true)
 {}
 
-BufferBase::Options::Options(const ConnPolicy &policy)
-    : circular_(policy.type == ConnPolicy::CIRCULAR_BUFFER)
-    , max_threads_(2)
+DataObjectBase::Options::Options(const ConnPolicy &policy)
+    : max_threads_(2)
 //    , multiple_writers_(policy.read_policy == ReadShared)
 //    , multiple_readers_(policy.write_policy == WriteShared)
     , multiple_writers_(false)
-    , multiple_readers_(false)
+    , multiple_readers_(true)
 {
 //    if (policy.max_threads == 0) {
 //        if (policy.read_policy == ReadShared) {

--- a/rtt/base/DataObjectBase.hpp
+++ b/rtt/base/DataObjectBase.hpp
@@ -1,13 +1,4 @@
 /***************************************************************************
-  tag: Peter Soetens  Mon Jan 19 14:11:26 CET 2004  DataObjectInterface.hpp
-
-                        DataObjectInterface.hpp -  description
-                           -------------------
-    begin                : Mon January 19 2004
-    copyright            : (C) 2004 Peter Soetens
-    email                : peter.soetens@mech.kuleuven.ac.be
-
- ***************************************************************************
  *   This library is free software; you can redistribute it and/or         *
  *   modify it under the terms of the GNU General Public                   *
  *   License as published by the Free Software Foundation;                 *
@@ -35,79 +26,46 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef CORELIB_DATAOBJECTINTERFACE_HPP
-#define CORELIB_DATAOBJECTINTERFACE_HPP
+#ifndef CORELIB_DATAOBJECTBASE_HPP
+#define CORELIB_DATAOBJECTBASE_HPP
 
-#include "DataObjectBase.hpp"
-#include "../FlowStatus.hpp"
-#include <boost/shared_ptr.hpp>
+#include "../rtt-fwd.hpp"
 
 namespace RTT
 { namespace base {
 
-
     /**
-     * @brief A DataObjectInterface implements multi-threaded read/write solutions.
+     * @brief Base class for all data object classes.
      *
-     * @see DataObject
-     * @param T The \a DataType which can be Get() or Set() with this DataObject.
      * @ingroup PortBuffers
      */
-    template <class T>
-    class DataObjectInterface : public DataObjectBase
+    class DataObjectBase
     {
     public:
         /**
-         * Used for shared_ptr management.
+         * A helper class to pass optional arguments to the constructor of \ref DataObjectLockFree<T>
+         * in order to avoid ambiguity.
          */
-        typedef typename boost::shared_ptr<DataObjectInterface<T> > shared_ptr;
+        class Options {
+        private:
+            unsigned int max_threads_;
+            bool multiple_writers_;
+            bool multiple_readers_;
 
-        /**
-         * Create a DataObject which is initially not reference counted.
-         */
-        DataObjectInterface() {}
+        public:
+            Options();
+            Options(const ConnPolicy &policy);
+            Options(unsigned int max_threads);
 
-        /**
-         * Destructor.
-         */
-        virtual ~DataObjectInterface() {}
+            unsigned int max_threads() const { return max_threads_; }
+            Options &max_threads(unsigned int value) { max_threads_ = value; return *this; }
+            bool multiple_writers() const { return multiple_writers_; }
+            Options &multiple_writers(bool value) { multiple_writers_ = value; return *this; }
+            bool multiple_readers() const { return multiple_readers_; }
+            Options &multiple_readers(bool value) { multiple_readers_ = value; return *this; }
+        };
 
-        /**
-         * The type of the data.
-         */
-        typedef T DataType;
-
-        /**
-         * Get a copy of the Data of this data object.
-         *
-         * @param pull A copy of the data.
-         */
-        virtual FlowStatus Get( DataType& pull, bool copy_old_data = true ) const = 0;
-
-        /**
-         * Get a copy of the data of this data object.
-         *
-         * @return A copy of the data.
-         */
-        virtual DataType Get() const = 0;
-
-        /**
-         * Set the data to a certain value.
-         *
-         * @param push The data which must be set.
-         */
-        virtual bool Set( const DataType& push ) = 0;
-
-        /**
-         * Provides a data sample to initialize this data object.
-         * As such enough storage
-         * space can be allocated before the actual writing begins.
-         *
-         * @param sample the data sample
-         * @param reset enforce reinitialization even if this operation clears the stored data.
-         * @return true if the data object was successfully (re)initialized.
-         */
-        virtual bool data_sample( const DataType& sample, bool reset = true ) = 0;
+        virtual ~DataObjectBase() {}
 
         /**
          * Clears any data stored by this data object, so that any subsequent Get() without

--- a/rtt/base/DataObjectInterface.hpp
+++ b/rtt/base/DataObjectInterface.hpp
@@ -40,6 +40,7 @@
 
 #include "DataObjectBase.hpp"
 #include "../FlowStatus.hpp"
+#include <boost/call_traits.hpp>
 #include <boost/shared_ptr.hpp>
 
 namespace RTT
@@ -57,6 +58,10 @@ namespace RTT
     class DataObjectInterface : public DataObjectBase
     {
     public:
+        typedef T value_t;
+        typedef typename boost::call_traits<T>::param_type param_t;
+        typedef typename boost::call_traits<T>::reference reference_t;
+
         /**
          * Used for shared_ptr management.
          */
@@ -73,42 +78,27 @@ namespace RTT
         virtual ~DataObjectInterface() {}
 
         /**
-         * The type of the data.
-         */
-        typedef T DataType;
-
-        /**
-         * Get a copy of the Data of this data object.
-         *
-         * @param pull A copy of the data.
-         * @param copy_old_data If true, also copy the data if the data object
-         *                      has not been updated since the last call.
-         * @param copy_sample   If true, copy the data unconditionally.
-         */
-        virtual FlowStatus Get( DataType& pull, bool copy_old_data, bool copy_sample ) const = 0;
-
-        /**
          * Get a copy of the Data of this data object.
          *
          * @param pull A copy of the data.
          * @param copy_old_data If true, also copy the data if the data object
          *                      has not been updated since the last call.
          */
-        virtual FlowStatus Get( DataType& pull, bool copy_old_data = true ) const = 0;
+        virtual FlowStatus Get( reference_t pull, bool copy_old_data = true ) const = 0;
 
         /**
          * Get a copy of the data of this data object.
          *
          * @return A copy of the data.
          */
-        virtual DataType Get() const = 0;
+        virtual value_t Get() const = 0;
 
         /**
          * Set the data to a certain value.
          *
          * @param push The data which must be set.
          */
-        virtual bool Set( const DataType& push ) = 0;
+        virtual bool Set( param_t push ) = 0;
 
         /**
          * Provides a data sample to initialize this data object.
@@ -119,7 +109,12 @@ namespace RTT
          * @param reset enforce reinitialization even if this operation clears the stored data.
          * @return true if the data object was successfully (re)initialized.
          */
-        virtual bool data_sample( const DataType& sample, bool reset = true ) = 0;
+        virtual bool data_sample( param_t sample, bool reset = true ) = 0;
+
+        /**
+         * Reads back a data sample.
+         */
+        virtual value_t data_sample() const = 0;
 
         /**
          * Clears any data stored by this data object, so that any subsequent Get() without

--- a/rtt/base/DataObjectInterface.hpp
+++ b/rtt/base/DataObjectInterface.hpp
@@ -81,6 +81,18 @@ namespace RTT
          * Get a copy of the Data of this data object.
          *
          * @param pull A copy of the data.
+         * @param copy_old_data If true, also copy the data if the data object
+         *                      has not been updated since the last call.
+         * @param copy_sample   If true, copy the data unconditionally.
+         */
+        virtual FlowStatus Get( DataType& pull, bool copy_old_data, bool copy_sample ) const = 0;
+
+        /**
+         * Get a copy of the Data of this data object.
+         *
+         * @param pull A copy of the data.
+         * @param copy_old_data If true, also copy the data if the data object
+         *                      has not been updated since the last call.
          */
         virtual FlowStatus Get( DataType& pull, bool copy_old_data = true ) const = 0;
 

--- a/rtt/base/DataObjectLockFree.hpp
+++ b/rtt/base/DataObjectLockFree.hpp
@@ -174,7 +174,7 @@ namespace RTT
          * @return A copy of the data.
          */
         virtual DataType Get() const {
-            DataType cache;
+            DataType cache = DataType();
             Get(cache);
             return cache;
         }
@@ -189,7 +189,6 @@ namespace RTT
         virtual FlowStatus Get( DataType& pull, bool copy_old_data = true ) const
         {
             if (!initialized) {
-                if (copy_old_data) pull = DataType();
                 return NoData;
             }
 
@@ -213,7 +212,7 @@ namespace RTT
             if (result == NewData) {
                 pull = reading->data;               // takes some time
                 reading->status = OldData;          // CAS?
-            } else if (copy_old_data) {
+            } else if ((result == OldData) && copy_old_data) {
                 pull = reading->data;               // takes some time
             }
 

--- a/rtt/base/DataObjectLockFree.hpp
+++ b/rtt/base/DataObjectLockFree.hpp
@@ -41,6 +41,8 @@
 
 #include "../os/oro_arch.h"
 #include "DataObjectInterface.hpp"
+#include "../Logger.hpp"
+#include "../types/Types.hpp"
 
 namespace RTT
 { namespace base {
@@ -78,17 +80,14 @@ namespace RTT
         : public DataObjectInterface<T>
     {
     public:
-        /**
-         * The type of the data.
-         */
-        typedef T DataType;
+        using typename DataObjectBase::Options;
+        using typename DataObjectInterface<T>::DataType;
 
         /**
          * @brief The maximum number of threads.
-         *
-         * When used in data flow, this is always 2.
          */
-        const unsigned int MAX_THREADS; // = 2
+        const unsigned int MAX_THREADS;
+
     private:
         /**
          * Conversion of number of threads to size of buffer.
@@ -104,11 +103,14 @@ namespace RTT
          */
         struct DataBuf {
             DataBuf()
-                : data(), counter(), next()
+                : data(), status(NoData), counter(), next()
             {
                 oro_atomic_set(&counter, 0);
             }
-            DataType data; mutable oro_atomic_t counter; DataBuf* next;
+            DataType data;
+            FlowStatus status;
+            mutable oro_atomic_t counter;
+            DataBuf* next;
         };
 
         typedef DataBuf* volatile VolPtrType;
@@ -122,22 +124,41 @@ namespace RTT
          * A 3 element Data buffer
          */
         DataBuf* data;
+
+        bool initialized;
+
     public:
 
         /**
-         * Construct a DataObjectLockFree by name.
-         *
-         * @param _name The name of this DataObject.
-         * @param initial_value The initial value of this DataObject.
+         * Construct an uninitialized DataObjectLockFree.
+         * @param max_threads The maximum number of threads accessing this DataObject.
          */
-        DataObjectLockFree( const T& initial_value = T(), unsigned int max_threads = 2 )
-            : MAX_THREADS(max_threads), BUF_LEN( max_threads + 2),
+        DataObjectLockFree( const Options &options = Options() )
+            : MAX_THREADS(options.max_threads()), BUF_LEN( options.max_threads() + 2),
               read_ptr(0),
-              write_ptr(0)
+              write_ptr(0),
+              initialized(false)
         {
         	data = new DataBuf[BUF_LEN];
         	read_ptr = &data[0];
         	write_ptr = &data[1];
+        }
+
+        /**
+         * Construct a DataObjectLockFree.
+         * @param initial_value The initial value of this DataObject.
+         * @param max_threads The maximum number of threads accessing this DataObject.
+         * @note You have to specify the maximum number of threads explicitly
+         */
+        DataObjectLockFree( const T& initial_value, const Options &options = Options() )
+            : MAX_THREADS(options.max_threads()), BUF_LEN( options.max_threads() + 2),
+              read_ptr(0),
+              write_ptr(0),
+              initialized(false)
+        {
+            data = new DataBuf[BUF_LEN];
+            read_ptr = &data[0];
+            write_ptr = &data[1];
             data_sample(initial_value);
         }
 
@@ -152,7 +173,11 @@ namespace RTT
          *
          * @return A copy of the data.
          */
-        virtual DataType Get() const {DataType cache; Get(cache); return cache; }
+        virtual DataType Get() const {
+            DataType cache;
+            Get(cache);
+            return cache;
+        }
 
         /**
          * Get a copy of the Data (non allocating).
@@ -161,8 +186,13 @@ namespace RTT
          *
          * @param pull A copy of the data.
          */
-        virtual void Get( DataType& pull ) const
+        virtual FlowStatus Get( DataType& pull, bool copy_old_data = true ) const
         {
+            if (!initialized) {
+                if (copy_old_data) pull = DataType();
+                return NoData;
+            }
+
             PtrType reading;
             // loop to combine Read/Modify of counter
             // This avoids a race condition where read_ptr
@@ -178,9 +208,18 @@ namespace RTT
             } while ( true );
             // from here on we are sure that 'reading'
             // is a valid buffer to read from.
-            pull = reading->data;               // takes some time
+
+            FlowStatus result = reading->status;
+            if (result == NewData) {
+                pull = reading->data;               // takes some time
+                reading->status = OldData;          // CAS?
+            } else if (copy_old_data) {
+                pull = reading->data;               // takes some time
+            }
+
             // XXX smp_mb
             oro_atomic_dec(&reading->counter);       // release buffer
+            return result;
         }
 
         /**
@@ -188,7 +227,7 @@ namespace RTT
          *
          * @param push The data which must be set.
          */
-        virtual void Set( const DataType& push )
+        virtual bool Set( const DataType& push )
         {
             /**
              * This method can not be called concurrently (only one
@@ -198,34 +237,77 @@ namespace RTT
              * not increment the counter on write_ptr+1). Hence, no
              * locking is needed.
              */
+
+            if (!initialized) {
+                types::TypeInfo *ti = types::Types()->getTypeInfo<DataType>();
+                log(Error) << "You set a lock-free data object of type " << (ti ? ti->getTypeName() : "(unknown)") << " without initializing it with a data sample. "
+                           << "This might not be real-time safe." << endlog();
+                data_sample(DataType(), true);
+            }
+
             // writeout in any case
-            write_ptr->data = push;
-            PtrType wrote_ptr = write_ptr;
+            PtrType writing = write_ptr;
+            writing->data = push;
+            writing->status = NewData;
+
             // if next field is occupied (by read_ptr or counter),
             // go to next and check again...
             while ( oro_atomic_read( &write_ptr->next->counter ) != 0 || write_ptr->next == read_ptr )
                 {
                     write_ptr = write_ptr->next;
-                    if (write_ptr == wrote_ptr)
-                        return; // nothing found, to many readers !
+                    if (write_ptr == writing)
+                        return false; // nothing found, to many readers !
                 }
 
             // we will be able to move, so replace read_ptr
-            read_ptr  = wrote_ptr;
+            read_ptr  = writing;
             write_ptr = write_ptr->next; // we checked this in the while loop
+            return true;
         }
 
-        virtual void data_sample( const DataType& sample ) {
-            // prepare the buffer.
-            for (unsigned int i = 0; i < BUF_LEN-1; ++i) {
-                data[i].data = sample;
-                data[i].next = &data[i+1];
+        virtual bool data_sample( const DataType& sample, bool reset = true ) {
+            if (!initialized || reset) {
+                // prepare the buffer.
+                for (unsigned int i = 0; i < BUF_LEN; ++i) {
+                    data[i].data = sample;
+                    data[i].status = NoData;
+                    data[i].next = &data[i+1];
+                }
+                data[BUF_LEN-1].next = &data[0];
+                initialized = true;
+                return true;
+            } else {
+                return initialized;
             }
-            data[BUF_LEN-1].data = sample;
-            data[BUF_LEN-1].next = &data[0];
+        }
+
+        // This is actually a copy of Get(), but it only sets the status to NoData once a valid buffer has been found.
+        // Subsequent read() calls will read from the same buffer and will return NoData until a new sample has been written.
+        virtual void clear() {
+            if (!initialized) return;
+
+            PtrType reading;
+            // loop to combine Read/Modify of counter
+            // This avoids a race condition where read_ptr
+            // could become write_ptr ( then we would read corrupted data).
+            do {
+                reading = read_ptr;            // copy buffer location
+                oro_atomic_inc(&reading->counter); // lock buffer, no more writes
+                // XXX smp_mb
+                if ( reading != read_ptr )     // if read_ptr changed,
+                    oro_atomic_dec(&reading->counter); // better to start over.
+                else
+                    break;
+            } while ( true );
+            // from here on we are sure that 'reading'
+            // is a valid buffer to read from.
+
+            reading->status = NoData;
+
+            // XXX smp_mb
+            oro_atomic_dec(&reading->counter);       // release buffer
         }
     };
 }}
 
 #endif
-

--- a/rtt/base/DataObjectLockFree.hpp
+++ b/rtt/base/DataObjectLockFree.hpp
@@ -80,8 +80,8 @@ namespace RTT
         : public DataObjectInterface<T>
     {
     public:
-        using typename DataObjectBase::Options;
-        using typename DataObjectInterface<T>::DataType;
+        typedef typename DataObjectBase::Options Options;
+        typedef typename DataObjectInterface<T>::DataType DataType;
 
         /**
          * @brief The maximum number of threads.

--- a/rtt/base/DataObjectLocked.hpp
+++ b/rtt/base/DataObjectLocked.hpp
@@ -91,14 +91,14 @@ namespace RTT
             if (status == NewData) {
                 pull = data;
                 status = OldData;
-            } else if (copy_old_data) {
+            } else if ((status == OldData) && copy_old_data) {
                 pull = data;
             }
             return result;
         }
 
         virtual DataType Get() const {
-            DataType cache;
+            DataType cache = DataType();
             Get(cache);
             return cache;
         }

--- a/rtt/base/DataObjectLocked.hpp
+++ b/rtt/base/DataObjectLocked.hpp
@@ -63,28 +63,68 @@ namespace RTT
          * One element of Data.
          */
         T data;
+
+        mutable FlowStatus status;
+        bool initialized;
+
     public:
         /**
-         * Construct a DataObjectLocked by name.
-         *
-         * @param _name The name of this DataObject.
+         * Construct an uninitialized DataObjectLocked.
          */
-        DataObjectLocked( const T& initial_value = T() )
-            : data(initial_value) {}
+        DataObjectLocked()
+            : data(), status(NoData), initialized(false) {}
+
+        /**
+         * Construct a DataObjectLocked with initial value.
+         */
+        DataObjectLocked( const T& initial_value )
+            : data(initial_value), status(NoData), initialized(true) {}
 
         /**
          * The type of the data.
          */
         typedef T DataType;
 
-        virtual void Get( DataType& pull ) const { os::MutexLock locker(lock); pull = data; }
+        virtual FlowStatus Get( DataType& pull, bool copy_old_data = true ) const {
+            os::MutexLock locker(lock);
+            FlowStatus result = status;
+            if (status == NewData) {
+                pull = data;
+                status = OldData;
+            } else if (copy_old_data) {
+                pull = data;
+            }
+            return result;
+        }
 
-        virtual DataType Get() const { DataType cache;  Get(cache); return cache; }
+        virtual DataType Get() const {
+            DataType cache;
+            Get(cache);
+            return cache;
+        }
 
-        virtual void Set( const DataType& push ) { os::MutexLock locker(lock); data = push; }
+        virtual bool Set( const DataType& push ) {
+            os::MutexLock locker(lock);
+            data = push;
+            status = NewData;
+            return true;
+        }
 
-        virtual void data_sample( const DataType& sample ) {
-            Set(sample);
+        virtual bool data_sample( const DataType& sample, bool reset ) {
+            os::MutexLock locker(lock);
+            if (!initialized || reset) {
+                data = sample;
+                status = NoData;
+                initialized = true;
+                return true;
+            } else {
+                return initialized;
+            }
+        }
+
+        virtual void clear() {
+            os::MutexLock locker(lock);
+            status = NoData;
         }
     };
 }}

--- a/rtt/base/DataObjectLocked.hpp
+++ b/rtt/base/DataObjectLocked.hpp
@@ -85,16 +85,20 @@ namespace RTT
          */
         typedef T DataType;
 
-        virtual FlowStatus Get( DataType& pull, bool copy_old_data = true ) const {
+        virtual FlowStatus Get( DataType& pull, bool copy_old_data, bool copy_sample ) const {
             os::MutexLock locker(lock);
             FlowStatus result = status;
             if (status == NewData) {
                 pull = data;
                 status = OldData;
-            } else if ((status == OldData) && copy_old_data) {
+            } else if (((status == OldData) && copy_old_data) || copy_sample) {
                 pull = data;
             }
             return result;
+        }
+
+        virtual FlowStatus Get( DataType& pull, bool copy_old_data = true ) const {
+            return Get( pull, copy_old_data, /* copy_sample = */ false );
         }
 
         virtual DataType Get() const {

--- a/rtt/base/DataObjectUnSync.hpp
+++ b/rtt/base/DataObjectUnSync.hpp
@@ -55,10 +55,14 @@ namespace RTT
     class DataObjectUnSync
         : public DataObjectInterface<T>
     {
+        typedef typename DataObjectInterface<T>::value_t value_t;
+        typedef typename DataObjectInterface<T>::reference_t reference_t;
+        typedef typename DataObjectInterface<T>::param_t param_t;
+
         /**
          * One element of Data.
          */
-        T data;
+        value_t data;
 
         mutable FlowStatus status;
         bool initialized;
@@ -73,42 +77,33 @@ namespace RTT
         /**
          * Construct a DataObjectUnSync with initial value.
          */
-        DataObjectUnSync( const T& initial_value )
+        DataObjectUnSync( param_t initial_value )
             : data(initial_value), status(NoData), initialized(true) {}
 
-        /**
-         * The type of the data.
-         */
-        typedef T DataType;
-
-        virtual FlowStatus Get( DataType& pull, bool copy_old_data, bool copy_sample ) const {
+        virtual FlowStatus Get( reference_t pull, bool copy_old_data = true ) const {
             FlowStatus result = status;
             if (status == NewData) {
                 pull = data;
                 status = OldData;
-            } else if (((status == OldData) && copy_old_data) || copy_sample) {
+            } else if ((status == OldData) && copy_old_data) {
                 pull = data;
             }
             return result;
         }
 
-        virtual FlowStatus Get( DataType& pull, bool copy_old_data = true ) const {
-            return Get( pull, copy_old_data, /* copy_sample = */ false );
-        }
-
-        virtual DataType Get() const {
-            DataType cache = DataType();
+        virtual value_t Get() const {
+            value_t cache = value_t();
             Get(cache);
             return cache;
         }
 
-        virtual bool Set( const DataType& push ) {
+        virtual bool Set( param_t push ) {
             data = push;
             status = NewData;
             return true;
         }
 
-        virtual bool data_sample( const DataType& sample, bool reset ) {
+        virtual bool data_sample( param_t sample, bool reset ) {
             if (!initialized || reset) {
                 Set(sample);
                 initialized = true;
@@ -118,7 +113,10 @@ namespace RTT
             }
         }
 
-        virtual T data_sample() const
+        /**
+         * Reads back a data sample.
+         */
+        virtual value_t data_sample() const
         {
             return data;
         }

--- a/rtt/base/DataObjectUnSync.hpp
+++ b/rtt/base/DataObjectUnSync.hpp
@@ -81,15 +81,19 @@ namespace RTT
          */
         typedef T DataType;
 
-        virtual FlowStatus Get( DataType& pull, bool copy_old_data = true ) const {
+        virtual FlowStatus Get( DataType& pull, bool copy_old_data, bool copy_sample ) const {
             FlowStatus result = status;
             if (status == NewData) {
                 pull = data;
                 status = OldData;
-            } else if ((status == OldData) && copy_old_data) {
+            } else if (((status == OldData) && copy_old_data) || copy_sample) {
                 pull = data;
             }
             return result;
+        }
+
+        virtual FlowStatus Get( DataType& pull, bool copy_old_data = true ) const {
+            return Get( pull, copy_old_data, /* copy_sample = */ false );
         }
 
         virtual DataType Get() const {

--- a/rtt/base/DataObjectUnSync.hpp
+++ b/rtt/base/DataObjectUnSync.hpp
@@ -86,14 +86,14 @@ namespace RTT
             if (status == NewData) {
                 pull = data;
                 status = OldData;
-            } else if (copy_old_data) {
+            } else if ((status == OldData) && copy_old_data) {
                 pull = data;
             }
             return result;
         }
 
         virtual DataType Get() const {
-            DataType cache;
+            DataType cache = DataType();
             Get(cache);
             return cache;
         }

--- a/rtt/base/DataObjectUnSync.hpp
+++ b/rtt/base/DataObjectUnSync.hpp
@@ -59,33 +59,69 @@ namespace RTT
          * One element of Data.
          */
         T data;
+
+        mutable FlowStatus status;
+        bool initialized;
+
     public:
         /**
-         * Construct a DataObjectUnSync by name.
-         *
-         * @param _name The name of this DataObject.
+         * Construct an uninitialized DataObjectUnSync.
          */
-        DataObjectUnSync( const T& initial_value = T() )
-            : data(initial_value) {}
+        DataObjectUnSync()
+            : data(), status(NoData), initialized(false) {}
+
+        /**
+         * Construct a DataObjectUnSync with initial value.
+         */
+        DataObjectUnSync( const T& initial_value )
+            : data(initial_value), status(NoData), initialized(true) {}
 
         /**
          * The type of the data.
          */
         typedef T DataType;
 
-        virtual void Get( DataType& pull ) const { pull = data; }
+        virtual FlowStatus Get( DataType& pull, bool copy_old_data = true ) const {
+            FlowStatus result = status;
+            if (status == NewData) {
+                pull = data;
+                status = OldData;
+            } else if (copy_old_data) {
+                pull = data;
+            }
+            return result;
+        }
 
-        virtual DataType Get() const { DataType cache;  Get(cache); return cache; }
+        virtual DataType Get() const {
+            DataType cache;
+            Get(cache);
+            return cache;
+        }
 
-        virtual void Set( const DataType& push ) { data = push; }
+        virtual bool Set( const DataType& push ) {
+            data = push;
+            status = NewData;
+            return true;
+        }
 
-        virtual void data_sample( const DataType& sample ) {
-            Set(sample);
+        virtual bool data_sample( const DataType& sample, bool reset ) {
+            if (!initialized || reset) {
+                Set(sample);
+                initialized = true;
+                return true;
+            } else {
+                return initialized;
+            }
         }
 
         virtual T data_sample() const
         {
             return data;
+        }
+
+        virtual void clear()
+        {
+            status = NoData;
         }
 
     };

--- a/rtt/internal/AtomicMWMRQueue.hpp
+++ b/rtt/internal/AtomicMWMRQueue.hpp
@@ -1,0 +1,317 @@
+/***************************************************************************
+  tag: The SourceWorks  Tue Sep 7 00:55:18 CEST 2010  AtomicQueue.hpp
+
+                        AtomicQueue.hpp -  description
+                           -------------------
+    begin                : Tue September 07 2010
+    copyright            : (C) 2010 The SourceWorks
+    email                : peter@thesourceworks.com
+
+ ***************************************************************************
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU General Public                   *
+ *   License as published by the Free Software Foundation;                 *
+ *   version 2 of the License.                                             *
+ *                                                                         *
+ *   As a special exception, you may use this file as part of a free       *
+ *   software library without restriction.  Specifically, if other files   *
+ *   instantiate templates or use macros or inline functions from this     *
+ *   file, or you compile this file and link it with other files to        *
+ *   produce an executable, this file does not by itself cause the         *
+ *   resulting executable to be covered by the GNU General Public          *
+ *   License.  This exception does not however invalidate any other        *
+ *   reasons why the executable file might be covered by the GNU General   *
+ *   Public License.                                                       *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public             *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 59 Temple Place,                                    *
+ *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef ORO_CORELIB_ATOMIC_MWMR_QUEUE_HPP
+#define ORO_CORELIB_ATOMIC_MWMR_QUEUE_HPP
+
+#include "AtomicQueue.hpp"
+#include "../os/CAS.hpp"
+#include <utility>
+
+namespace RTT
+{
+    namespace internal {
+    /**
+     * Create an atomic, non-blocking single ended queue (FIFO) for storing
+     * a \b pointer to \a T. It is a
+     * Many Readers, Many Writers implementation
+     * based on the atomic Compare And Swap instruction. Any number of threads
+     * may access the queue concurrently.
+     *
+     * This queue tries to obey strict ordering, but under high contention
+     * of reads interfering writes, one or more elements may be dequeued out of order.
+     * For this reason, size() is expensive to accurately calculate the size.
+     *
+     * Due to the same limitations, it is possible that the full capacity of the
+     * queue is not used (simulations show seldomly an off by one element if capacity==10) and
+     * that isFull() returns true, while size() < capacity().
+     *
+     * @warning You can not store null pointers.
+     * @param T The pointer type to be stored in the Queue.
+     * Example : AtomicQueue< A* > is a queue of pointers to A.
+     *
+     * @ingroup CoreLibBuffers
+     */
+    template<class T>
+    class AtomicMWMRQueue : public AtomicQueue<T>
+    {
+        const int _size;
+        typedef T C;
+        typedef volatile C* CachePtrType;
+        typedef C* volatile CacheObjType;
+        typedef C  ValueType;
+        typedef C* PtrType;
+
+        union SIndexes
+        {
+        	unsigned long _value;
+        	unsigned short _index[2];
+        };
+
+        /**
+         * The pointer to the buffer can be cached,
+         * the contents are volatile.
+         */
+        CachePtrType  _buf;
+
+        /**
+         * The indexes are packed into one double word.
+         * Therefore the read and write index can be read and written atomically.
+         */
+        volatile SIndexes _indxes;
+
+        /**
+         * The loose ordering may cause missed items in our
+         * queue which are not pointed at by the read pointer.
+         * This function recovers such items from _buf.
+         * @return zero if nothing to recover, the location of
+         * a lost item otherwise.
+         */
+        CachePtrType recover_r() const
+        {
+            // The implementation starts from the read pointer,
+            // and wraps around until all fields were scanned.
+            // As such, the out-of-order elements will at least
+            // be returned in their relative order.
+            SIndexes start;
+            start._value = _indxes._value;
+            unsigned short r = start._index[1];
+            while( r != _size) {
+                if (_buf[r])
+                    return &_buf[r];
+                ++r;
+            }
+            r = 0;
+            while( r != start._index[1]) {
+                if (_buf[r])
+                    return &_buf[r];
+                ++r;
+            }
+            return 0;
+        }
+
+        /**
+         * Atomic advance and wrap of the Write pointer.
+         * Return the old position or zero if queue is full.
+         */
+        CachePtrType propose_w()
+        {
+        	SIndexes oldval, newval;
+            do {
+            	oldval._value = _indxes._value; /*Points to a free writable pointer.*/
+                newval._value = oldval._value; /*Points to the next writable pointer.*/
+                // check for full on a *Copy* of oldval:
+                if ( (newval._index[0] == newval._index[1] - 1) || (newval._index[0] == newval._index[1] + _size - 1) )
+                {
+                    // note: in case of high contention, there might be existing empty fields
+                    // in _buf that aren't used.
+                    return 0;
+                }
+                ++newval._index[0];
+                if ( newval._index[0] == _size )
+                	newval._index[0] = 0;
+                // if ptr is unchanged, replace it with newval.
+            } while ( !os::CAS( &_indxes._value, oldval._value, newval._value) );
+
+            // the returned field may contain data, in that case, the caller needs to retry.
+            return &_buf[ oldval._index[0] ];
+        }
+        /**
+         * Atomic advance and wrap of the Read pointer.
+         * Return the data position or zero if queue is empty.
+         */
+        CachePtrType propose_r()
+        {
+        	SIndexes oldval, newval;
+            do {
+            	oldval._value = _indxes._value;
+            	newval._value = oldval._value;
+                // check for empty on a *Copy* of oldval:
+                if ( newval._index[0] == newval._index[1] )
+                {
+                    // seldom: R and W are indicating empty, but 'lost' fields
+                    // are to be picked up. Return these
+                    // that would have been read eventually after some writes.
+                    return recover_r();
+                }
+                ++newval._index[1];
+                if ( newval._index[1] == _size )
+                	newval._index[1] = 0;
+
+            } while ( !os::CAS( &_indxes._value, oldval._value, newval._value) );
+            // the returned field may contain *no* data, in that case, the caller needs to retry.
+            // as such r will advance until it hits a data sample or write pointer.
+            return &_buf[oldval._index[1] ];
+        }
+
+        // non-copyable !
+        AtomicMWMRQueue( const AtomicQueue<T>& );
+    public:
+        using typename AtomicQueue<T>::size_type;
+
+        /**
+         * Create an AtomicQueue with queue size \a size.
+         * @param size The size of the queue, should be 1 or greater.
+         */
+        AtomicMWMRQueue( unsigned int size )
+            : _size(size+1)
+        {
+            _buf= new C[_size];
+            this->clear();
+        }
+
+        ~AtomicMWMRQueue()
+        {
+            delete[] _buf;
+        }
+
+        /**
+         * Inspect if the Queue is full.
+         * @return true if full, false otherwise.
+         */
+        bool isFull() const
+        {
+            // two cases where the queue is full :
+            // if wptr is one behind rptr or if wptr is at end
+            // and rptr at beginning.
+            SIndexes val;
+            val._value = _indxes._value;
+            return val._index[0] == val._index[1] - 1 || val._index[0] == val._index[1] + _size - 1;
+        }
+
+        /**
+         * Inspect if the Queue is empty.
+         * @return true if empty, false otherwise.
+         */
+        bool isEmpty() const
+        {
+            // empty if nothing to read.
+            SIndexes val;
+            val._value = _indxes._value;
+            return val._index[0] == val._index[1] && recover_r() == 0;
+        }
+
+        /**
+         * Return the maximum number of items this queue can contain.
+         */
+        size_type capacity() const
+        {
+            return _size -1;
+        }
+
+        /**
+         * Return the exact number of elements in the queue.
+         * This is slow because it scans the whole
+         * queue.
+         */
+        size_type size() const
+        {
+            int c = 0, ret = 0;
+            while (c != _size ) {
+                if (_buf[c++] )
+                    ++ret;
+            }
+            return ret;
+            //int c = (_indxes._index[0] - _indxes._index[1]);
+            //return c >= 0 ? c : c + _size;
+        }
+
+        /**
+         * Enqueue an item.
+         * @param value The value to enqueue, not zero.
+         * @return false if queue is full or value is zero, true if queued.
+         */
+        bool enqueue(const T& value)
+        {
+            if ( value == 0 )
+                return false;
+            CachePtrType loc;
+            C null = 0;
+            do {
+                loc = propose_w();
+                if ( loc == 0 )
+                    return false; //full
+                // if loc contains a zero, write it, otherwise, re-try.
+            } while( !os::CAS(loc, null, value));
+            return true;
+        }
+
+        /**
+         * Dequeue an item.
+         * @param value The value dequeued.
+         * @return false if queue is empty, true if dequeued.
+         */
+        bool dequeue( T& result )
+        {
+            CachePtrType loc;
+            C null = 0;
+            do {
+                loc = propose_r();
+                if ( loc == 0 )
+                    return false; // empty
+                result = *loc;
+                // if loc still contains result, clear it, otherwise, re-try.
+            } while( result == 0 || !os::CAS(loc, result, null) );
+            assert(result);
+            return true;
+        }
+
+        /**
+         * Return the next to be read value.
+         */
+        const T front() const
+        {
+            return _buf[_indxes._index[1] ];
+        }
+
+        /**
+         * Clear all contents of the Queue and thus make it empty.
+         */
+        void clear()
+        {
+            for(int i = 0 ; i != _size; ++i) {
+                _buf[i] = 0;
+            }
+            _indxes._value = 0;
+        }
+
+    };
+
+}}
+
+#endif

--- a/rtt/internal/AtomicMWMRQueue.hpp
+++ b/rtt/internal/AtomicMWMRQueue.hpp
@@ -182,7 +182,7 @@ namespace RTT
         // non-copyable !
         AtomicMWMRQueue( const AtomicQueue<T>& );
     public:
-        using typename AtomicQueue<T>::size_type;
+        typedef typename AtomicQueue<T>::size_type size_type;
 
         /**
          * Create an AtomicQueue with queue size \a size.

--- a/rtt/internal/AtomicMWSRQueue.hpp
+++ b/rtt/internal/AtomicMWSRQueue.hpp
@@ -160,7 +160,7 @@ namespace RTT
             AtomicMWSRQueue(const AtomicMWSRQueue<T>&);
 
         public:
-            using typename AtomicQueue<T>::size_type;
+            typedef typename AtomicQueue<T>::size_type size_type;
 
             /**
              * Create an AtomicMWSRQueue with queue size \a size.

--- a/rtt/internal/AtomicMWSRQueue.hpp
+++ b/rtt/internal/AtomicMWSRQueue.hpp
@@ -39,6 +39,7 @@
 #ifndef ORO_CORELIB_ATOMIC_MWSR_QUEUE_HPP
 #define ORO_CORELIB_ATOMIC_MWSR_QUEUE_HPP
 
+#include "AtomicQueue.hpp"
 #include "../os/CAS.hpp"
 #include <utility>
 
@@ -56,14 +57,14 @@ namespace RTT
          * @ingroup CoreLibBuffers
          */
         template<class T>
-        class AtomicMWSRQueue
+        class AtomicMWSRQueue : public AtomicQueue<T>
         {
             //typedef _T* T;
             const int _size;
             typedef T C;
             typedef volatile C* CachePtrType;
             typedef C* volatile CacheObjType;
-            typedef C ValueType;
+            typedef C  ValueType;
             typedef C* PtrType;
 
             /**
@@ -157,8 +158,9 @@ namespace RTT
 
             // non-copyable !
             AtomicMWSRQueue(const AtomicMWSRQueue<T>&);
+
         public:
-            typedef unsigned int size_type;
+            using typename AtomicQueue<T>::size_type;
 
             /**
              * Create an AtomicMWSRQueue with queue size \a size.

--- a/rtt/internal/AtomicQueue.hpp
+++ b/rtt/internal/AtomicQueue.hpp
@@ -39,26 +39,13 @@
 #ifndef ORO_CORELIB_ATOMIC_QUEUE_HPP
 #define ORO_CORELIB_ATOMIC_QUEUE_HPP
 
-#include "../os/CAS.hpp"
-#include <utility>
-
 namespace RTT
 {
     namespace internal {
+
     /**
-     * Create an atomic, non-blocking single ended queue (FIFO) for storing
-     * a \b pointer to \a T. It is a
-     * Many Readers, Many Writers implementation
-     * based on the atomic Compare And Swap instruction. Any number of threads
-     * may access the queue concurrently.
-     *
-     * This queue tries to obey strict ordering, but under high contention
-     * of reads interfering writes, one or more elements may be dequeued out of order.
-     * For this reason, size() is expensive to accurately calculate the size.
-     *
-     * Due to the same limitations, it is possible that the full capacity of the
-     * queue is not used (simulations show seldomly an off by one element if capacity==10) and
-     * that isFull() returns true, while size() < capacity().
+     * An atomic, non-blocking single ended queue (FIFO) for storing
+     * a \b pointer to \a T.
      *
      * @warning You can not store null pointers.
      * @param T The pointer type to be stored in the Queue.
@@ -69,246 +56,58 @@ namespace RTT
     template<class T>
     class AtomicQueue
     {
-        const int _size;
-        typedef T C;
-        typedef volatile C* CachePtrType;
-        typedef C* volatile CacheObjType;
-        typedef C  ValueType;
-        typedef C* PtrType;
-
-        union SIndexes
-        {
-        	unsigned long _value;
-        	unsigned short _index[2];
-        };
-
-        /**
-         * The pointer to the buffer can be cached,
-         * the contents are volatile.
-         */
-        CachePtrType  _buf;
-
-        /**
-         * The indexes are packed into one double word.
-         * Therefore the read and write index can be read and written atomically.
-         */
-        volatile SIndexes _indxes;
-
-        /**
-         * The loose ordering may cause missed items in our
-         * queue which are not pointed at by the read pointer.
-         * This function recovers such items from _buf.
-         * @return zero if nothing to recover, the location of
-         * a lost item otherwise.
-         */
-        CachePtrType recover_r() const
-        {
-            // The implementation starts from the read pointer,
-            // and wraps around until all fields were scanned.
-            // As such, the out-of-order elements will at least
-            // be returned in their relative order.
-            SIndexes start;
-            start._value = _indxes._value;
-            unsigned short r = start._index[1];
-            while( r != _size) {
-                if (_buf[r])
-                    return &_buf[r];
-                ++r;
-            }
-            r = 0;
-            while( r != start._index[1]) {
-                if (_buf[r])
-                    return &_buf[r];
-                ++r;
-            }
-            return 0;
-        }
-
-        /**
-         * Atomic advance and wrap of the Write pointer.
-         * Return the old position or zero if queue is full.
-         */
-        CachePtrType propose_w()
-        {
-        	SIndexes oldval, newval;
-            do {
-            	oldval._value = _indxes._value; /*Points to a free writable pointer.*/
-                newval._value = oldval._value; /*Points to the next writable pointer.*/
-                // check for full on a *Copy* of oldval:
-                if ( (newval._index[0] == newval._index[1] - 1) || (newval._index[0] == newval._index[1] + _size - 1) )
-                {
-                    // note: in case of high contention, there might be existing empty fields
-                    // in _buf that aren't used.
-                    return 0;
-                }
-                ++newval._index[0];
-                if ( newval._index[0] == _size )
-                	newval._index[0] = 0;
-                // if ptr is unchanged, replace it with newval.
-            } while ( !os::CAS( &_indxes._value, oldval._value, newval._value) );
-
-            // the returned field may contain data, in that case, the caller needs to retry.
-            return &_buf[ oldval._index[0] ];
-        }
-        /**
-         * Atomic advance and wrap of the Read pointer.
-         * Return the data position or zero if queue is empty.
-         */
-        CachePtrType propose_r()
-        {
-        	SIndexes oldval, newval;
-            do {
-            	oldval._value = _indxes._value;
-            	newval._value = oldval._value;
-                // check for empty on a *Copy* of oldval:
-                if ( newval._index[0] == newval._index[1] )
-                {
-                    // seldom: R and W are indicating empty, but 'lost' fields
-                    // are to be picked up. Return these
-                    // that would have been read eventually after some writes.
-                    return recover_r();
-                }
-                ++newval._index[1];
-                if ( newval._index[1] == _size )
-                	newval._index[1] = 0;
-
-            } while ( !os::CAS( &_indxes._value, oldval._value, newval._value) );
-            // the returned field may contain *no* data, in that case, the caller needs to retry.
-            // as such r will advance until it hits a data sample or write pointer.
-            return &_buf[oldval._index[1] ];
-        }
-
-        // non-copyable !
-        AtomicQueue( const AtomicQueue<T>& );
     public:
         typedef unsigned int size_type;
 
-        /**
-         * Create an AtomicQueue with queue size \a size.
-         * @param size The size of the queue, should be 1 or greater.
-         */
-        AtomicQueue( unsigned int size )
-            : _size(size+1)
-        {
-            _buf= new C[_size];
-            this->clear();
-        }
-
-        ~AtomicQueue()
-        {
-            delete[] _buf;
-        }
+        virtual ~AtomicQueue() {}
 
         /**
          * Inspect if the Queue is full.
          * @return true if full, false otherwise.
          */
-        bool isFull() const
-        {
-            // two cases where the queue is full :
-            // if wptr is one behind rptr or if wptr is at end
-            // and rptr at beginning.
-            SIndexes val;
-            val._value = _indxes._value;
-            return val._index[0] == val._index[1] - 1 || val._index[0] == val._index[1] + _size - 1;
-        }
+        virtual bool isFull() const = 0;
 
         /**
          * Inspect if the Queue is empty.
          * @return true if empty, false otherwise.
          */
-        bool isEmpty() const
-        {
-            // empty if nothing to read.
-            SIndexes val;
-            val._value = _indxes._value;
-            return val._index[0] == val._index[1] && recover_r() == 0;
-        }
+        virtual bool isEmpty() const = 0;
 
         /**
          * Return the maximum number of items this queue can contain.
          */
-        size_type capacity() const
-        {
-            return _size -1;
-        }
+        virtual size_type capacity() const = 0;
 
         /**
          * Return the exact number of elements in the queue.
          * This is slow because it scans the whole
          * queue.
          */
-        size_type size() const
-        {
-            int c = 0, ret = 0;
-            while (c != _size ) {
-                if (_buf[c++] )
-                    ++ret;
-            }
-            return ret;
-            //int c = (_indxes._index[0] - _indxes._index[1]);
-            //return c >= 0 ? c : c + _size;
-        }
+        virtual size_type size() const = 0;
 
         /**
          * Enqueue an item.
          * @param value The value to enqueue, not zero.
          * @return false if queue is full or value is zero, true if queued.
          */
-        bool enqueue(const T& value)
-        {
-            if ( value == 0 )
-                return false;
-            CachePtrType loc;
-            C null = 0;
-            do {
-                loc = propose_w();
-                if ( loc == 0 )
-                    return false; //full
-                // if loc contains a zero, write it, otherwise, re-try.
-            } while( !os::CAS(loc, null, value));
-            return true;
-        }
+        virtual bool enqueue(const T& value) = 0;
 
         /**
          * Dequeue an item.
          * @param value The value dequeued.
          * @return false if queue is empty, true if dequeued.
          */
-        bool dequeue( T& result )
-        {
-            CachePtrType loc;
-            C null = 0;
-            do {
-                loc = propose_r();
-                if ( loc == 0 )
-                    return false; // empty
-                result = *loc;
-                // if loc still contains result, clear it, otherwise, re-try.
-            } while( result == 0 || !os::CAS(loc, result, null) );
-            assert(result);
-            return true;
-        }
+        virtual bool dequeue( T& result ) = 0;
 
         /**
          * Return the next to be read value.
          */
-        const T front() const
-        {
-            return _buf[_indxes._index[1] ];
-        }
+        virtual const T front() const = 0;
 
         /**
          * Clear all contents of the Queue and thus make it empty.
          */
-        void clear()
-        {
-            for(int i = 0 ; i != _size; ++i) {
-                _buf[i] = 0;
-            }
-            _indxes._value = 0;
-        }
-
+        virtual void clear() = 0;
     };
 
 }}

--- a/rtt/internal/ChannelBufferElement.hpp
+++ b/rtt/internal/ChannelBufferElement.hpp
@@ -64,9 +64,9 @@ namespace RTT { namespace internal {
         const ConnPolicy policy;
 
     public:
+        typedef typename base::ChannelElement<T>::value_t value_t;
         typedef typename base::ChannelElement<T>::param_t param_t;
         typedef typename base::ChannelElement<T>::reference_t reference_t;
-        typedef typename base::ChannelElement<T>::value_t value_t;
 
         ChannelBufferElement(typename base::BufferInterface<T>::shared_ptr buffer, const ConnPolicy& policy = ConnPolicy())
             : buffer(buffer), last_sample_p(0), policy(policy) {}
@@ -146,7 +146,7 @@ namespace RTT { namespace internal {
             return base::ChannelElement<T>::data_sample(sample);
         }
 
-        virtual T data_sample()
+        virtual value_t data_sample()
         {
             return buffer->data_sample();
         }

--- a/rtt/internal/ChannelDataElement.hpp
+++ b/rtt/internal/ChannelDataElement.hpp
@@ -41,6 +41,7 @@
 
 #include "../base/ChannelElement.hpp"
 #include "../base/DataObjectInterface.hpp"
+#include "../ConnPolicy.hpp"
 
 namespace RTT { namespace internal {
 
@@ -49,24 +50,24 @@ namespace RTT { namespace internal {
     template<typename T>
     class ChannelDataElement : public base::ChannelElement<T>
     {
-        bool written, mread;
         typename base::DataObjectInterface<T>::shared_ptr data;
+        const ConnPolicy policy;
 
     public:
         typedef typename base::ChannelElement<T>::param_t param_t;
         typedef typename base::ChannelElement<T>::reference_t reference_t;
 
-        ChannelDataElement(typename base::DataObjectInterface<T>::shared_ptr sample)
-            : written(false), mread(false), data(sample) {}
+        ChannelDataElement(typename base::DataObjectInterface<T>::shared_ptr sample, const ConnPolicy& policy = ConnPolicy())
+            : data(sample), policy(policy) {}
 
         /** Update the data sample stored in this element.
          * It always returns true. */
         virtual bool write(param_t sample)
         {
-            data->Set(sample);
-            written = true;
-            mread = false;
-            return this->signal();
+            if (data->Set(sample))
+                return this->signal();
+            else
+                return true; // false would disconnect the channel
         }
 
         /** Reads the last sample given to write()
@@ -75,20 +76,7 @@ namespace RTT { namespace internal {
          */
         virtual FlowStatus read(reference_t sample, bool copy_old_data)
         {
-            if (written)
-            {
-                if ( !mread ) {
-		    data->Get(sample);
-                    mread = true;
-                    return NewData;
-                }
-
-		if(copy_old_data)
-		    data->Get(sample);
-
-                return OldData;
-            }
-            return NoData;
+            return data->Get(sample, copy_old_data);
         }
 
         /** Resets the stored sample. After clear() has been called, read()
@@ -96,14 +84,13 @@ namespace RTT { namespace internal {
          */
         virtual void clear()
         {
-            written = false;
-            mread = false;
+            data->clear();
             base::ChannelElement<T>::clear();
         }
 
         virtual bool data_sample(param_t sample)
         {
-            data->data_sample(sample);
+            if (!data->data_sample(sample)) return false;
             return base::ChannelElement<T>::data_sample(sample);
         }
 
@@ -112,6 +99,12 @@ namespace RTT { namespace internal {
             return data->Get();
         }
 
+        /** Returns a pointer to the ConnPolicy that has been used to construct the underlying data object.
+        */
+        virtual const ConnPolicy* getConnPolicy() const
+        {
+            return &policy;
+        }
     };
 }}
 

--- a/rtt/internal/ChannelDataElement.hpp
+++ b/rtt/internal/ChannelDataElement.hpp
@@ -96,7 +96,9 @@ namespace RTT { namespace internal {
 
         virtual T data_sample()
         {
-            return data->Get();
+            T sample;
+            (void) data->Get(sample, true, /* copy_sample = */ true);
+            return sample;
         }
 
         /** Returns a pointer to the ConnPolicy that has been used to construct the underlying data object.

--- a/rtt/internal/ChannelDataElement.hpp
+++ b/rtt/internal/ChannelDataElement.hpp
@@ -54,6 +54,7 @@ namespace RTT { namespace internal {
         const ConnPolicy policy;
 
     public:
+        typedef typename base::ChannelElement<T>::value_t value_t;
         typedef typename base::ChannelElement<T>::param_t param_t;
         typedef typename base::ChannelElement<T>::reference_t reference_t;
 
@@ -94,11 +95,9 @@ namespace RTT { namespace internal {
             return base::ChannelElement<T>::data_sample(sample);
         }
 
-        virtual T data_sample()
+        virtual value_t data_sample()
         {
-            T sample;
-            (void) data->Get(sample, true, /* copy_sample = */ true);
-            return sample;
+            return data->data_sample();
         }
 
         /** Returns a pointer to the ConnPolicy that has been used to construct the underlying data object.

--- a/rtt/internal/ConnFactory.hpp
+++ b/rtt/internal/ConnFactory.hpp
@@ -148,8 +148,8 @@ namespace RTT
                     data_object.reset( new base::DataObjectLockFree<T>(initial_value) );
                     break;
 #else
-		case ConnPolicy::LOCK_FREE:
-		    RTT::log(Warning) << "lock free connection policy is unavailable on this system, defaulting to LOCKED" << RTT::endlog();
+                case ConnPolicy::LOCK_FREE:
+                    RTT::log(Warning) << "lock free connection policy is unavailable on this system, defaulting to LOCKED" << RTT::endlog();
 #endif
                 case ConnPolicy::LOCKED:
                     data_object.reset( new base::DataObjectLocked<T>(initial_value) );
@@ -158,9 +158,7 @@ namespace RTT
                     data_object.reset( new base::DataObjectUnSync<T>(initial_value) );
                     break;
                 }
-
-                ChannelDataElement<T>* result = new ChannelDataElement<T>(data_object);
-                return result;
+                return new ChannelDataElement<T>(data_object, policy);
             }
             else if (policy.type == ConnPolicy::BUFFER || policy.type == ConnPolicy::CIRCULAR_BUFFER)
             {
@@ -169,20 +167,20 @@ namespace RTT
                 {
 #ifndef OROBLD_OS_NO_ASM
                 case ConnPolicy::LOCK_FREE:
-                    buffer_object = new base::BufferLockFree<T>(policy.size, initial_value, policy.type == ConnPolicy::CIRCULAR_BUFFER);
+                    buffer_object = new base::BufferLockFree<T>(policy.size, initial_value, policy);
                     break;
 #else
-		case ConnPolicy::LOCK_FREE:
-		    RTT::log(Warning) << "lock free connection policy is unavailable on this system, defaulting to LOCKED" << RTT::endlog();
+                case ConnPolicy::LOCK_FREE:
+                    RTT::log(Warning) << "lock free connection policy is unavailable on this system, defaulting to LOCKED" << RTT::endlog();
 #endif
                 case ConnPolicy::LOCKED:
-                    buffer_object = new base::BufferLocked<T>(policy.size, initial_value, policy.type == ConnPolicy::CIRCULAR_BUFFER);
+                    buffer_object = new base::BufferLocked<T>(policy.size, initial_value, policy);
                     break;
                 case ConnPolicy::UNSYNC:
-                    buffer_object = new base::BufferUnSync<T>(policy.size, initial_value, policy.type == ConnPolicy::CIRCULAR_BUFFER);
+                    buffer_object = new base::BufferUnSync<T>(policy.size, initial_value, policy);
                     break;
                 }
-                return new ChannelBufferElement<T>(typename base::BufferInterface<T>::shared_ptr(buffer_object));
+                return new ChannelBufferElement<T>(typename base::BufferInterface<T>::shared_ptr(buffer_object), policy);
             }
             return NULL;
         }

--- a/tests/buffers_test.cpp
+++ b/tests/buffers_test.cpp
@@ -1119,29 +1119,63 @@ BOOST_AUTO_TEST_CASE( testDObjUnSync )
 
 BOOST_AUTO_TEST_CASE( testBufLockFree4Writers1Reader )
 {
-    buffer = lockfree;
+    buffer
+        = new BufferLockFree<Dummy>(QS, Dummy(), BufferBase::Options()
+                                                 .circular(false)
+                                                 .multiple_writers(true)
+                                                 .max_threads(5));
     testBufMultiThreaded(4, 1);
-    buffer = circular = clockfree;
+    delete buffer;
+
+    circular = buffer
+        = new BufferLockFree<Dummy>(QS, Dummy(), BufferBase::Options()
+                                                 .circular(true)
+                                                 .multiple_writers(true)
+                                                 .max_threads(5));
     testBufMultiThreaded(4, 1);
+    delete buffer;
 }
 
 BOOST_AUTO_TEST_CASE( testBufLockFree4Writers4Readers )
 {
-    buffer = new BufferLockFree<Dummy>(QS, Dummy(), BufferBase::Options().circular(false).multiple_readers(true));
+    buffer
+        = new BufferLockFree<Dummy>(QS, Dummy(), BufferBase::Options()
+                                                 .circular(false)
+                                                 .multiple_writers(true)
+                                                 .multiple_readers(true)
+                                                 .max_threads(8));
     testBufMultiThreaded(4, 4);
     delete buffer;
 
-    buffer = circular = new BufferLockFree<Dummy>(QS, Dummy(), BufferBase::Options().circular(true).multiple_readers(true));
+    circular = buffer
+        = new BufferLockFree<Dummy>(QS, Dummy(), BufferBase::Options()
+                                                 .circular(true)
+                                                 .multiple_writers(true)
+                                                 .multiple_readers(true)
+                                                 .max_threads(8));
     testBufMultiThreaded(4, 4);
     delete buffer;
 }
 
 BOOST_AUTO_TEST_CASE( testBufLocked4Writers4Readers )
 {
-    buffer = locked;
+    buffer
+        = new BufferLocked<Dummy>(QS, Dummy(), BufferBase::Options()
+                                               .circular(false)
+                                               .multiple_writers(true)
+                                               .multiple_readers(true)
+                                               .max_threads(8));
     testBufMultiThreaded(4, 4);
-    buffer = circular = clocked;
+    delete buffer;
+
+    circular = buffer
+        = new BufferLocked<Dummy>(QS, Dummy(), BufferBase::Options()
+                                               .circular(true)
+                                               .multiple_writers(true)
+                                               .multiple_readers(true)
+                                               .max_threads(8));
     testBufMultiThreaded(4, 4);
+    delete buffer;
 }
 
 BOOST_AUTO_TEST_CASE( testDObjLockFreeSingleWriter4Readers )

--- a/tests/buffers_test.cpp
+++ b/tests/buffers_test.cpp
@@ -123,9 +123,9 @@ class ThreadPool : public std::vector< std::pair< shared_ptr<Worker>, shared_ptr
 {
 public:
     typedef std::vector< std::pair< shared_ptr<Worker>, shared_ptr<ThreadInterface> > > Threads;
-    using typename Threads::value_type;
-    using typename Threads::iterator;
-    using typename Threads::const_iterator;
+    typedef typename Threads::value_type value_type;
+    typedef typename Threads::iterator iterator;
+    typedef typename Threads::const_iterator const_iterator;
 
     template <typename Arg1>
     ThreadPool(int threads, int scheduler, int priority, Seconds period, const std::string &name, const Arg1 &arg1)

--- a/tests/buffers_test.cpp
+++ b/tests/buffers_test.cpp
@@ -119,10 +119,10 @@ public:
 };
 
 template <class Worker>
-class ThreadPool : public std::vector< std::pair< shared_ptr<Worker>, shared_ptr<ThreadInterface> > >
+class ThreadPool : public std::vector< std::pair< boost::shared_ptr<Worker>, boost::shared_ptr<ThreadInterface> > >
 {
 public:
-    typedef std::vector< std::pair< shared_ptr<Worker>, shared_ptr<ThreadInterface> > > Threads;
+    typedef std::vector< std::pair< boost::shared_ptr<Worker>, boost::shared_ptr<ThreadInterface> > > Threads;
     typedef typename Threads::value_type value_type;
     typedef typename Threads::iterator iterator;
     typedef typename Threads::const_iterator const_iterator;

--- a/tests/buffers_test.cpp
+++ b/tests/buffers_test.cpp
@@ -638,7 +638,11 @@ void BuffersDataFlowTest::testCirc()
 void BuffersDataFlowTest::testDObj()
 {
     Dummy* c = new Dummy(2.0, 1.0, 0.0);
-    Dummy  d;
+    Dummy  d(5.0, 4.0, 3.0);
+
+    BOOST_REQUIRE_EQUAL( NoData, dataobj->Get(d) );
+    BOOST_REQUIRE_EQUAL( d, Dummy(5.0, 4.0, 3.0) );
+
     dataobj->Set( *c );
     BOOST_REQUIRE_EQUAL( *c, dataobj->Get() );
     int i = 0;

--- a/tests/buffers_test.cpp
+++ b/tests/buffers_test.cpp
@@ -673,10 +673,12 @@ void BuffersDataFlowTest::testBufMultiThreaded(int number_of_writers, int number
     int total_writes = 0, total_dropped = 0, total_reads = 0;
     std::map<FlowStatus, int> total_reads_by_status;
     BOOST_FOREACH(ThreadPool<BufferWriter>::value_type &writer, writers) {
+        BOOST_REQUIRE( !writer.second->isRunning() );
         total_writes += writer.first->writes;
         BOOST_CHECK_GT(writer.first->writes, 0);
     }
     BOOST_FOREACH(ThreadPool<BufferReader>::value_type &reader, readers) {
+        BOOST_REQUIRE( !reader.second->isRunning() );
         total_reads += reader.first->reads;
         BOOST_CHECK_GT(reader.first->reads, 0);
         BOOST_FOREACH(ReadsByStatusMap::value_type &reads_by_status, reader.first->reads_by_status) {
@@ -707,10 +709,12 @@ void BuffersDataFlowTest::testDObjMultiThreaded(int number_of_writers, int numbe
     int total_writes = 0, total_dropped = 0, total_reads = 0;
     std::map<FlowStatus, int> total_reads_by_status;
     BOOST_FOREACH(ThreadPool<DataObjectWriter>::value_type &writer, writers) {
+        BOOST_REQUIRE( !writer.second->isRunning() );
         total_writes += writer.first->writes;
         BOOST_CHECK_GT(writer.first->writes, 0);
     }
     BOOST_FOREACH(ThreadPool<DataObjectReader>::value_type &reader, readers) {
+        BOOST_REQUIRE( !reader.second->isRunning() );
         total_reads += reader.first->reads;
         BOOST_CHECK_GT(reader.first->reads, 0);
         BOOST_FOREACH(ReadsByStatusMap::value_type &reads_by_status, reader.first->reads_by_status) {
@@ -773,44 +777,7 @@ public:
         }
         void finalize() {}
     };
-
-    void testMPoolMultiThreaded(int number_of_workers);
 };
-
-void BuffersMPoolTest::testMPoolMultiThreaded(int number_of_workers)
-{
-    {
-        BOOST_CHECK_EQUAL( mpool->size(), QS);
-        ThreadPool<BuffersMPoolTest::Worker<Dummy> > workers(number_of_workers, ORO_SCHED_OTHER, 0, 0, "BuffersMPoolWorker", mpool);
-        BOOST_REQUIRE( workers.start() );
-        sleep(5);
-        BOOST_REQUIRE( workers.stop() );
-        BOOST_CHECK_EQUAL( mpool->size(), QS);
-
-        int total_cycles = 0;
-        BOOST_FOREACH(ThreadPool<BuffersMPoolTest::Worker<Dummy> >::value_type &worker, workers) {
-            BOOST_CHECK_GT(worker.first->cycles, 0);
-            log(Info) << worker.second->getName() << ": " << worker.first->cycles << " cycles" << endlog();
-            total_cycles += worker.first->cycles;
-        }
-    }
-    {
-        BOOST_CHECK_EQUAL( vpool->size(), QS);
-        ThreadPool<BuffersMPoolTest::Worker<std::vector<Dummy> > > workers(number_of_workers, ORO_SCHED_OTHER, 0, 0, "BuffersVPoolWorker", vpool);
-        BOOST_REQUIRE( workers.start() );
-        sleep(5);
-        BOOST_REQUIRE( workers.stop() );
-        BOOST_CHECK_EQUAL( vpool->size(), QS);
-
-        int total_cycles = 0;
-        BOOST_FOREACH(ThreadPool<BuffersMPoolTest::Worker<std::vector<Dummy> > >::value_type &worker, workers) {
-            BOOST_CHECK_GT(worker.first->cycles, 0);
-            log(Info) << worker.second->getName() << ": " << worker.first->cycles << " cycles" << endlog();
-            total_cycles += worker.first->cycles;
-        }
-    }
-}
-
 
 std::ostream& operator<<( std::ostream& os, const Dummy& d )  {
 	os << "(" << d.d1 <<","<<d.d2<<","<<d.d3<<")";
@@ -848,7 +815,7 @@ struct LLFWorker : public RunnableInterface
     void step() {
         while (stop == false ) {
             //log(Info) << "Appending, i="<<i<<endlog();
-            while ( mlst->append( Dummy(i,i,i) ) ) { ++i; ++appends; }
+            while ( stop == false && mlst->append( Dummy(i,i,i) ) ) { ++i; ++appends; }
             //log(Info) << "Erasing, i="<<i<<endlog();
             while ( mlst->erase( Dummy(i-1,i-1,i-1) ) ) { --i; ++erases; }
         }
@@ -1241,7 +1208,38 @@ BOOST_AUTO_TEST_CASE( testMemoryPool )
 BOOST_AUTO_TEST_CASE( testMemoryPoolMultiThreaded )
 {
     Logger::In in("testMemoryPoolMultiThreaded");
-    testMPoolMultiThreaded(QS);
+    int number_of_workers = QS;
+
+    {
+        BOOST_CHECK_EQUAL( mpool->size(), QS);
+        ThreadPool<BuffersMPoolTest::Worker<Dummy> > workers(number_of_workers, ORO_SCHED_OTHER, 0, 0, "BuffersMPoolWorker", mpool);
+        BOOST_REQUIRE( workers.start() );
+        sleep(5);
+        BOOST_REQUIRE( workers.stop() );
+        BOOST_CHECK_EQUAL( mpool->size(), QS);
+
+        int total_cycles = 0;
+        BOOST_FOREACH(ThreadPool<BuffersMPoolTest::Worker<Dummy> >::value_type &worker, workers) {
+            BOOST_CHECK_GT(worker.first->cycles, 0);
+            log(Info) << worker.second->getName() << ": " << worker.first->cycles << " cycles" << endlog();
+            total_cycles += worker.first->cycles;
+        }
+    }
+    {
+        BOOST_CHECK_EQUAL( vpool->size(), QS);
+        ThreadPool<BuffersMPoolTest::Worker<std::vector<Dummy> > > workers(number_of_workers, ORO_SCHED_OTHER, 0, 0, "BuffersVPoolWorker", vpool);
+        BOOST_REQUIRE( workers.start() );
+        sleep(5);
+        BOOST_REQUIRE( workers.stop() );
+        BOOST_CHECK_EQUAL( vpool->size(), QS);
+
+        int total_cycles = 0;
+        BOOST_FOREACH(ThreadPool<BuffersMPoolTest::Worker<std::vector<Dummy> > >::value_type &worker, workers) {
+            BOOST_CHECK_GT(worker.first->cycles, 0);
+            log(Info) << worker.second->getName() << ": " << worker.first->cycles << " cycles" << endlog();
+            total_cycles += worker.first->cycles;
+        }
+    }
 }
 
 #if 0
@@ -1310,47 +1308,35 @@ BOOST_AUTO_TEST_CASE( testSortedList )
     BOOST_CHECK( mslist->empty() );
 }
 #endif
+BOOST_AUTO_TEST_SUITE_END()
 
 #ifdef OROPKG_OS_GNULINUX
-
-BOOST_AUTO_TEST_SUITE_END()
 BOOST_FIXTURE_TEST_SUITE( BuffersStressLockFreeTestSuite, BuffersAtomicMWMRQueueTest )
 
 BOOST_AUTO_TEST_CASE( testListLockFree )
 {
-    LLFWorker* aworker = new LLFWorker( listlockfree );
-    LLFWorker* bworker = new LLFWorker( listlockfree );
-    LLFWorker* cworker = new LLFWorker( listlockfree );
+    ThreadPool< LLFWorker > pool(5, ORO_SCHED_OTHER, 0, 0.0, "LLFWorker", listlockfree);
     LLFGrower* grower = new LLFGrower( listlockfree );
 
     {
-        boost::scoped_ptr<Activity> athread( new Activity(ORO_SCHED_OTHER, 0, 0, aworker, "ActivityA" ));
-        boost::scoped_ptr<Activity> bthread( new Activity(ORO_SCHED_OTHER, 0, 0, bworker, "ActivityB" ));
-        boost::scoped_ptr<Activity> cthread( new Activity(ORO_SCHED_OTHER, 0, 0, cworker, "ActivityC" ));
-        boost::scoped_ptr<Activity> gthread( new Activity(ORO_SCHED_OTHER, 0, 0, grower, "ActivityG" ));
+        boost::scoped_ptr<Activity> gthread( new Activity(ORO_SCHED_OTHER, 0, 0, grower, "LLFGrower" ));
 
-        athread->start();
-        bthread->start();
-        cthread->start();
+        BOOST_REQUIRE(pool.start());
 
         sleep(5);
-        gthread->start();
+        BOOST_REQUIRE(gthread->start());
         sleep(10);
-        gthread->stop();
+        BOOST_REQUIRE(gthread->stop());
         sleep(5);
 
-        athread->stop();
-        bthread->stop();
-        cthread->stop();
+        BOOST_REQUIRE(pool.stop());
     }
 
 #if 0
-    log(Info) << "Athread appends: " << aworker->appends<<endlog();
-    log(Info) << "Athread erases: " << aworker->erases<<endlog();
-    log(Info) << "Bthread appends: " << bworker->appends<<endlog();
-    log(Info) << "Bthread erases: " << bworker->erases<<endlog();
-    log(Info) << "Cthread appends: " << cworker->appends<<endlog();
-    log(Info) << "Cthread erases: " << cworker->erases<<endlog();
+    for(ThreadPool< LLFWorker >::const_iterator it = pool.begin(); it != pool.end(); ++it) {
+        log(Info) << it->second->getName() << " appends: " << it->first->appends<<endlog();
+        log(Info) << it->second->getName() << " erases: " << it->first->erases<<endlog();
+    }
     log(Info) << "List capacity: "<< listlockfree->capacity()<<endlog();
     log(Info) << "List size: "<< listlockfree->size()<<endlog();
 //     while( listlockfree->empty() == false ) {
@@ -1360,68 +1346,61 @@ BOOST_AUTO_TEST_CASE( testListLockFree )
 //     }
 #endif
 
-    BOOST_CHECK( aworker->appends == aworker->erases );
-    BOOST_CHECK( bworker->appends == bworker->erases );
-    BOOST_CHECK( cworker->appends == cworker->erases );
+    for(ThreadPool< LLFWorker >::const_iterator it = pool.begin(); it != pool.end(); ++it) {
+        BOOST_CHECK_EQUAL( it->first->appends, it->first->erases );
+    }
 
-    delete aworker;
-    delete bworker;
-    delete cworker;
+    pool.clear();
     delete grower;
 }
-#endif
 
-#ifdef OROPKG_OS_GNULINUX
-BOOST_AUTO_TEST_CASE( testAtomicQueue )
+BOOST_AUTO_TEST_CASE( testAtomicMWMRQueue )
 {
-    Logger::In in("testAtomicQueue");
+    Logger::In in("testAtomicMWMRQueue");
 
     MWMRQueueType* qt = new MWMRQueueType(QS);
-    AQWorker<MWMRQueueType>* aworker = new AQWorker<MWMRQueueType>( qt );
-    AQWorker<MWMRQueueType>* bworker = new AQWorker<MWMRQueueType>( qt );
-    AQWorker<MWMRQueueType>* cworker = new AQWorker<MWMRQueueType>( qt );
+    ThreadPool< AQWorker<MWMRQueueType> > pool(5, ORO_SCHED_OTHER, 20, 0.0, "AQWorker", qt);
     AQGrower<MWMRQueueType>* grower = new AQGrower<MWMRQueueType>( qt );
     AQEater<MWMRQueueType>* eater = new AQEater<MWMRQueueType>( qt );
+    boost::scoped_ptr<Activity> gthread( new Activity(20, grower, "AQGrower"));
+    boost::scoped_ptr<Activity> ethread( new Activity(20, eater, "AQEater"));
+
+    // avoid system lock-ups
+    gthread->thread()->setScheduler(ORO_SCHED_OTHER);
+    ethread->thread()->setScheduler(ORO_SCHED_OTHER);
 
     {
-        boost::scoped_ptr<Activity> athread( new Activity(20, aworker, "ActivityA" ));
-        boost::scoped_ptr<Activity> bthread( new Activity(20, bworker, "ActivityB" ));
-        boost::scoped_ptr<Activity> cthread( new Activity(20, cworker, "ActivityC" ));
-        boost::scoped_ptr<Activity> gthread( new Activity(20, grower, "ActivityG"));
-        boost::scoped_ptr<Activity> ethread( new Activity(20, eater, "ActivityE"));
-
-        // avoid system lock-ups
-        athread->thread()->setScheduler(ORO_SCHED_OTHER);
-        bthread->thread()->setScheduler(ORO_SCHED_OTHER);
-        cthread->thread()->setScheduler(ORO_SCHED_OTHER);
-        gthread->thread()->setScheduler(ORO_SCHED_OTHER);
-
         log(Info) <<"Stressing multi-read/multi-write..." <<endlog();
-        athread->start();
-        bthread->start();
-        cthread->start();
+        BOOST_REQUIRE(pool.start());
         sleep(5);
         log(Info) <<"Stressing multi-read/multi-write...on full buffer" <<endlog();
-        gthread->start(); // stress full bufs
+        BOOST_REQUIRE(gthread->start()); // stress full bufs
         sleep(5);
-        gthread->stop();
+        BOOST_REQUIRE(gthread->stop());
         log(Info) <<"Stressing multi-read/multi-write...on empty buffer" <<endlog();
-        ethread->start(); // stress empty bufs
+        BOOST_REQUIRE(ethread->start()); // stress empty bufs
         sleep(5);
-        athread->stop();
-        bthread->stop();
-        cthread->stop();
+        BOOST_REQUIRE(pool.stop());
         gthread->start(); // stress single-reader single-writer
         log(Info) <<"Stressing read&write..." <<endlog();
         sleep(5);
-        gthread->stop();
-        ethread->stop();
+        BOOST_REQUIRE(gthread->stop());
+        BOOST_REQUIRE(ethread->stop());
     }
 
-    log(Info) <<endlog()
-         << "Total appends: " << aworker->appends + bworker->appends + cworker->appends+ grower->appends<<endlog();
-    log(Info) << "Total erases : " << aworker->erases + bworker->erases+ cworker->erases + qt->size() + eater->erases <<endlog();
-    if (aworker->appends + bworker->appends + cworker->appends+ grower->appends != aworker->erases + bworker->erases+ cworker->erases + int(qt->size()) + eater->erases) {
+    int appends = 0;
+    int erases = 0;
+    for(ThreadPool< AQWorker<MWMRQueueType> >::const_iterator it = pool.begin(); it != pool.end(); ++it) {
+        appends += it->first->appends;
+        erases += it->first->erases;
+    }
+    appends += grower->appends;
+    erases += eater->erases;
+
+    log(Info) << nlog()
+              << "Total appends: " << appends << endlog();
+    log(Info) << "Total erases : " << erases << endlog();
+    if (appends != erases + int(qt->size())) {
         log(Info) << "Mismatch detected !" <<endlog();
     }
     int i = 0; // left-over count
@@ -1443,13 +1422,13 @@ BOOST_AUTO_TEST_CASE( testAtomicQueue )
     BOOST_CHECK_EQUAL( qt->size(), 0 );
 
     // assert: sum queues == sum dequeues
-    BOOST_CHECK_EQUAL( aworker->appends + bworker->appends + cworker->appends + grower->appends,
-                       aworker->erases + bworker->erases + cworker->erases + i + eater->erases );
-    delete aworker;
-    delete bworker;
-    delete cworker;
+    BOOST_CHECK_EQUAL( appends,
+                       erases + i );
+
+    pool.clear();
     delete grower;
     delete eater;
+    delete qt;
 }
 
 BOOST_AUTO_TEST_CASE( testAtomicMWSRQueue )
@@ -1457,46 +1436,41 @@ BOOST_AUTO_TEST_CASE( testAtomicMWSRQueue )
     Logger::In in("testAtomicMWSRQueue");
 
     MWSRQueueType* qt = new MWSRQueueType(QS);
-    AQGrower<MWSRQueueType>* aworker = new AQGrower<MWSRQueueType>( qt );
-    AQGrower<MWSRQueueType>* bworker = new AQGrower<MWSRQueueType>( qt );
-    AQGrower<MWSRQueueType>* cworker = new AQGrower<MWSRQueueType>( qt );
+    ThreadPool< AQGrower<MWSRQueueType> > pool(5, ORO_SCHED_OTHER, 20, 0.0, "AQGrower", qt);
     AQGrower<MWSRQueueType>* grower = new AQGrower<MWSRQueueType>( qt );
     AQEater<MWSRQueueType>* eater = new AQEater<MWSRQueueType>( qt );
+    boost::scoped_ptr<Activity> gthread( new Activity(20, grower, "AQGrower"));
+    boost::scoped_ptr<Activity> ethread( new Activity(20, eater, "AQEater"));
+
+    // avoid system lock-ups
+    gthread->thread()->setScheduler(ORO_SCHED_OTHER);
+    ethread->thread()->setScheduler(ORO_SCHED_OTHER);
 
     {
-        boost::scoped_ptr<Activity> athread( new Activity(20, aworker, "ActivityA" ));
-        boost::scoped_ptr<Activity> bthread( new Activity(20, bworker, "ActivityB" ));
-        boost::scoped_ptr<Activity> cthread( new Activity(20, cworker, "ActivityC" ));
-        boost::scoped_ptr<Activity> gthread( new Activity(20, grower, "ActivityG"));
-        boost::scoped_ptr<Activity> ethread( new Activity(20, eater, "ActivityE"));
-
-        // avoid system lock-ups
-        athread->thread()->setScheduler(ORO_SCHED_OTHER);
-        bthread->thread()->setScheduler(ORO_SCHED_OTHER);
-        cthread->thread()->setScheduler(ORO_SCHED_OTHER);
-        gthread->thread()->setScheduler(ORO_SCHED_OTHER);
-        ethread->thread()->setScheduler(ORO_SCHED_OTHER);
-
         log(Info) <<"Stressing multi-write/single-read..." <<endlog();
-        athread->start();
-        bthread->start();
-        cthread->start();
-        gthread->start();
-        ethread->start();
+        BOOST_REQUIRE(pool.start());
+        BOOST_REQUIRE(gthread->start());
+        BOOST_REQUIRE(ethread->start());
         sleep(5);
-        athread->stop();
-        bthread->stop();
-        cthread->stop();
+        BOOST_REQUIRE(pool.stop());
         log(Info) <<"Stressing single-write/single-read..." <<endlog();
         sleep(5);
-        gthread->stop();
-        ethread->stop();
+        BOOST_REQUIRE(gthread->stop());
+        BOOST_REQUIRE(ethread->stop());
     }
 
+    int appends = 0;
+    int erases = 0;
+    for(ThreadPool< AQGrower<MWSRQueueType> >::const_iterator it = pool.begin(); it != pool.end(); ++it) {
+        appends += it->first->appends;
+    }
+    appends += grower->appends;
+    erases += eater->erases;
+
     log(Info) << nlog()
-         << "Total appends: " << aworker->appends + bworker->appends + cworker->appends+ grower->appends<<endlog();
-    log(Info) << "Total erases : " << eater->erases <<endlog();
-    if (aworker->appends + bworker->appends + cworker->appends+ grower->appends != int(qt->size()) + eater->erases) {
+              << "Total appends: " << appends << endlog();
+    log(Info) << "Total erases : " << erases << endlog();
+    if (appends != int(qt->size()) + erases) {
         log(Info) << "Mismatch detected !" <<endlog();
     }
     int i = 0; // left-over count
@@ -1518,14 +1492,14 @@ BOOST_AUTO_TEST_CASE( testAtomicMWSRQueue )
     BOOST_CHECK_EQUAL( qt->size(), 0 );
 
     // assert: sum queues == sum dequeues
-    BOOST_CHECK_EQUAL( aworker->appends + bworker->appends + cworker->appends + grower->appends,
-                       i + eater->erases );
-    delete aworker;
-    delete bworker;
-    delete cworker;
+    BOOST_CHECK_EQUAL( appends,
+                       erases + i );
+
+    pool.clear();
     delete grower;
     delete eater;
     delete qt;
 }
-#endif
+
 BOOST_AUTO_TEST_SUITE_END()
+#endif

--- a/tests/buffers_test.cpp
+++ b/tests/buffers_test.cpp
@@ -36,6 +36,9 @@
 #include <os/Thread.hpp>
 #include <rtt-config.h>
 
+#include <boost/foreach.hpp>
+#include <boost/lexical_cast.hpp>
+
 using namespace std;
 using namespace RTT;
 using namespace RTT::detail;
@@ -73,27 +76,27 @@ public:
 };
 
 
-typedef AtomicQueue<Dummy*> QueueType;
+typedef AtomicMWMRQueue<Dummy*> MWMRQueueType;
 typedef AtomicMWSRQueue<Dummy*> MWSRQueueType;
 
 // Don't make queue size too large, we want to catch
 // overrun issues too.
 #define QS 10
 
-class BuffersAQueueTest
+class BuffersAtomicMWMRQueueTest
 {
 public:
-    AtomicQueue<Dummy*>* aqueue;
+    MWMRQueueType* aqueue;
     ThreadInterface* athread;
     ThreadInterface* bthread;
     ListLockFree<Dummy>* listlockfree;
 
-    BuffersAQueueTest()
+    BuffersAtomicMWMRQueueTest()
     {
-        aqueue = new AtomicQueue<Dummy*>(QS);
+        aqueue = new MWMRQueueType(QS);
         listlockfree = new ListLockFree<Dummy>(10, 4);
     }
-    ~BuffersAQueueTest(){
+    ~BuffersAtomicMWMRQueueTest(){
         aqueue->clear();
         delete aqueue;
         delete listlockfree;
@@ -103,15 +106,63 @@ public:
 class BuffersAtomicMWSRQueueTest
 {
 public:
-    AtomicMWSRQueue<Dummy*>* aqueue;
+    MWSRQueueType* aqueue;
 
     BuffersAtomicMWSRQueueTest()
     {
-        aqueue = new AtomicMWSRQueue<Dummy*>(QS);
+        aqueue = new MWSRQueueType(QS);
     }
     ~BuffersAtomicMWSRQueueTest(){
         aqueue->clear();
         delete aqueue;
+    }
+};
+
+template <class Worker>
+class ThreadPool : public std::vector< std::pair< shared_ptr<Worker>, shared_ptr<ThreadInterface> > >
+{
+public:
+    typedef std::vector< std::pair< shared_ptr<Worker>, shared_ptr<ThreadInterface> > > Threads;
+    using typename Threads::value_type;
+    using typename Threads::iterator;
+    using typename Threads::const_iterator;
+
+    template <typename Arg1>
+    ThreadPool(int threads, int scheduler, int priority, Seconds period, const std::string &name, const Arg1 &arg1)
+        : Threads(threads)
+    {
+        int count = 0;
+        for(iterator worker = this->begin(); worker != this->end(); ++worker) {
+            worker->first.reset(new Worker(arg1));
+            worker->second.reset(new Activity(scheduler, priority, period, worker->first.get(), name + boost::lexical_cast<std::string>(count++)));
+        }
+    }
+
+    ~ThreadPool()
+    {
+        stop();
+        for(iterator worker = this->begin(); worker != this->end(); ++worker) {
+            worker->second.reset();
+            worker->first.reset();
+        }
+    }
+
+    bool start()
+    {
+        bool result = true;
+        for(const_iterator worker = this->begin(); worker != this->end(); ++worker) {
+            if (!worker->second->start()) result = false;
+        }
+        return result;
+    }
+
+    bool stop()
+    {
+        bool result = true;
+        for(const_iterator worker = this->begin(); worker != this->end(); ++worker) {
+            worker->second->stop();
+        }
+        return result;
     }
 };
 
@@ -134,28 +185,30 @@ public:
     DataObjectLockFree<Dummy>* dlockfree;
     DataObjectUnSync<Dummy>* dunsync;
 
-    ThreadInterface* athread;
-    ThreadInterface* bthread;
-
     void testBuf();
     void testCirc();
     void testDObj();
 
+    typedef std::map<FlowStatus, int> ReadsByStatusMap;
+
+    void testBufMultiThreaded(int number_of_writers, int number_of_readers);
+    void testDObjMultiThreaded(int number_of_writers, int number_of_readers);
+
     BuffersDataFlowTest()
     {
-        // clasical variants
-        lockfree = new BufferLockFree<Dummy>(QS);
-        locked = new BufferLocked<Dummy>(QS);
-        unsync = new BufferUnSync<Dummy>(QS);
+        // classical variants
+        lockfree = new BufferLockFree<Dummy>(QS, Dummy());
+        locked = new BufferLocked<Dummy>(QS, Dummy());
+        unsync = new BufferUnSync<Dummy>(QS, Dummy());
 
         // circular variants.
-        clockfree = new BufferLockFree<Dummy>(QS,Dummy(), true);
-        clocked = new BufferLocked<Dummy>(QS,Dummy(), true);
-        cunsync = new BufferUnSync<Dummy>(QS,Dummy(), true);
+        clockfree = new BufferLockFree<Dummy>(QS, Dummy(), BufferBase::Options().circular(true));
+        clocked = new BufferLocked<Dummy>(QS, Dummy(), BufferBase::Options().circular(true));
+        cunsync = new BufferUnSync<Dummy>(QS, Dummy(), BufferBase::Options().circular(true));
 
-        dlockfree = new DataObjectLockFree<Dummy>();
-        dlocked   = new DataObjectLocked<Dummy>();
-        dunsync   = new DataObjectUnSync<Dummy>();
+        dlockfree = new DataObjectLockFree<Dummy>(Dummy());
+        dlocked   = new DataObjectLocked<Dummy>(Dummy());
+        dunsync   = new DataObjectUnSync<Dummy>(Dummy());
 
         // defaults
         buffer = lockfree;
@@ -173,6 +226,138 @@ public:
         delete dlocked;
         delete dunsync;
     }
+
+    class DataObjectWriter : public RunnableInterface {
+    private:
+        DataObjectInterface<Dummy> *dataobj;
+        bool stop;
+        Dummy sample;
+
+    public:
+        int writes;
+        int dropped;
+
+    public:
+        DataObjectWriter(DataObjectInterface<Dummy> *dataobj) : dataobj(dataobj), stop(false), writes(0), dropped(0) {}
+        bool initialize() {
+            stop = false;
+            return true;
+        }
+        void step() {
+            while (stop == false) {
+                if (dataobj->Set(sample)) {
+                    ++writes;
+                } else {
+                    ++dropped;
+                }
+            }
+        }
+
+        void finalize() {}
+
+        bool breakLoop() {
+            stop = true;
+            return true;
+        }
+    };
+
+    class DataObjectReader : public RunnableInterface {
+    private:
+        DataObjectInterface<Dummy> *dataobj;
+        bool stop;
+        Dummy sample;
+
+    public:
+        int reads;
+        ReadsByStatusMap reads_by_status;
+
+    public:
+        DataObjectReader(DataObjectInterface<Dummy> *dataobj) : dataobj(dataobj), stop(false), reads(0) {}
+        bool initialize() {
+            stop = false;
+            return true;
+        }
+        void step() {
+            while (stop == false) {
+                FlowStatus fs = dataobj->Get(sample, false);
+                ++reads;
+                ++reads_by_status[fs];
+            }
+        }
+
+        void finalize() {}
+
+        bool breakLoop() {
+            stop = true;
+            return true;
+        }
+    };
+
+    class BufferWriter : public RunnableInterface {
+    private:
+        BufferInterface<Dummy> *buffer;
+        bool stop;
+        Dummy sample;
+
+    public:
+        int writes;
+        int dropped;
+
+    public:
+        BufferWriter(BufferInterface<Dummy> *buffer) : buffer(buffer), stop(false), writes(0), dropped(0) {}
+        bool initialize() {
+            stop = false;
+            return true;
+        }
+        void step() {
+            while (stop == false) {
+                if (buffer->Push(sample)) {
+                    ++writes;
+                } else {
+                    ++dropped;
+                }
+            }
+        }
+
+        void finalize() {}
+
+        bool breakLoop() {
+            stop = true;
+            return true;
+        }
+    };
+
+    class BufferReader : public RunnableInterface {
+    private:
+        BufferInterface<Dummy> *buffer;
+        bool stop;
+        Dummy sample;
+
+    public:
+        int reads;
+        ReadsByStatusMap reads_by_status;
+
+    public:
+        BufferReader(BufferInterface<Dummy> *buffer) : buffer(buffer), stop(false), reads(0) {}
+        bool initialize() {
+            stop = false;
+            return true;
+        }
+        void step() {
+            while (stop == false) {
+                FlowStatus fs = buffer->Pop(sample);
+                ++reads;
+                ++reads_by_status[fs];
+            }
+        }
+
+        void finalize() {}
+
+        bool breakLoop() {
+            stop = true;
+            return true;
+        }
+    };
 };
 
 void BuffersDataFlowTest::testBuf()
@@ -468,6 +653,72 @@ void BuffersDataFlowTest::testDObj()
     delete c;
 }
 
+void BuffersDataFlowTest::testBufMultiThreaded(int number_of_writers, int number_of_readers)
+{
+    ThreadPool<BufferWriter> writers(number_of_writers, ORO_SCHED_OTHER, 0, 0, "BufferWriter", buffer);
+    ThreadPool<BufferReader> readers(number_of_readers, ORO_SCHED_OTHER, 0, 0, "BufferReader", buffer);
+
+    buffer->clear();
+
+    BOOST_REQUIRE( readers.start() );
+    BOOST_REQUIRE( writers.start() );
+    sleep(5);
+    BOOST_REQUIRE( writers.stop() );
+    BOOST_REQUIRE( readers.stop() );
+
+    int total_writes = 0, total_dropped = 0, total_reads = 0;
+    std::map<FlowStatus, int> total_reads_by_status;
+    BOOST_FOREACH(ThreadPool<BufferWriter>::value_type &writer, writers) {
+        total_writes += writer.first->writes;
+        BOOST_CHECK_GT(writer.first->writes, 0);
+    }
+    BOOST_FOREACH(ThreadPool<BufferReader>::value_type &reader, readers) {
+        total_reads += reader.first->reads;
+        BOOST_CHECK_GT(reader.first->reads, 0);
+        BOOST_FOREACH(ReadsByStatusMap::value_type &reads_by_status, reader.first->reads_by_status) {
+            total_reads_by_status[reads_by_status.first] += reads_by_status.second;
+        }
+    }
+
+    if (buffer != circular) {
+        BOOST_CHECK_EQUAL(total_writes, (total_reads_by_status[NewData] + buffer->size()));
+        BOOST_WARN_EQUAL(0, total_dropped);
+    } else {
+        BOOST_CHECK_GE(total_writes, (total_reads_by_status[NewData] + buffer->size()));
+        BOOST_CHECK_EQUAL(0, total_dropped);
+    }
+}
+
+void BuffersDataFlowTest::testDObjMultiThreaded(int number_of_writers, int number_of_readers)
+{
+    ThreadPool<DataObjectWriter> writers(number_of_writers, ORO_SCHED_OTHER, 0, 0, "DataObjectWriter", dataobj);
+    ThreadPool<DataObjectReader> readers(number_of_readers, ORO_SCHED_OTHER, 0, 0, "DataObjectReader", dataobj);
+
+    BOOST_REQUIRE( readers.start() );
+    BOOST_REQUIRE( writers.start() );
+    sleep(5);
+    BOOST_REQUIRE( writers.stop() );
+    BOOST_REQUIRE( readers.stop() );
+
+    int total_writes = 0, total_dropped = 0, total_reads = 0;
+    std::map<FlowStatus, int> total_reads_by_status;
+    BOOST_FOREACH(ThreadPool<DataObjectWriter>::value_type &writer, writers) {
+        total_writes += writer.first->writes;
+        BOOST_CHECK_GT(writer.first->writes, 0);
+    }
+    BOOST_FOREACH(ThreadPool<DataObjectReader>::value_type &reader, readers) {
+        total_reads += reader.first->reads;
+        BOOST_CHECK_GT(reader.first->reads, 0);
+        BOOST_FOREACH(ReadsByStatusMap::value_type &reads_by_status, reader.first->reads_by_status) {
+            total_reads_by_status[reads_by_status.first] += reads_by_status.second;
+        }
+    }
+
+    // BOOST_CHECK_EQUAL(total_writes, total_reads_by_status[NewData]);
+    BOOST_CHECK_GE(total_writes, total_reads_by_status[NewData]);
+    BOOST_WARN_EQUAL(total_dropped, 0);
+}
+
 class BuffersMPoolTest
 {
 public:
@@ -488,7 +739,73 @@ public:
         delete mpool;
         delete vpool;
     }
+
+    template <typename T>
+    class Worker : public base::RunnableInterface
+    {
+    private:
+        TsPool<T> *mpool;
+        bool stop;
+    public:
+        int cycles;
+
+        Worker(TsPool<T> *pool) : mpool(pool), stop(false), cycles(0) {}
+        bool initialize() {
+            stop = false;
+            return true;
+        }
+        void step() {
+            while( stop == false ) {
+                T *item;
+                BOOST_VERIFY( item = mpool->allocate() );
+                getThread()->yield();
+                if (item) BOOST_VERIFY(mpool->deallocate(item));
+                ++cycles;
+            }
+        }
+        bool breakLoop() {
+            stop = true;
+            return true;
+        }
+        void finalize() {}
+    };
+
+    void testMPoolMultiThreaded(int number_of_workers);
 };
+
+void BuffersMPoolTest::testMPoolMultiThreaded(int number_of_workers)
+{
+    {
+        BOOST_CHECK_EQUAL( mpool->size(), QS);
+        ThreadPool<BuffersMPoolTest::Worker<Dummy> > workers(number_of_workers, ORO_SCHED_OTHER, 0, 0, "BuffersMPoolWorker", mpool);
+        BOOST_REQUIRE( workers.start() );
+        sleep(5);
+        BOOST_REQUIRE( workers.stop() );
+        BOOST_CHECK_EQUAL( mpool->size(), QS);
+
+        int total_cycles = 0;
+        BOOST_FOREACH(ThreadPool<BuffersMPoolTest::Worker<Dummy> >::value_type &worker, workers) {
+            BOOST_CHECK_GT(worker.first->cycles, 0);
+            log(Info) << worker.second->getName() << ": " << worker.first->cycles << " cycles" << endlog();
+            total_cycles += worker.first->cycles;
+        }
+    }
+    {
+        BOOST_CHECK_EQUAL( vpool->size(), QS);
+        ThreadPool<BuffersMPoolTest::Worker<std::vector<Dummy> > > workers(number_of_workers, ORO_SCHED_OTHER, 0, 0, "BuffersVPoolWorker", vpool);
+        BOOST_REQUIRE( workers.start() );
+        sleep(5);
+        BOOST_REQUIRE( workers.stop() );
+        BOOST_CHECK_EQUAL( vpool->size(), QS);
+
+        int total_cycles = 0;
+        BOOST_FOREACH(ThreadPool<BuffersMPoolTest::Worker<std::vector<Dummy> > >::value_type &worker, workers) {
+            BOOST_CHECK_GT(worker.first->cycles, 0);
+            log(Info) << worker.second->getName() << ": " << worker.first->cycles << " cycles" << endlog();
+            total_cycles += worker.first->cycles;
+        }
+    }
+}
 
 
 std::ostream& operator<<( std::ostream& os, const Dummy& d )  {
@@ -526,12 +843,12 @@ struct LLFWorker : public RunnableInterface
     }
     void step() {
         while (stop == false ) {
-            //cout << "Appending, i="<<i<<endl;
+            //log(Info) << "Appending, i="<<i<<endlog();
             while ( mlst->append( Dummy(i,i,i) ) ) { ++i; ++appends; }
-            //cout << "Erasing, i="<<i<<endl;
+            //log(Info) << "Erasing, i="<<i<<endlog();
             while ( mlst->erase( Dummy(i-1,i-1,i-1) ) ) { --i; ++erases; }
         }
-        //cout << "Stopping, i="<<i<<endl;
+        //log(Info) << "Stopping, i="<<i<<endlog();
     }
 
     void finalize() {}
@@ -595,9 +912,9 @@ struct AQWorker : public RunnableInterface
     void step() {
         Dummy* d = orig;
         while (stop == false ) {
-            //cout << "Appending, i="<<i<<endl;
+            //log(Info) << "Appending, i="<<i<<endlog();
             if ( mlst->enqueue( d ) ) { ++appends; }
-            //cout << "Erasing, i="<<i<<endl;
+            //log(Info) << "Erasing, i="<<i<<endlog();
             if ( mlst->dequeue( d ) ) {
                 if( *d != *orig) {
                     os::MutexLock lock(m);
@@ -606,7 +923,7 @@ struct AQWorker : public RunnableInterface
                 ++erases;
             }
         }
-        //cout << "Stopping, i="<<i<<endl;
+        //log(Info) << "Stopping, i="<<i<<endlog();
     }
 
     void finalize() {}
@@ -695,9 +1012,9 @@ struct AQEater : public RunnableInterface
 };
 
 
-BOOST_FIXTURE_TEST_SUITE( BuffersAtomicTestSuite, BuffersAQueueTest )
+BOOST_FIXTURE_TEST_SUITE( BuffersAtomicMWMRQueueTestSuite, BuffersAtomicMWMRQueueTest )
 
-BOOST_AUTO_TEST_CASE( testAtomicQueue )
+BOOST_AUTO_TEST_CASE( testAtomicMWMRQueue )
 {
     /**
      * Single Threaded test for AtomicQueue.
@@ -737,7 +1054,7 @@ BOOST_AUTO_TEST_CASE( testAtomicQueue )
 }
 BOOST_AUTO_TEST_SUITE_END()
 
-BOOST_FIXTURE_TEST_SUITE( BuffersMWSRQueueTestSuite, BuffersAtomicMWSRQueueTest )
+BOOST_FIXTURE_TEST_SUITE( BuffersAtomicMWSRQueueTestSuite, BuffersAtomicMWSRQueueTest )
 
 BOOST_AUTO_TEST_CASE( testAtomicMWSRQueue )
 {
@@ -829,6 +1146,46 @@ BOOST_AUTO_TEST_CASE( testDObjUnSync )
     testDObj();
 }
 
+BOOST_AUTO_TEST_CASE( testBufLockFree4Writers1Reader )
+{
+    buffer = lockfree;
+    testBufMultiThreaded(4, 1);
+    buffer = circular = clockfree;
+    testBufMultiThreaded(4, 1);
+}
+
+BOOST_AUTO_TEST_CASE( testBufLockFree4Writers4Readers )
+{
+    buffer = new BufferLockFree<Dummy>(QS, Dummy(), BufferBase::Options().circular(false).multiple_readers(true));
+    testBufMultiThreaded(4, 4);
+    delete buffer;
+
+    buffer = circular = new BufferLockFree<Dummy>(QS, Dummy(), BufferBase::Options().circular(true).multiple_readers(true));
+    testBufMultiThreaded(4, 4);
+    delete buffer;
+}
+
+BOOST_AUTO_TEST_CASE( testBufLocked4Writers4Readers )
+{
+    buffer = locked;
+    testBufMultiThreaded(4, 4);
+    buffer = circular = clocked;
+    testBufMultiThreaded(4, 4);
+}
+
+BOOST_AUTO_TEST_CASE( testDObjLockFreeSingleWriter4Readers )
+{
+    dataobj = new DataObjectLockFree<Dummy>(Dummy(), /* max_threads = */ 5);
+    testDObjMultiThreaded(1, 4);
+    delete dataobj;
+}
+
+BOOST_AUTO_TEST_CASE( testDObjLockedSingleWriter4Readers )
+{
+    dataobj = dlocked;
+    testDObjMultiThreaded(1, 4);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_FIXTURE_TEST_SUITE( BuffersMPoolTestSuite, BuffersMPoolTest )
 
@@ -875,6 +1232,12 @@ BOOST_AUTO_TEST_CASE( testMemoryPool )
     }
     BOOST_CHECK_EQUAL( mpv.size(), 0 );
     BOOST_CHECK_EQUAL( mpool->size(), QS);
+}
+
+BOOST_AUTO_TEST_CASE( testMemoryPoolMultiThreaded )
+{
+    Logger::In in("testMemoryPoolMultiThreaded");
+    testMPoolMultiThreaded(QS);
 }
 
 #if 0
@@ -947,7 +1310,7 @@ BOOST_AUTO_TEST_CASE( testSortedList )
 #ifdef OROPKG_OS_GNULINUX
 
 BOOST_AUTO_TEST_SUITE_END()
-BOOST_FIXTURE_TEST_SUITE( BuffersStressLockFreeTestSuite, BuffersAQueueTest )
+BOOST_FIXTURE_TEST_SUITE( BuffersStressLockFreeTestSuite, BuffersAtomicMWMRQueueTest )
 
 BOOST_AUTO_TEST_CASE( testListLockFree )
 {
@@ -978,17 +1341,17 @@ BOOST_AUTO_TEST_CASE( testListLockFree )
     }
 
 #if 0
-    cout << "Athread appends: " << aworker->appends<<endl;
-    cout << "Athread erases: " << aworker->erases<<endl;
-    cout << "Bthread appends: " << bworker->appends<<endl;
-    cout << "Bthread erases: " << bworker->erases<<endl;
-    cout << "Cthread appends: " << cworker->appends<<endl;
-    cout << "Cthread erases: " << cworker->erases<<endl;
-    cout << "List capacity: "<< listlockfree->capacity()<<endl;
-    cout << "List size: "<< listlockfree->size()<<endl;
+    log(Info) << "Athread appends: " << aworker->appends<<endlog();
+    log(Info) << "Athread erases: " << aworker->erases<<endlog();
+    log(Info) << "Bthread appends: " << bworker->appends<<endlog();
+    log(Info) << "Bthread erases: " << bworker->erases<<endlog();
+    log(Info) << "Cthread appends: " << cworker->appends<<endlog();
+    log(Info) << "Cthread erases: " << cworker->erases<<endlog();
+    log(Info) << "List capacity: "<< listlockfree->capacity()<<endlog();
+    log(Info) << "List size: "<< listlockfree->size()<<endlog();
 //     while( listlockfree->empty() == false ) {
 //         Dummy d =  listlockfree->back();
-//         //cout << "Left: "<< d <<endl;
+//         //log(Info) << "Left: "<< d <<endlog();
 //         BOOST_CHECK( listlockfree->erase( d ) );
 //     }
 #endif
@@ -1007,12 +1370,14 @@ BOOST_AUTO_TEST_CASE( testListLockFree )
 #ifdef OROPKG_OS_GNULINUX
 BOOST_AUTO_TEST_CASE( testAtomicQueue )
 {
-    QueueType* qt = new QueueType(QS);
-    AQWorker<QueueType>* aworker = new AQWorker<QueueType>( qt );
-    AQWorker<QueueType>* bworker = new AQWorker<QueueType>( qt );
-    AQWorker<QueueType>* cworker = new AQWorker<QueueType>( qt );
-    AQGrower<QueueType>* grower = new AQGrower<QueueType>( qt );
-    AQEater<QueueType>* eater = new AQEater<QueueType>( qt );
+    Logger::In in("testAtomicQueue");
+
+    MWMRQueueType* qt = new MWMRQueueType(QS);
+    AQWorker<MWMRQueueType>* aworker = new AQWorker<MWMRQueueType>( qt );
+    AQWorker<MWMRQueueType>* bworker = new AQWorker<MWMRQueueType>( qt );
+    AQWorker<MWMRQueueType>* cworker = new AQWorker<MWMRQueueType>( qt );
+    AQGrower<MWMRQueueType>* grower = new AQGrower<MWMRQueueType>( qt );
+    AQEater<MWMRQueueType>* eater = new AQEater<MWMRQueueType>( qt );
 
     {
         boost::scoped_ptr<Activity> athread( new Activity(20, aworker, "ActivityA" ));
@@ -1049,11 +1414,11 @@ BOOST_AUTO_TEST_CASE( testAtomicQueue )
         ethread->stop();
     }
 
-    cout <<endl
-         << "Total appends: " << aworker->appends + bworker->appends + cworker->appends+ grower->appends<<endl;
-    cout << "Total erases : " << aworker->erases + bworker->erases+ cworker->erases + qt->size() + eater->erases <<endl;
+    log(Info) <<endlog()
+         << "Total appends: " << aworker->appends + bworker->appends + cworker->appends+ grower->appends<<endlog();
+    log(Info) << "Total erases : " << aworker->erases + bworker->erases+ cworker->erases + qt->size() + eater->erases <<endlog();
     if (aworker->appends + bworker->appends + cworker->appends+ grower->appends != aworker->erases + bworker->erases+ cworker->erases + int(qt->size()) + eater->erases) {
-        cout << "Mismatch detected !" <<endl;
+        log(Info) << "Mismatch detected !" <<endlog();
     }
     int i = 0; // left-over count
     Dummy* d = 0;
@@ -1067,7 +1432,7 @@ BOOST_AUTO_TEST_CASE( testAtomicQueue )
             break;
         }
     }
-    cout << "Left in Queue: "<< i <<endl;
+    log(Info) << "Left in Queue: "<< i <<endlog();
     BOOST_CHECK( qt->dequeue(d) == false );
     BOOST_CHECK( qt->dequeue(d) == false );
     BOOST_CHECK( qt->isEmpty() );
@@ -1085,6 +1450,8 @@ BOOST_AUTO_TEST_CASE( testAtomicQueue )
 
 BOOST_AUTO_TEST_CASE( testAtomicMWSRQueue )
 {
+    Logger::In in("testAtomicMWSRQueue");
+
     MWSRQueueType* qt = new MWSRQueueType(QS);
     AQGrower<MWSRQueueType>* aworker = new AQGrower<MWSRQueueType>( qt );
     AQGrower<MWSRQueueType>* bworker = new AQGrower<MWSRQueueType>( qt );
@@ -1122,11 +1489,11 @@ BOOST_AUTO_TEST_CASE( testAtomicMWSRQueue )
         ethread->stop();
     }
 
-    cout <<endl
-         << "Total appends: " << aworker->appends + bworker->appends + cworker->appends+ grower->appends<<endl;
-    cout << "Total erases : " << eater->erases <<endl;
+    log(Info) << nlog()
+         << "Total appends: " << aworker->appends + bworker->appends + cworker->appends+ grower->appends<<endlog();
+    log(Info) << "Total erases : " << eater->erases <<endlog();
     if (aworker->appends + bworker->appends + cworker->appends+ grower->appends != int(qt->size()) + eater->erases) {
-        cout << "Mismatch detected !" <<endl;
+        log(Info) << "Mismatch detected !" <<endlog();
     }
     int i = 0; // left-over count
     Dummy* d = 0;
@@ -1140,7 +1507,7 @@ BOOST_AUTO_TEST_CASE( testAtomicMWSRQueue )
             break;
         }
     }
-    cout << "Left in Queue: "<< i <<endl;
+    log(Info) << "Left in Queue: "<< i <<endlog();
     BOOST_CHECK( qt->dequeue(d) == false );
     BOOST_CHECK( qt->dequeue(d) == false );
     BOOST_CHECK( qt->isEmpty() );
@@ -1154,6 +1521,7 @@ BOOST_AUTO_TEST_CASE( testAtomicMWSRQueue )
     delete cworker;
     delete grower;
     delete eater;
+    delete qt;
 }
 #endif
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/ports_test.cpp
+++ b/tests/ports_test.cpp
@@ -161,12 +161,18 @@ BOOST_AUTO_TEST_CASE( testPortTaskInterface )
 BOOST_AUTO_TEST_CASE(testPortConnectionInitialization)
 {
     OutputPort<int> wp("WriterName", true);
-    InputPort<int> rp("ReaderName", ConnPolicy::data(true));
+    InputPort<int> rp("ReaderName", ConnPolicy::data(ConnPolicy::LOCK_FREE, true));
+
+    wp.setDataSample(-1);
 
     BOOST_CHECK( wp.createConnection(rp) );
     int value = 0;
     BOOST_CHECK( !rp.read(value) );
+    BOOST_CHECK_EQUAL( value, 0 );
     BOOST_CHECK( !wp.getLastWrittenValue(value) );
+    rp.getDataSample(value);
+    BOOST_CHECK_EQUAL( -1, value );
+
     wp.write(10);
     BOOST_CHECK( rp.read(value) );
     BOOST_CHECK_EQUAL( 10, value );


### PR DESCRIPTION
This pull request is part of a bigger effort to add support for new connection semantics to RTT (see #114).
- Moved storage of the `FlowStatus` to the `DataObjectInterface` or `BufferInterface` implementations instead as unprotected member variables of `ChannelDataElement`
- Decide whether to use an `AtomicMWMRQueue` (renamed from `AtomicQueue`) or an `AtomicMWSRQueue` in `BufferLockFree` depending on whether the buffer is circular or must support multiple reader threads.
  For a circular buffer also the writer thread may consume elements if the buffer is full, so the queue has to support multiple readers. This was broken in previous versions of RTT v2 and could lead to buffer corruption on concurrent writer/reader access.
- Added a boolean return value to `DataObjectInterface::Set()` in order to notify the caller whether setting the data object succeeded or not. It can only fail for `DataObjectLockFree` if too many readers try to access it concurrently.
- Allow to construct uninitialized data objects or buffers and added a boolean argument to `data_sample(...)` to enforce reinitialization or not
- Added base class `base::DataObjectBase` for all data object types, similar to existing `base::BufferBase`
- Added new structs `base::BufferBase::Options` and `base::DataObjectBase::Options` to pass options to the constructors of buffer and data objects to avoid ambiguity
- Store the ConnPolicy used to construct the data object or buffer in `ChannelDataElement` or `ChannelBufferElement`, respectively
- Added multi-threaded tests for class `TsPool`, data objects and buffers
