### PR TITLE
Added new mutex class SharedMutex which implements a shared lock ownership mode

### DIFF
--- a/rtt/os/CAS.hpp
+++ b/rtt/os/CAS.hpp
@@ -59,7 +59,9 @@ namespace RTT
      * Overload of Compare And Swap for oro_atomic_t.
      */
     inline bool CAS( volatile oro_atomic_t* addr, const int expected, const int value) {
-        return expected == oro_cmpxchg(&oro_atomic_read(addr), expected, value);
+        // assume that oro_atomic_read(addr) returns a reference
+        volatile int &ref = oro_atomic_read(addr);
+        return expected == oro_cmpxchg(&ref, expected, value);
     }
 
 }}

--- a/rtt/os/CAS.hpp
+++ b/rtt/os/CAS.hpp
@@ -51,8 +51,15 @@ namespace RTT
      * return \a false.
      */
     template< class T, class V, class W >
-    bool CAS( volatile T* addr, const V& expected, const W& value) {
+    inline bool CAS( volatile T* addr, const V& expected, const W& value) {
         return expected == oro_cmpxchg(addr, expected, value);
+    }
+
+    /**
+     * Overload of Compare And Swap for oro_atomic_t.
+     */
+    inline bool CAS( volatile oro_atomic_t* addr, const int expected, const int value) {
+        return expected == oro_cmpxchg(&oro_atomic_read(addr), expected, value);
     }
 
 }}

--- a/rtt/os/Mutex.hpp
+++ b/rtt/os/Mutex.hpp
@@ -42,6 +42,8 @@
 #include "fosi.h"
 #include "../rtt-config.h"
 #include "rtt-os-fwd.hpp"
+#include "CAS.hpp"
+#include "Semaphore.hpp"
 #include "Time.hpp"
 
 #include <cassert>
@@ -69,11 +71,11 @@ namespace RTT
 		virtual void lock() =0;
 		virtual void unlock() =0;
 		virtual bool trylock() = 0;
-		virtual bool timedlock(Seconds s) = 0;
+		virtual bool timedlock(Seconds) = 0;
         virtual void lock_shared() {}
         virtual void unlock_shared() {}
         virtual bool trylock_shared() { return false; }
-        virtual bool timedlock_shared(Seconds s) { return false; }
+        virtual bool timedlock_shared(Seconds) { return false; }
 	};
 
 
@@ -330,86 +332,108 @@ namespace RTT
     };
 
     /**
-     * @brief An object oriented wrapper around a shared mutex (multiple readers allowed).
+     * @brief An object oriented wrapper around a shared mutex
+     * (multiple readers allowed, but only one writer with exclusive access).
      *
      * A mutex can only be  unlock()'ed, by the thread which lock()'ed
      * it. A trylock is a non blocking lock action which fails or succeeds.
+     *
+     * Implementation is motivated by
+     * http://preshing.com/20150316/semaphores-are-surprisingly-versatile/#a-lightweight-semaphore-with-partial-spinning.
      *
      * @see MutexLock, MutexTryLock, SharedMutexLock, SharedMutexTryLock, Mutex
      */
     class RTT_API SharedMutex : public MutexInterface
     {
-#ifndef ORO_OS_USE_BOOST_THREAD
     protected:
-        rt_mutex_t m;
-        rt_cond_t shared_cond;
-        rt_cond_t exclusive_cond;
-        unsigned shared_count;
-        bool exclusive;
+        typedef unsigned int Status;
+        oro_atomic_t status;
+        Semaphore read_semaphore;
+        Semaphore write_semaphore;
+
+        static const Status one_reader       = (1 << 0);
+        static const Status one_wait_to_read = (1 << 10);
+        static const Status one_writer       = (1 << 20);
+        static const Status status_mask      = (1 << 10) - 1;
+
+        static inline unsigned int readers(Status status) {
+            return (status & status_mask);
+        }
+        static inline unsigned int waitToRead(Status status) {
+            return ((status >> 10) & status_mask);
+        }
+        static inline unsigned int writers(Status status) {
+            return ((status >> 20) & status_mask);
+        }
+
     public:
         /**
         * Initialize a shared Mutex.
         */
         SharedMutex()
-            : shared_count(0)
-            , exclusive(false)
+            : read_semaphore(0)
+            , write_semaphore(0)
         {
-            rtos_mutex_init( &m );
-            rtos_cond_init( &shared_cond );
-            rtos_cond_init( &exclusive_cond );
+            ORO_ATOMIC_SETUP( &status, 0 );
         }
 
         /**
         * Destroy a shared Mutex.
-        * If the Mutex is still locked, the RTOS
-        * will not be asked to clean up its resources.
         */
         virtual ~SharedMutex()
         {
-            if ( trylock() ) {
-                unlock();
-                rtos_mutex_destroy( &m );
-                rtos_cond_destroy( &shared_cond );
-                rtos_cond_destroy( &exclusive_cond );
-            }
+            ORO_ATOMIC_CLEANUP( &status );
         }
 
         virtual void lock ()
         {
-            rtos_mutex_lock( &m );
-            while (shared_count || exclusive) {
-                rtos_cond_wait(&exclusive_cond, &m);
+            Status old_status, new_status;
+            do {
+                new_status = old_status = (Status) oro_atomic_read( &status );
+                new_status += one_writer;
+                assert(writers(new_status) > 0);  // overflow?
+            } while(!CAS(&status, (int) old_status, (int) new_status));
+
+            if (readers(old_status) > 0 || writers(old_status) > 0) {
+                write_semaphore.wait();
             }
-            exclusive = true;
-            rtos_mutex_unlock( &m );
         }
 
         virtual void unlock()
         {
-            rtos_mutex_lock( &m );
-            assert(shared_count == 0);
-            assert(exclusive);
-            exclusive = false;
-            rtos_cond_broadcast( &exclusive_cond );
-            rtos_cond_broadcast( &shared_cond );
-            rtos_mutex_unlock( &m );
+            Status old_status, new_status;
+            unsigned int wait_to_read = 0;
+            do {
+                new_status = old_status = (Status) oro_atomic_read( &status );
+                assert(readers(old_status) == 0);
+                assert(writers(old_status) > 0);
+                new_status -= one_writer;
+                wait_to_read = waitToRead(old_status);
+                if (wait_to_read > 0) {
+                    // all waiting threads can be unblocked
+                    new_status = (new_status & (status_mask << 20)) | wait_to_read;
+                }
+            } while(!CAS(&status, (int) old_status, (int) new_status));
+
+            // Signal threads that have been waiting for a read lock
+            if (wait_to_read > 0) {
+                for(unsigned int i = 0; i < wait_to_read; ++i) read_semaphore.signal();
+            } else
+            // ... or signal a thread that has been waiting for a write lock
+            if (writers(old_status) > 1) {
+                write_semaphore.signal();
+            }
         }
 
         /**
         * Try to lock this mutex exclusively
         *
-        * @return true when the locking succeeded, false otherwise
+        * @note not implemented for this type of mutex
+        * @return false
         */
         virtual bool trylock()
         {
-            rtos_mutex_lock( &m );
-            if (shared_count || exclusive) {
-                rtos_mutex_unlock( &m );
-                return false;
-            }
-            exclusive = true;
-            rtos_mutex_unlock( &m );
-            return true;
+            return false;
         }
 
         /**
@@ -417,21 +441,14 @@ namespace RTT
         * than the specified timeout.
         *
         * @param  s The maximum time to wait before aqcuiring the lock.
-        * @return true when the locking succeeded, false otherwise
+        *
+        * @note not implemented for this type of mutex
+        * @return false
         */
         virtual bool timedlock(Seconds s)
         {
-            RTT::nsecs abs_time = rtos_get_time_ns() + Seconds_to_nsecs(s);
-            rtos_mutex_lock( &m );
-            while (shared_count || exclusive) {
-                if ( rtos_cond_timedwait( &exclusive_cond, &m, abs_time ) != 0 ) {
-                    rtos_mutex_unlock( &m );
-                    return false;
-                }
-            }
-            exclusive = true;
-            rtos_mutex_unlock( &m );
-            return true;
+            (void) s;
+            return false;
         }
 
         /**
@@ -439,124 +456,22 @@ namespace RTT
          */
         void lock_shared ()
         {
-            rtos_mutex_lock( &m );
-            while (exclusive) {
-                rtos_cond_wait(&shared_cond, &m);
-            }
-            shared_count++;
-            rtos_mutex_unlock( &m );
-        }
-
-        /**
-         * Release shared ownership of this mutex.
-         */
-        virtual void unlock_shared()
-        {
-            rtos_mutex_lock( &m );
-            assert(shared_count > 0);
-            assert(!exclusive);
-            if (shared_count > 0) shared_count--;
-            rtos_cond_broadcast( &exclusive_cond );
-            rtos_mutex_unlock( &m );
-        }
-
-        /**
-        * Attempt to obtain shared ownership of this mutex
-        *
-        * @return true when the locking succeeded, false otherwise
-        */
-        virtual bool trylock_shared()
-        {
-            rtos_mutex_lock( &m );
-            if (exclusive) {
-                rtos_mutex_unlock( &m );
-                return false;
-            }
-            shared_count++;
-            rtos_mutex_unlock( &m );
-            return true;
-        }
-
-        /**
-        * Attempt to obtain shared ownership of this mutex, but don't wait longer for the lock
-        * than the specified timeout.
-        *
-        * @param  s The maximum time to wait before aqcuiring the lock.
-        * @return true when the locking succeeded, false otherwise
-        */
-        virtual bool timedlock_shared(Seconds s)
-        {
-            RTT::nsecs abs_time = rtos_get_time_ns() + Seconds_to_nsecs(s);
-            rtos_mutex_lock( &m );
-            while (exclusive) {
-                if ( rtos_cond_timedwait( &shared_cond, &m, abs_time ) != 0 ) {
-                    rtos_mutex_unlock( &m );
-                    return false;
+            Status old_status, new_status;
+            do {
+                new_status = old_status = (Status) oro_atomic_read( &status );
+                if (writers(old_status) > 0) {
+                    new_status += one_wait_to_read;
+                    assert(waitToRead(new_status) > 0);  // overflow?
+                } else {
+                    new_status += one_reader;
+                    assert(readers(new_status) > 0);  // overflow?
                 }
+            } while(!CAS(&status, (int) old_status, (int) new_status));
+
+            // wait until all writers are finished
+            if (writers(old_status) > 0) {
+                read_semaphore.wait();
             }
-            shared_count++;
-            rtos_mutex_unlock( &m );
-            return true;
-        }
-
-#else
-    protected:
-        boost::shared_mutex sharedm;
-    public:
-        /**
-         * Initialize a shared Mutex.
-         */
-        SharedMutex()
-        {
-        }
-
-        /**
-        * Destroy a SharedMutex.
-        * If the SharedMutex is still locked, the RTOS
-        * will not be asked to clean up its resources.
-        */
-        virtual ~SharedMutex()
-        {
-        }
-
-        void lock ()
-        {
-            sharedm.lock();
-        }
-
-        virtual void unlock()
-        {
-            sharedm.unlock();
-        }
-
-        /**
-        * Try to lock this mutex
-        *
-        * @return true when the locking succeeded, false otherwise
-        */
-        virtual bool trylock()
-        {
-            return sharedm.try_lock();
-        }
-
-        /**
-        * Lock this mutex, but don't wait longer for the lock
-        * than the specified timeout.
-        *
-        * @param  s The maximum time to wait before aqcuiring the lock.
-        * @return true when the locking succeeded, false otherwise
-        */
-        virtual bool timedlock(Seconds s)
-        {
-            return sharedm.timed_lock( boost::posix_time::microseconds( Seconds_to_nsecs(s)/1000 ) );
-        }
-
-        /**
-         * Obtain shared ownership of this mutex.
-         */
-        void lock_shared ()
-        {
-            sharedm.lock_shared();
         }
 
         /**
@@ -564,17 +479,28 @@ namespace RTT
          */
         virtual void unlock_shared()
         {
-            sharedm.unlock_shared();
+            Status old_status, new_status;
+            do {
+                new_status = old_status = (Status) oro_atomic_read( &status );
+                assert(readers(old_status) > 0);
+                new_status -= one_reader;
+            } while(!CAS(&status, (int) old_status, (int) new_status));
+
+            // one writer thread can be unblocked if there are no more readers
+            if (readers(old_status) == 1 && writers(old_status) > 0) {
+                write_semaphore.signal();
+            }
         }
 
         /**
         * Attempt to obtain shared ownership of this mutex
         *
-        * @return true when the locking succeeded, false otherwise
+        * @note not implemented for this type of mutex
+        * @return false
         */
         virtual bool trylock_shared()
         {
-            return sharedm.try_lock_shared();
+            return false;
         }
 
         /**
@@ -582,13 +508,15 @@ namespace RTT
         * than the specified timeout.
         *
         * @param  s The maximum time to wait before aqcuiring the lock.
-        * @return true when the locking succeeded, false otherwise
+        *
+        * @note not implemented for this type of mutex
+        * @return false
         */
         virtual bool timedlock_shared(Seconds s)
         {
-            return sharedm.timed_lock_shared( boost::posix_time::microseconds( Seconds_to_nsecs(s)/1000 ) );
+            (void) s;
+            return false;
         }
-#endif
     };
 
 }}

--- a/rtt/os/Mutex.hpp
+++ b/rtt/os/Mutex.hpp
@@ -43,6 +43,9 @@
 #include "../rtt-config.h"
 #include "rtt-os-fwd.hpp"
 #include "Time.hpp"
+
+#include <cassert>
+
 #ifdef ORO_OS_USE_BOOST_THREAD
 // BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG is defined in rtt-config.h
 #include <boost/thread/mutex.hpp>

--- a/rtt/os/Mutex.hpp
+++ b/rtt/os/Mutex.hpp
@@ -47,6 +47,7 @@
 // BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG is defined in rtt-config.h
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
+#include <boost/thread/shared_mutex.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #endif
 
@@ -56,7 +57,7 @@ namespace RTT
     /**
      * @brief An interface to a Mutex.
      *
-     * @see MutexLock, MutexTryLock, MutexRecursive
+     * @see MutexLock, MutexTryLock, MutexRecursive, SharedMutexLock
      */
 	class RTT_API MutexInterface
 	{
@@ -66,6 +67,10 @@ namespace RTT
 		virtual void unlock() =0;
 		virtual bool trylock() = 0;
 		virtual bool timedlock(Seconds s) = 0;
+        virtual void lock_shared() {}
+        virtual void unlock_shared() {}
+        virtual bool trylock_shared() { return false; }
+        virtual bool timedlock_shared(Seconds s) { return false; }
 	};
 
 
@@ -317,6 +322,268 @@ namespace RTT
         virtual bool timedlock(Seconds s)
         {
             return recm.timed_lock( boost::posix_time::microseconds( Seconds_to_nsecs(s)/1000 ) );
+        }
+#endif
+    };
+
+    /**
+     * @brief An object oriented wrapper around a shared mutex (multiple readers allowed).
+     *
+     * A mutex can only be  unlock()'ed, by the thread which lock()'ed
+     * it. A trylock is a non blocking lock action which fails or succeeds.
+     *
+     * @see MutexLock, MutexTryLock, SharedMutexLock, SharedMutexTryLock, Mutex
+     */
+    class RTT_API SharedMutex : public MutexInterface
+    {
+#ifndef ORO_OS_USE_BOOST_THREAD
+    protected:
+        rt_mutex_t m;
+        rt_cond_t shared_cond;
+        rt_cond_t exclusive_cond;
+        unsigned shared_count;
+        bool exclusive;
+    public:
+        /**
+        * Initialize a shared Mutex.
+        */
+        SharedMutex()
+            : shared_count(0)
+            , exclusive(false)
+        {
+            rtos_mutex_init( &m );
+            rtos_cond_init( &shared_cond );
+            rtos_cond_init( &exclusive_cond );
+        }
+
+        /**
+        * Destroy a shared Mutex.
+        * If the Mutex is still locked, the RTOS
+        * will not be asked to clean up its resources.
+        */
+        virtual ~SharedMutex()
+        {
+            if ( trylock() ) {
+                unlock();
+                rtos_mutex_destroy( &m );
+                rtos_cond_destroy( &shared_cond );
+                rtos_cond_destroy( &exclusive_cond );
+            }
+        }
+
+        virtual void lock ()
+        {
+            rtos_mutex_lock( &m );
+            while (shared_count || exclusive) {
+                rtos_cond_wait(&exclusive_cond, &m);
+            }
+            exclusive = true;
+            rtos_mutex_unlock( &m );
+        }
+
+        virtual void unlock()
+        {
+            rtos_mutex_lock( &m );
+            assert(shared_count == 0);
+            assert(exclusive);
+            exclusive = false;
+            rtos_cond_broadcast( &exclusive_cond );
+            rtos_cond_broadcast( &shared_cond );
+            rtos_mutex_unlock( &m );
+        }
+
+        /**
+        * Try to lock this mutex exclusively
+        *
+        * @return true when the locking succeeded, false otherwise
+        */
+        virtual bool trylock()
+        {
+            rtos_mutex_lock( &m );
+            if (shared_count || exclusive) {
+                rtos_mutex_unlock( &m );
+                return false;
+            }
+            exclusive = true;
+            rtos_mutex_unlock( &m );
+            return true;
+        }
+
+        /**
+        * Lock this mutex exclusively, but don't wait longer for the lock
+        * than the specified timeout.
+        *
+        * @param  s The maximum time to wait before aqcuiring the lock.
+        * @return true when the locking succeeded, false otherwise
+        */
+        virtual bool timedlock(Seconds s)
+        {
+            RTT::nsecs abs_time = rtos_get_time_ns() + Seconds_to_nsecs(s);
+            rtos_mutex_lock( &m );
+            while (shared_count || exclusive) {
+                if ( rtos_cond_timedwait( &exclusive_cond, &m, abs_time ) != 0 ) {
+                    rtos_mutex_unlock( &m );
+                    return false;
+                }
+            }
+            exclusive = true;
+            rtos_mutex_unlock( &m );
+            return true;
+        }
+
+        /**
+         * Obtain shared ownership of this mutex.
+         */
+        void lock_shared ()
+        {
+            rtos_mutex_lock( &m );
+            while (exclusive) {
+                rtos_cond_wait(&shared_cond, &m);
+            }
+            shared_count++;
+            rtos_mutex_unlock( &m );
+        }
+
+        /**
+         * Release shared ownership of this mutex.
+         */
+        virtual void unlock_shared()
+        {
+            rtos_mutex_lock( &m );
+            assert(shared_count > 0);
+            assert(!exclusive);
+            if (shared_count > 0) shared_count--;
+            rtos_cond_broadcast( &exclusive_cond );
+            rtos_mutex_unlock( &m );
+        }
+
+        /**
+        * Attempt to obtain shared ownership of this mutex
+        *
+        * @return true when the locking succeeded, false otherwise
+        */
+        virtual bool trylock_shared()
+        {
+            rtos_mutex_lock( &m );
+            if (exclusive) {
+                rtos_mutex_unlock( &m );
+                return false;
+            }
+            shared_count++;
+            rtos_mutex_unlock( &m );
+            return true;
+        }
+
+        /**
+        * Attempt to obtain shared ownership of this mutex, but don't wait longer for the lock
+        * than the specified timeout.
+        *
+        * @param  s The maximum time to wait before aqcuiring the lock.
+        * @return true when the locking succeeded, false otherwise
+        */
+        virtual bool timedlock_shared(Seconds s)
+        {
+            RTT::nsecs abs_time = rtos_get_time_ns() + Seconds_to_nsecs(s);
+            rtos_mutex_lock( &m );
+            while (exclusive) {
+                if ( rtos_cond_timedwait( &shared_cond, &m, abs_time ) != 0 ) {
+                    rtos_mutex_unlock( &m );
+                    return false;
+                }
+            }
+            shared_count++;
+            rtos_mutex_unlock( &m );
+            return true;
+        }
+
+#else
+    protected:
+        boost::shared_mutex sharedm;
+    public:
+        /**
+         * Initialize a shared Mutex.
+         */
+        SharedMutex()
+        {
+        }
+
+        /**
+        * Destroy a SharedMutex.
+        * If the SharedMutex is still locked, the RTOS
+        * will not be asked to clean up its resources.
+        */
+        virtual ~SharedMutex()
+        {
+        }
+
+        void lock ()
+        {
+            sharedm.lock();
+        }
+
+        virtual void unlock()
+        {
+            sharedm.unlock();
+        }
+
+        /**
+        * Try to lock this mutex
+        *
+        * @return true when the locking succeeded, false otherwise
+        */
+        virtual bool trylock()
+        {
+            return sharedm.try_lock();
+        }
+
+        /**
+        * Lock this mutex, but don't wait longer for the lock
+        * than the specified timeout.
+        *
+        * @param  s The maximum time to wait before aqcuiring the lock.
+        * @return true when the locking succeeded, false otherwise
+        */
+        virtual bool timedlock(Seconds s)
+        {
+            return sharedm.timed_lock( boost::posix_time::microseconds( Seconds_to_nsecs(s)/1000 ) );
+        }
+
+        /**
+         * Obtain shared ownership of this mutex.
+         */
+        void lock_shared ()
+        {
+            sharedm.lock_shared();
+        }
+
+        /**
+         * Release shared ownership of this mutex.
+         */
+        virtual void unlock_shared()
+        {
+            sharedm.unlock_shared();
+        }
+
+        /**
+        * Attempt to obtain shared ownership of this mutex
+        *
+        * @return true when the locking succeeded, false otherwise
+        */
+        virtual bool trylock_shared()
+        {
+            return sharedm.try_lock_shared();
+        }
+
+        /**
+        * Attempt to obtain shared ownership of this mutex, but don't wait longer for the lock
+        * than the specified timeout.
+        *
+        * @param  s The maximum time to wait before aqcuiring the lock.
+        * @return true when the locking succeeded, false otherwise
+        */
+        virtual bool timedlock_shared(Seconds s)
+        {
+            return sharedm.timed_lock_shared( boost::posix_time::microseconds( Seconds_to_nsecs(s)/1000 ) );
         }
 #endif
     };

--- a/rtt/os/MutexLock.hpp
+++ b/rtt/os/MutexLock.hpp
@@ -196,6 +196,40 @@ namespace RTT
              bool successful;
 
      };
+
+     /**
+      * @brief SharedMutexLock is a scope based Monitor, protecting critical
+      * sections with a SharedMutex object through locking and unlocking it.
+      */
+     class RTT_API SharedMutexLock
+     {
+
+         public:
+             /**
+              * Create a shared lock on a SharedMutex object.
+              *
+              * @param mutex The Mutex to be locked.
+              */
+             SharedMutexLock( MutexInterface &mutex )
+             {
+                 _mutex = &mutex;
+                 _mutex->lock_shared ();
+             }
+
+             /**
+              * Remove a lock from a SharedMutex object
+              */
+             ~SharedMutexLock()
+             {
+                 _mutex->unlock_shared();
+             }
+
+         protected:
+             MutexInterface *_mutex;
+
+             SharedMutexLock()
+             {}
+     };
 }}
 
 #endif

--- a/rtt/os/oro_arch_interface.h
+++ b/rtt/os/oro_arch_interface.h
@@ -55,12 +55,22 @@ void oro_atomic_set(oro_atomic_t* a, int n);
 void oro_atomic_add(oro_atomic_t *a, int n);
 
 /**
- * Substract n from a
+ * Add n to a and return the new value
+ */
+int oro_atomic_add_return(oro_atomic_t *a, int n);
+
+/**
+ * Subtract n from a
  */
 void oro_atomic_sub(int n, oro_atomic_t *a, int n);
 
 /**
- * Substract n from a and test for zero
+ * Subtract n from a and return the new value
+ */
+int oro_atomic_sub_return(int n, oro_atomic_t *a, int n);
+
+/**
+ * Subtract n from a and test for zero
  */
 int oro_atomic_sub_and_test(oro_atomic_t *a, int n);
 
@@ -70,9 +80,19 @@ int oro_atomic_sub_and_test(oro_atomic_t *a, int n);
 void oro_atomic_inc(oro_atomic_t *a);
 
 /**
+ * Increment a atomically and return the new value
+ */
+int oro_atomic_inc_return(oro_atomic_t *a);
+
+/**
  * Decrement a atomically
  */
 void oro_atomic_dec(oro_atomic_t *a);
+
+/**
+ * Decrement a atomically and return the new value
+ */
+int oro_atomic_dec_return(oro_atomic_t *a);
 
 /**
  * Decrement a atomically and test for zero.

--- a/rtt/os/oro_gcc/oro_arch.h
+++ b/rtt/os/oro_gcc/oro_arch.h
@@ -27,7 +27,15 @@ static __inline__ void oro_atomic_add(oro_atomic_t *a_int, int n)
 }
 
 /**
- * Substract n from a_int
+ * Add n to a_int and return the new value
+ */
+static __inline__ int oro_atomic_add_return(oro_atomic_t *a_int, int n)
+{
+    return __sync_add_and_fetch(&a_int->cnt, n);
+}
+
+/**
+ * Subtract n from a_int
  */
 static __inline__ void oro_atomic_sub(oro_atomic_t *a_int, int n)
 {
@@ -35,7 +43,15 @@ static __inline__ void oro_atomic_sub(oro_atomic_t *a_int, int n)
 }
 
 /**
- * Substract n from a_int and test for zero
+ * Subtract n from a_int and return the new value
+ */
+static __inline__ int oro_atomic_sub_return(oro_atomic_t *a_int, int n)
+{
+    return __sync_sub_and_fetch(&a_int->cnt, n);
+}
+
+/**
+ * Subtract n from a_int and test for zero
  */
 static __inline__ int oro_atomic_sub_and_test(oro_atomic_t *a_int, int n)
 {
@@ -51,11 +67,27 @@ static __inline__ void oro_atomic_inc(oro_atomic_t *a_int)
 }
 
 /**
+ * Increment a_int atomically and return the new value
+ */
+static __inline__ int oro_atomic_inc_return(oro_atomic_t *a_int)
+{
+    return __sync_fetch_and_add(&a_int->cnt, 1);
+}
+
+/**
  * Decrement a_int atomically
  */
 static __inline__ void oro_atomic_dec(oro_atomic_t *a_int)
 {
     (void)__sync_fetch_and_sub(&a_int->cnt, 1);
+}
+
+/**
+ * Decrement a_int atomically and return the new value
+ */
+static __inline__ int oro_atomic_dec_return(oro_atomic_t *a_int)
+{
+    return __sync_fetch_and_sub(&a_int->cnt, 1);
 }
 
 /**

--- a/rtt/os/oro_i386/oro_arch.h
+++ b/rtt/os/oro_i386/oro_arch.h
@@ -64,12 +64,28 @@ static __inline__ void oro_atomic_add( oro_atomic_t *v, int i)
 		:"ir" (i), "m" (v->counter));
 }
 
+static __inline__ int oro_atomic_add_return( oro_atomic_t *v, int i)
+{
+  /* Modern 486+ processor */
+	int __i = i;
+	__asm__ __volatile__(
+		ORO_LOCK "xaddl %0, %1"
+		: "+r" (i), "+m" (v->counter)
+		: : "memory");
+	return i + __i;
+}
+
 static __inline__ void oro_atomic_sub( oro_atomic_t *v, int i)
 {
 	__asm__ __volatile__(
 		ORO_LOCK "subl %1,%0"
 		:"=m" (v->counter)
 		:"ir" (i), "m" (v->counter));
+}
+
+static __inline__ int oro_atomic_sub_return( oro_atomic_t *v, int i)
+{
+	return oro_atomic_add_return( v, -i );
 }
 
 static __inline__ void oro_atomic_inc(oro_atomic_t *v)
@@ -87,6 +103,9 @@ static __inline__ void oro_atomic_dec(oro_atomic_t *v)
 		:"=m" (v->counter)
 		:"m" (v->counter));
 }
+
+#define oro_atomic_inc_return(v) (oro_atomic_add_return(v, 1))
+#define oro_atomic_dec_return(v) (oro_atomic_sub_return(v, 1))
 
 static __inline__ int oro_atomic_dec_and_test(oro_atomic_t *v)
 {

--- a/rtt/os/oro_noasm/oro_arch.h
+++ b/rtt/os/oro_noasm/oro_arch.h
@@ -73,9 +73,23 @@ static __inline__ void oro_atomic_add(oro_atomic_t *a_int, int n )
   rtos_mutex_lock(&((a_int)->m)); (a_int)->cnter += n; rtos_mutex_unlock(&((a_int)->m));
 }
 
+static __inline__ int oro_atomic_add_return(oro_atomic_t *a_int, int n )
+{
+  int new_value;
+  rtos_mutex_lock(&((a_int)->m)); new_value = ((a_int)->cnter += n); rtos_mutex_unlock(&((a_int)->m));
+  return new_value;
+}
+
 static __inline__ void oro_atomic_sub(oro_atomic_t *a_int, int n )
 {
   rtos_mutex_lock(&((a_int)->m)); (a_int)->cnter -= n; rtos_mutex_unlock(&((a_int)->m));
+}
+
+static __inline__ int oro_atomic_sub_return(oro_atomic_t *a_int, int n )
+{
+  int new_value;
+  rtos_mutex_lock(&((a_int)->m)); new_value = ((a_int)->cnter -= n); rtos_mutex_unlock(&((a_int)->m));
+  return new_value;
 }
 
 static __inline__ int oro_atomic_add_and_test(oro_atomic_t *a_int, int n )
@@ -97,9 +111,23 @@ static __inline__ void oro_atomic_inc(oro_atomic_t *a_int)
   rtos_mutex_lock(&((a_int)->m)); ++((a_int)->cnter) ; rtos_mutex_unlock(&((a_int)->m));
 }
 
+static __inline__ int oro_atomic_inc_return(oro_atomic_t *a_int)
+{
+  int new_value;
+  rtos_mutex_lock(&((a_int)->m)); new_value = (++((a_int)->cnter)) ; rtos_mutex_unlock(&((a_int)->m));
+  return new_value;
+}
+
 static __inline__ void oro_atomic_dec(oro_atomic_t *a_int)
 {
   rtos_mutex_lock(&((a_int)->m)); --((a_int)->cnter) ; rtos_mutex_unlock(&((a_int)->m));
+}
+
+static __inline__ int oro_atomic_dec_return(oro_atomic_t *a_int)
+{
+  int new_value;
+  rtos_mutex_lock(&((a_int)->m)); new_value = (--((a_int)->cnter)) ; rtos_mutex_unlock(&((a_int)->m));
+  return new_value;
 }
 
 static __inline__ int oro_atomic_dec_and_test(oro_atomic_t *a_int)

--- a/rtt/os/oro_x86_64/oro_arch.h
+++ b/rtt/os/oro_x86_64/oro_arch.h
@@ -64,12 +64,27 @@ static __inline__ void oro_atomic_add(oro_atomic_t *v, int i)
 		:"ir" (i), "m" (v->counter));
 }
 
+static __inline__ int oro_atomic_add_return(oro_atomic_t *v, int i)
+{
+	int __i = i;
+	__asm__ __volatile__(
+		ORO_LOCK "xaddl %0, %1"
+		: "+r" (i), "+m" (v->counter)
+		: : "memory");
+	return i + __i;
+}
+
 static __inline__ void oro_atomic_sub(oro_atomic_t *v, int i)
 {
 	__asm__ __volatile__(
 		ORO_LOCK "subl %1,%0"
 		:"=m" (v->counter)
 		:"ir" (i), "m" (v->counter));
+}
+
+static __inline__ int oro_atomic_sub_return(oro_atomic_t *v, int i)
+{
+	return oro_atomic_add_return(v, -i);
 }
 
 static __inline__ int oro_atomic_sub_and_test(oro_atomic_t *v, int i)
@@ -98,6 +113,9 @@ static __inline__ void oro_atomic_dec(oro_atomic_t *v)
 		:"=m" (v->counter)
 		:"m" (v->counter));
 }
+
+#define oro_atomic_inc_return(v)  (oro_atomic_add_return(v, 1))
+#define oro_atomic_dec_return(v)  (oro_atomic_sub_return(v, 1))
 
 static __inline__ int oro_atomic_dec_and_test(oro_atomic_t *v)
 {

--- a/rtt/os/rtt-os-fwd.hpp
+++ b/rtt/os/rtt-os-fwd.hpp
@@ -12,6 +12,8 @@ namespace RTT {
         class MutexRecursive;
         class MutexTimedLock;
         class MutexTryLock;
+        class SharedMutex;
+        class SharedMutexLock;
         class Semaphore;
         class StartStopManager;
         class Thread;


### PR DESCRIPTION
This pull request is part of a bigger effort to add support for new connection semantics to RTT (see #114).

The new mutex type implements a shared ownership lock that allows concurrent access to shared data by multiple readers and exclusive access for writers. This lock type is used to protect the input and output pointers lists in the new `ChannelElementBase` implementations.

The concept of a shared mutex is targeted to be added to the C++ standard library sooner or later as [std::shared_mutex](http://en.cppreference.com/w/cpp/thread/shared_mutex) and provided by the Boost thread library as [boost::shared_mutex](http://www.boost.org/doc/libs/1_54_0/doc/html/thread/synchronization.html#thread.synchronization.locks.shared_lock).
