### PR TITLE
Timer: fixed wake up time on 32 bit systems

### DIFF
--- a/rtt/os/Timer.cpp
+++ b/rtt/os/Timer.cpp
@@ -41,6 +41,7 @@
 #include "../Activity.hpp"
 #include "../Logger.hpp"
 #include "../os/fosi.h"
+#include <limits>
 
 namespace RTT {
     using namespace base;
@@ -71,7 +72,7 @@ namespace RTT {
                 MutexLock locker(m);
                 // We can't use infinite as the OS may internally use time_spec, which can not
                 // represent as much in the future (until 2038) // XXX Year-2038 Bug
-                wake_up_time = (TimeService::InfiniteNSecs/4)-1;
+                wake_up_time = 1000000000LL * std::numeric_limits<int32_t>::max();
                 for (TimerIds::iterator it = mtimers.begin(); it != mtimers.end(); ++it) {
                     if ( it->expires != 0 && it->expires < wake_up_time  ) {
                         wake_up_time = it->expires;


### PR DESCRIPTION
The existing comment is right:
We can't use infinite as the OS may internally use time_spec, which can not
represent as much in the future (until 2038) // XXX Year-2038 Bug

but used value of InfiniteNSecs/4 exceeds max in32 seconds.

Changed to use value to be converted within max int32 seconds.
