### PR TITLE
Revert "added ability to load a plugin using a operation on a task."

### DIFF
--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -118,7 +118,6 @@ namespace RTT
 
         this->addOperation("trigger", &TaskContext::trigger, this, ClientThread).doc("Trigger the update method for execution in the thread of this task.\n Only succeeds if the task isRunning() and allowed by the Activity executing this task.");
         this->addOperation("loadService", &TaskContext::loadService, this, ClientThread).doc("Loads a service known to RTT into this component.").arg("service_name","The name with which the service is registered by in the PluginLoader.");
-        this->addOperation("loadPlugin", &TaskContext::loadPlugin, this, ClientThread).doc("Loads a RTT plugin.").arg("plugin_path","The path to the shared library containing the plugin.");
         // activity runs from the start.
         if (our_act)
             our_act->start();
@@ -236,12 +235,6 @@ namespace RTT
             return true;
         return PluginLoader::Instance()->loadService(service_name, this);
     }
-    
-    bool TaskContext::loadPlugin(const string& pluginPath)
-    {
-        return PluginLoader::Instance()->loadPlugin(pluginPath, "");
-    }
-
 
     void TaskContext::addUser( TaskContext* peer )
     {

--- a/rtt/TaskContext.hpp
+++ b/rtt/TaskContext.hpp
@@ -325,13 +325,6 @@ namespace RTT
          */
         bool loadService(const std::string& service_name);
 
-        /**
-         * Use this method to load a plugin.
-         * @param pluginPath The path to the shared library containing the plugin.
-         * @return true if the plugin was present already or could be loaded.
-         */
-        bool loadPlugin(const std::string& pluginPath);
-        
         /** @} */
 
         /**


### PR DESCRIPTION
This PR reverts commits 9011cf9615dfdd6db02c4781c9bd38de76ebad12 and 9c9e008f74d87e4b352d0294f5bda47b1c1550ef from #90, that add a `loadPlugin()` operation to the TaskContext interface.

Alternative solutions are:
- use a remote proxy for the DeploymentComponent (the `import()` operation is doing exactly the same)
- add the `loadPlugin()` operation to one application-specific subclass instead of to the base class `TaskContext`

It should be noted that there is a difference between loading a plugin (in the process) and loading a service (in a component or in the global service). Plugins can provide a service, but they can also provide typekits, transports or do something completely different. And of top of that there are packages, which are basically collections of component libraries and/or plugins. Some APIs in RTT do not clearly separate these two concepts (e.g. `PluginLoader::loadPlugin(name, path_list)`, which actually loads all plugins provided by a package called `name`).

So generally loading a plugin is not related to a specific component (you are not passing the `this` pointer to anyone). What you probably wanted to do is to load a service plugin in the TaskContext based on the name of the plugin or package that provides this service (which may not be a 1:1 mapping if the package provides more than one service). This sounds more like an extension of the existing `loadService()` operation than a task for a separate operation.
