### PR TITLE
enable corba oneway communication for write()

### DIFF
--- a/rtt/transports/corba/DataFlow.idl
+++ b/rtt/transports/corba/DataFlow.idl
@@ -41,7 +41,7 @@ module RTT
          * Writes into this Channel Element.
          * @return false if the channel became invalid
          */
-        boolean write(in any sample);
+        oneway void write(in any sample);
         /**
          * Disconnect and dispose this object.
          * You may no longer use this object after calling this method.

--- a/rtt/transports/corba/RemoteChannelElement.hpp
+++ b/rtt/transports/corba/RemoteChannelElement.hpp
@@ -335,14 +335,14 @@ namespace RTT {
             /**
              * CORBA IDL function.
              */
-            bool write(const ::CORBA::Any& sample) ACE_THROW_SPEC ((
+            void write(const ::CORBA::Any& sample) ACE_THROW_SPEC ((
           	      CORBA::SystemException
           	    ))
             {
                 typename internal::ValueDataSource<T> value_data_source;
                 value_data_source.ref();
                 transport.updateFromAny(&sample, &value_data_source);
-                return base::ChannelElement<T>::write(value_data_source.rvalue());
+                base::ChannelElement<T>::write(value_data_source.rvalue());
             }
 
             virtual bool data_sample(typename base::ChannelElement<T>::param_t sample)


### PR DESCRIPTION
Hi,

Using the rock framework we found a severe issue when a output port is connected to a local and a remote port at the same time and the network is congested. This congestion is also affecting local connections, which it shouldn't. So when out robot is mapping using a point cloud provider task and a mapping task and we are watching the point clouds created from a remote pc, this can result in no point clouds are transmitted to the robot's mapping task any more.

I created a minimal example to create the issue (using the rock framework).
A sending task is connected to a local and a remote input port.
The remote task context is connected via wlan and the congestion was created by using the "iperf" network benchmark.

https://github.com/planthaber/orocos_oneway_test

see the readme there on how to execute it

The result was that **no data** was transmitted **on the local connection while the remote connection was congested**. After the benchmark finished, the connection worked as expected again.

The issue arises because port data is send through corba, where default behavior is to wait for an reply of the remote before the interface returns (write() in this case). Waiting for the reply takes obviously some time when the network is congested. I am not deep enough into RTT to see why the messages actually vanish or if this issue can be solved another way, but this PR solves the issue by telling corba not to wait for a reply after write.

I think it will not change the behavior of RTT in other ways, because the return value of the write() function is not evaluated at the following location and I did not find another location where it is used:

https://github.com/orocos-toolchain/rtt/blob/master/rtt/transports/corba/RemoteChannelElement.hpp#L318

There the return value is not checked only marshalling exceptions are handled. When the return value is not evaluated, why should we wait for it?

Kind regards,

Steffen

@doudou @goldhoorn @2maz @jmachowinski @D-Alex @leifole




