### PR TITLE
Added test suite to test connecting and disconnecting ports concurrently

### DIFF
--- a/rtt/base/PortInterface.cpp
+++ b/rtt/base/PortInterface.cpp
@@ -64,6 +64,10 @@ PortInterface& PortInterface::doc(const std::string& desc) {
     return *this;
 }
 
+bool PortInterface::connectedTo(PortInterface* port) {
+    return cmanager.connectedTo(port);
+}
+
 bool PortInterface::isLocal() const
 { return serverProtocol() == 0; }
 int PortInterface::serverProtocol() const

--- a/rtt/base/PortInterface.hpp
+++ b/rtt/base/PortInterface.hpp
@@ -103,6 +103,9 @@ namespace RTT
         /** Returns true if this port is connected */
         virtual bool connected() const = 0;
 
+        /** Returns true if this port is connected to the given port*/
+        virtual bool connectedTo(PortInterface* port);
+
         /** Returns the types::TypeInfo object for the port's type */
         virtual const types::TypeInfo* getTypeInfo() const = 0;
 

--- a/rtt/internal/ConnFactory.hpp
+++ b/rtt/internal/ConnFactory.hpp
@@ -488,6 +488,11 @@ namespace RTT
                 return false;
             }
 
+            if (output_port.connectedTo(&input_port)) {
+                log(Info) << "OutputPort " << output_port.getName() << " is already connected to " << input_port.getName() << ", ignoring new connection." << endlog();
+                return true;
+            }
+
             InputPort<T>* input_p = dynamic_cast<InputPort<T>*>(&input_port);
 
             // Shared push connection? => forward to createAndCheckSharedConnection()

--- a/rtt/internal/ConnectionManager.cpp
+++ b/rtt/internal/ConnectionManager.cpp
@@ -109,6 +109,16 @@ namespace RTT
         bool ConnectionManager::connected() const
         { return !connections.empty(); }
 
+        bool ConnectionManager::connectedTo(base::PortInterface* port)
+        {
+            RTT::os::MutexLock lock(connection_lock);
+            boost::scoped_ptr<ConnID> conn_id( port->getPortID() );
+            for(Connections::const_iterator conn_it = connections.begin(); conn_it != connections.end(); ++conn_it ) {
+                if (conn_it->get<0>() && conn_id->isSameID(*conn_it->get<0>())) return true;
+            }
+            return false;
+        }
+
         bool ConnectionManager::addConnection(ConnID* conn_id, ChannelElementBase::shared_ptr channel, ConnPolicy policy)
         { RTT::os::MutexLock lock(connection_lock);
             assert(conn_id);

--- a/rtt/internal/ConnectionManager.hpp
+++ b/rtt/internal/ConnectionManager.hpp
@@ -119,6 +119,11 @@ namespace RTT
              */
             bool connected() const;
 
+            /** Returns true if there exists a connection to the given port
+             */
+            bool connectedTo(base::PortInterface* port);
+
+
             /** Removes the connection that connects this port to \c port */
             bool disconnect(base::PortInterface* port);
 

--- a/tests/ports_test.cpp
+++ b/tests/ports_test.cpp
@@ -1000,3 +1000,247 @@ BOOST_AUTO_TEST_CASE(testPortDataSource)
 
 BOOST_AUTO_TEST_SUITE_END()
 
+/**
+ * Another fixture for concurrency test.
+ */
+class ConcurrencyPortsTestFixture
+{
+public:
+    template <typename T>
+    class PortWriterThread : public Activity
+    {
+    public:
+        PortWriterThread(const T& sample = T())
+            : port("writer"), sample(sample), step_counter(0), write_counter(0)
+        {}
+        void step() {
+            if (port.write(sample) == WriteSuccess) {
+                ++write_counter;
+            }
+            this->trigger();
+            this->yield();
+            ++step_counter;
+        }
+        bool breakLoop() { return true; }
+    public:
+        OutputPort<T> port;
+        T sample;
+        unsigned step_counter;
+        unsigned write_counter;
+    };
+
+    template <typename T>
+    class PortReaderThread : public Activity
+    {
+    public:
+        PortReaderThread()
+            : port("reader"), step_counter(0), read_counter(0)
+        {}
+        void step() {
+            if (port.read(sample) == NewData) {
+                ++read_counter;
+            }
+            this->trigger();
+            this->yield();
+            ++step_counter;
+        }
+        bool breakLoop() { return true; }
+    public:
+        InputPort<T> port;
+        T sample;
+        unsigned step_counter;
+        unsigned read_counter;
+    };
+
+    class PortConnectorThread : public Activity
+    {
+    public:
+        PortConnectorThread(PortInterface &connect_port, PortInterface &other_port, const ConnPolicy &policy = ConnPolicy())
+            : connect_port(connect_port), other_port(other_port), policy(policy), step_counter(0), connect_counter(0), disconnect_counter(0), connected(false)
+        {}
+        void step() {
+            if (!connected) {
+                if (connect_port.connectTo(&other_port, policy)) {
+                    ++connect_counter;
+                    connected = true;
+                } else {
+                    (void)0;
+                }
+            } else {
+                if (!shared_connection) {
+                    connect_port.disconnect();
+                } else {
+                    connect_port.getManager()->removeConnection(shared_connection.get());
+                }
+                ++disconnect_counter;
+                connected = false;
+            }
+            this->trigger();
+            this->yield();
+            ++step_counter;
+        }
+        bool breakLoop() { return true; }
+    public:
+        PortInterface &connect_port;
+        PortInterface &other_port;
+        RTT::internal::SharedConnectionBase::shared_ptr shared_connection;
+        ConnPolicy policy;
+        unsigned step_counter;
+        unsigned connect_counter;
+        unsigned disconnect_counter;
+
+    private:
+        bool connected;
+    };
+
+    typedef double T;
+    PortWriterThread<T> writer;
+    PortReaderThread<T> reader;
+    OutputPort<T> another_output_port;
+    InputPort<T> another_input_port;
+    PortConnectorThread another_output_connector, another_input_connector;
+
+public:
+    ConcurrencyPortsTestFixture()
+        : writer()
+        , reader()
+        , another_output_port("another_output_port")
+        , another_input_port("another_input_port")
+        , another_output_connector(another_output_port, reader.port)
+        , another_input_connector(another_input_port, writer.port)
+    {}
+
+    ~ConcurrencyPortsTestFixture()
+    {
+        stop();
+        disconnect();
+    }
+
+    bool connect(const ConnPolicy &policy) {
+        another_output_connector.policy = policy;
+        another_input_connector.policy = policy;
+        return writer.port.connectTo(&reader.port, policy);
+    }
+
+    void disconnect() {
+        writer.port.disconnect();
+        reader.port.disconnect();
+        another_output_port.disconnect();
+        another_input_port.disconnect();
+    }
+
+    bool start()
+    {
+        bool result = true;
+        result = writer.start() && result;
+        result = reader.start() && result;
+        result = another_output_connector.start() && result;
+        result = another_input_connector.start() && result;
+        return true;
+    }
+
+    bool stop()
+    {
+        bool result = true;
+        result = writer.stop() && result;
+        result = reader.stop() && result;
+        result = another_output_connector.stop() && result;
+        result = another_input_connector.stop() && result;
+        return true;
+    }
+};
+
+// Registers the fixture into the 'registry'
+BOOST_FIXTURE_TEST_SUITE(  ConcurrencyPortsTestSuite,  ConcurrencyPortsTestFixture )
+
+BOOST_AUTO_TEST_CASE( testConcurrencyWritePrivateReadUnordered )
+{
+    ConnPolicy policy = ConnPolicy::data(ConnPolicy::LOCK_FREE);
+    policy.write_policy = WritePrivate;
+    policy.read_policy = ReadUnordered;
+
+    BOOST_REQUIRE( connect(policy) );
+    BOOST_REQUIRE( start() );
+    sleep(1);
+    BOOST_REQUIRE( stop() );
+    disconnect();
+
+    BOOST_TEST_MESSAGE("Number of writes:                  " << writer.write_counter);
+    BOOST_CHECK_GE( writer.write_counter, 100 );
+    BOOST_TEST_MESSAGE("Number of reads:                   " << reader.read_counter);
+    BOOST_CHECK_GE( reader.read_counter, 100 );
+    BOOST_TEST_MESSAGE("Number of connects to input port:  " << another_output_connector.connect_counter);
+    BOOST_CHECK_GE( another_output_connector.connect_counter, 100 );
+    BOOST_TEST_MESSAGE("Number of connects to output port: " << another_input_connector.connect_counter);
+    BOOST_CHECK_GE( another_input_connector.connect_counter, 100 );
+}
+
+BOOST_AUTO_TEST_CASE( testConcurrencyWritePrivateReadShared )
+{
+    ConnPolicy policy = ConnPolicy::data(ConnPolicy::LOCKED);
+    policy.write_policy = WritePrivate;
+    policy.read_policy = ReadShared;
+
+    BOOST_REQUIRE( connect(policy) );
+    BOOST_REQUIRE( start() );
+    sleep(1);
+    BOOST_REQUIRE( stop() );
+    disconnect();
+
+    BOOST_TEST_MESSAGE("Number of writes:                  " << writer.write_counter);
+    BOOST_CHECK_GE( writer.write_counter, 100 );
+    BOOST_TEST_MESSAGE("Number of reads:                   " << reader.read_counter);
+    BOOST_CHECK_GE( reader.read_counter, 100 );
+    BOOST_TEST_MESSAGE("Number of connects to input port:  " << another_output_connector.connect_counter);
+    BOOST_CHECK_GE( another_output_connector.connect_counter, 100 );
+    BOOST_TEST_MESSAGE("Number of connects to output port: " << another_input_connector.connect_counter);
+    BOOST_CHECK_GE( another_input_connector.connect_counter, 100 );
+}
+
+BOOST_AUTO_TEST_CASE( testConcurrencyWriteSharedReadUnordered )
+{
+    ConnPolicy policy = ConnPolicy::data(ConnPolicy::LOCK_FREE);
+    policy.write_policy = WriteShared;
+    policy.read_policy = ReadUnordered;
+
+    BOOST_REQUIRE( connect(policy) );
+    BOOST_REQUIRE( start() );
+    sleep(1);
+    BOOST_REQUIRE( stop() );
+    disconnect();
+
+    BOOST_TEST_MESSAGE("Number of writes:                  " << writer.write_counter);
+    BOOST_CHECK_GE( writer.write_counter, 100 );
+    BOOST_TEST_MESSAGE("Number of reads:                   " << reader.read_counter);
+    BOOST_CHECK_GE( reader.read_counter, 100 );
+    BOOST_TEST_MESSAGE("Number of connects to input port:  " << another_output_connector.connect_counter);
+    BOOST_CHECK_GE( another_output_connector.connect_counter, 100 );
+    BOOST_TEST_MESSAGE("Number of connects to output port: " << another_input_connector.connect_counter);
+    BOOST_CHECK_GE( another_input_connector.connect_counter, 100 );
+}
+
+BOOST_AUTO_TEST_CASE( testConcurrencySharedConnection )
+{
+    ConnPolicy policy = ConnPolicy::data(ConnPolicy::LOCKED);
+    policy.write_policy = WriteShared;
+    policy.read_policy = ReadShared;
+
+    BOOST_REQUIRE( connect(policy) );
+    another_output_connector.shared_connection = writer.port.getSharedConnection();
+    another_input_connector.shared_connection = reader.port.getSharedConnection();
+    BOOST_REQUIRE( start() );
+    sleep(1);
+    BOOST_REQUIRE( stop() );
+    disconnect();
+
+    BOOST_TEST_MESSAGE("Number of writes:                  " << writer.write_counter);
+    BOOST_CHECK_GE( writer.write_counter, 100 );
+    BOOST_TEST_MESSAGE("Number of reads:                   " << reader.read_counter);
+    BOOST_CHECK_GE( reader.read_counter, 100 );
+    BOOST_TEST_MESSAGE("Number of connects to input port:  " << another_output_connector.connect_counter);
+    BOOST_CHECK_GE( another_output_connector.connect_counter, 100 );
+    BOOST_TEST_MESSAGE("Number of connects to output port: " << another_input_connector.connect_counter);
+    BOOST_CHECK_GE( another_input_connector.connect_counter, 100 );
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/ports_test.cpp
+++ b/tests/ports_test.cpp
@@ -746,7 +746,7 @@ BOOST_AUTO_TEST_CASE(testInvalidReadPolicyConnections)
     cp_BUFFER5.read_policy = ReadShared;
     cp_BUFFER10.read_policy = ReadShared;
     BOOST_CHECK( wp1.connectTo(&rp, cp_BUFFER5) );
-    BOOST_CHECK( !wp1.connectTo(&rp, cp_BUFFER10) );
+    BOOST_CHECK( !wp2.connectTo(&rp, cp_BUFFER10) );
     rp.disconnect();
 }
 


### PR DESCRIPTION
These new tests run 4 threads each. Two of them are continuously writing to and reading from an OutputPort/InputPort pair, while the other two connect and disconnect an additional OutputPort and an additional InputPort to these ports, respectively.

The four test cases cover the four different connection layouts introduced with the updated-dataflow-semantics branch (see #114).