### PR TITLE
Fixed invalid read of freed thread name in os::Thread destructor

### DIFF
--- a/rtt/os/ecos/fosi_internal.cpp
+++ b/rtt/os/ecos/fosi_internal.cpp
@@ -50,6 +50,7 @@ namespace RTT
 	INTERNAL_QUAL int rtos_task_delete_main(RTOS_TASK* main_task)
 	{
         free(main_task->name);
+        main_task->name = NULL;
 	    return 0;
 	}
 
@@ -177,6 +178,7 @@ namespace RTT
     INTERNAL_QUAL void rtos_task_delete(RTOS_TASK* mytask) {
       // Free name
       free(mytask->name);
+      mytask->name = NULL;
       // KG: Peter does not check return values, it appears...
       bool succeed = cyg_thread_delete(mytask->handle);
       if (succeed == false)
@@ -190,8 +192,10 @@ namespace RTT
     {
       cyg_thread_info info;
       bool succeed = cyg_thread_get_info(t->handle,cyg_thread_get_id(t->handle),&info);
-      if (succeed == false)
+      if (succeed == false) {
           diag_printf("fosi_internal.hpp rtos_task_get_name() WARNING: cyg_thread_get_info returned false...\n");
+          return "(destroyed)";
+      }
       return info.name;
     }
 

--- a/rtt/os/gnulinux/fosi_internal.cpp
+++ b/rtt/os/gnulinux/fosi_internal.cpp
@@ -79,6 +79,7 @@ namespace RTT
 	{
         pthread_attr_destroy( &(main_task->attr) );
         free(main_task->name);
+        main_task->name = NULL;
 	    return 0;
 	}
 
@@ -278,6 +279,7 @@ namespace RTT
         pthread_join( mytask->thread, 0);
         pthread_attr_destroy( &(mytask->attr) );
 	    free(mytask->name);
+        mytask->name = NULL;
 	}
 
     INTERNAL_QUAL int rtos_task_check_scheduler(int* scheduler)
@@ -431,7 +433,7 @@ namespace RTT
 
 	INTERNAL_QUAL const char * rtos_task_get_name(const RTOS_TASK* task)
 	{
-	    return task->name;
+        return task->name ? task->name : "(destroyed)";
 	}
 
     }

--- a/rtt/os/lxrt/fosi_internal.cpp
+++ b/rtt/os/lxrt/fosi_internal.cpp
@@ -137,6 +137,7 @@ namespace RTT
             //stop_rt_timer();
             rt_task_delete(main_task->rtaitask);
             free(main_task->name);
+            main_task->name = NULL;
             munlockall();
             return 0;
         }
@@ -340,6 +341,7 @@ namespace RTT
                 Logger::log() << Logger::Critical << "Failed to join "<< mytask->name <<"."<< Logger::endl;
 
             free( mytask->name );
+            mytask->name = NULL;
             // rt_task_delete is done in wrapper !
         }
 
@@ -382,7 +384,7 @@ namespace RTT
 
         INTERNAL_QUAL const char * rtos_task_get_name(const RTOS_TASK* t)
         {
-            return t->name;
+            return t->name ? t->name : "(destroyed)";
         }
 
         INTERNAL_QUAL int rtos_task_get_priority(const RTOS_TASK *t)

--- a/rtt/os/macosx/fosi_internal.cpp
+++ b/rtt/os/macosx/fosi_internal.cpp
@@ -63,6 +63,7 @@ namespace RTT
 	{
         pthread_attr_destroy( &(main_task->attr) );
         free( main_task->name );
+        main_task->name = NULL;
 	    return 0;
 	}
 
@@ -204,6 +205,7 @@ namespace RTT
             pthread_join( mytask->thread, 0);
             pthread_attr_destroy( &(mytask->attr) );
 	    free(mytask->name);
+        mytask->name = NULL;
 	}
 
         INTERNAL_QUAL int rtos_task_check_scheduler(int* scheduler)
@@ -281,7 +283,7 @@ namespace RTT
 
 	INTERNAL_QUAL const char * rtos_task_get_name(const RTOS_TASK* task)
 	{
-	    return task->name;
+        return task->name ? task->name : "(destroyed)";
 	}
 
     }

--- a/rtt/os/win32/fosi_internal.cpp
+++ b/rtt/os/win32/fosi_internal.cpp
@@ -130,6 +130,7 @@ void ErrorHandler(LPTSTR lpszFunction)
         //pthread_attr_destroy( &(main_task->attr) );
 		// printf("rtos_task_delete_main");
 		free(main_task->name);
+        main_task->name = NULL;
 	    return 0;
 	}
 
@@ -350,7 +351,7 @@ void ErrorHandler(LPTSTR lpszFunction)
     	}
     	*/
 
-    	return t->name;
+        return t->name ? t->name : "(destroyed)";
     }
 
     }

--- a/rtt/os/xenomai/fosi_internal.cpp
+++ b/rtt/os/xenomai/fosi_internal.cpp
@@ -172,6 +172,7 @@ namespace RTT
         {
             //rt_task_delete( &(main_task->xenotask) );
             free (main_task->name);
+            main_task->name = NULL;
             munlockall();
             return 0;
         }
@@ -427,7 +428,7 @@ namespace RTT
         }
 
         INTERNAL_QUAL const char* rtos_task_get_name(const RTOS_TASK* mytask) {
-            return mytask->name;
+            return mytask->name ? mytask->name : "(destroyed)";
         }
 
     	INTERNAL_QUAL unsigned int rtos_task_get_pid(const RTOS_TASK* task)
@@ -450,6 +451,8 @@ namespace RTT
                 log(Error) << "Failed to join with thread " << mytask->name << endlog();
             }
             rt_task_delete(&(mytask->xenotask));
+            free(mytask->name);
+            mytask->name = NULL;
         }
 
         INTERNAL_QUAL int rtos_task_set_priority(RTOS_TASK * mytask, int priority)


### PR DESCRIPTION
The destructor of class `RTT::os::Thread` calls the `getName()` method for logging, which forwards to `rtos_task_get_name()`, but the memory that holds the thread name has already been freed at that point. This patch should fix this problem for all target types, but I only tested it for gnulinux so far.