### PR TITLE
Master statemachine execution logic

### DIFF
--- a/rtt/scripting/StateMachine.cpp
+++ b/rtt/scripting/StateMachine.cpp
@@ -1240,8 +1240,6 @@ namespace RTT {
 
         // execute the entry program of the initial state.
         if ( !inError() ) {
-            enableEvents(current);
-
             if ( this->executePreCheck() ) {
                 smStatus = Status::active;
                 TRACE("Activated.");

--- a/rtt/scripting/StateMachine.cpp
+++ b/rtt/scripting/StateMachine.cpp
@@ -1110,8 +1110,8 @@ namespace RTT {
             runState(next);
             enableEvents(next);
         } else {
-            // schedule a new run of the current state
-            if (current)
+            // schedule a new run of the current state, only if previous run finished.
+            if (current && currentRun == 0)
                 runState(current);
         }
 

--- a/rtt/scripting/StateMachine.cpp
+++ b/rtt/scripting/StateMachine.cpp
@@ -209,14 +209,13 @@ namespace RTT {
     bool StateMachine::automatic()
     {
         TRACE_INIT();
-        // if you go from reactive to automatic,
-        // first execute the run program, before
-        // evaluating transitions.
+        //
         if ( smStatus != Status::inactive && smStatus != Status::unloaded && smStatus != Status::error) {
             TRACE( "Will start." );
             smStatus = Status::running;
             os::MutexLock lock(execlock);
             runState( current );
+
             return true;
         }
         TRACE( "Won't start." );
@@ -316,30 +315,51 @@ namespace RTT {
             return true;
             break;
         case Status::requesting:
-            if ( this->executePending() ) {   // if all steps done,
-                this->requestNextState();
-                this->executePending();       // execute steps of next state
-                TRACE("Is active now.");
-                smStatus = Status::active;
+            // finish entry and if finished, run the run program:
+            if ( this->executePreCheck() == false)  {
+                TRACE("Yielding Entry program...");
+                break;
+            }
+            TRACE("Is active now.");
+            smStatus = Status::active;
+            // check transitions:
+            this->requestNextState();
+            // post-check transitioning:
+            if ( this->executePostCheck() == false) {
+                TRACE("Yielding ...");
+                break;
             }
             break;
         case Status::active:
-            this->executePending();
+            this->executePreCheck();
             break;
         case Status::running:
-            if ( this->executePending() == false) {
-                TRACE("Yielding...");
+            // finish entry and if finished, run the run program:
+            if ( this->executePreCheck() == false)  {
+                TRACE("Yielding Entry program...");
                 break;
             }
-            // if all pending done:
-            this->requestNextState();     // one state at a time
-            this->executePending();       // execute steps of next state
+            // check transitions:
+            this->requestNextState();
+            // post-check transitioning:
+            if ( this->executePostCheck() == false) {
+                TRACE("Yielding ...");
+                break;
+            }
             break;
         case Status::paused:
             if (mstep) {
-                if ( this->executePending(true) ) {    // if all steps done,
-                    this->requestNextState(true); // one state at a time
-                    this->executePending(true);       // execute steps of next state
+                // finish entry and if finished, run the run program:
+                if ( this->executePreCheck(true) == false)  {
+                    TRACE("Yielding Entry program...");
+                    break;
+                }
+                // check transitions:
+                this->requestNextState(true);
+                // post-check transitioning:
+                if ( this->executePostCheck(true) == false) {
+                    TRACE("Yielding ...");
+                    break;
                 }
                 TRACE("Did a step.");
                 mstep = false;
@@ -445,7 +465,7 @@ namespace RTT {
                 TRACE("Transition triggered from '"+ (current ? current->getName() : "null") +"' to '"+(newState ? newState->getName() : "null")+"'.");
                 // reset handle and run, in case it is still set ( during error
                 // or when an event arrived ).
-                currentRun = 0;
+                //currentRun = 0;
                 currentHandle = 0;
                 if ( transProg ) {
                     transProg->reset();
@@ -461,11 +481,6 @@ namespace RTT {
                 leaveState(current);
                 assert( currentEntry == 0); // we assume that in executePending, trans and exit get executed first and entry is stil null.
             }
-        // schedule a run for the next 'step'.
-        // if handle above finished, run will be called directly
-        // in executePending. if handle was not finished
-        // or stepping, it will be called after handle.
-        runState( newState );
     }
 
     void StateMachine::enableGlobalEvents( )
@@ -633,7 +648,7 @@ namespace RTT {
         if( current == 0 )
             return 0;
         // only a run program may be interrupted...
-        if ( !interruptible() || currentTrans ) {
+        if ( !interruptible() || currentTrans || current != next) {
             return current; // can not accept request, still in transition.
         }
 
@@ -995,19 +1010,18 @@ namespace RTT {
 
     bool StateMachine::executePending( bool stepping )
     {
+            return executePreCheck(stepping) && executePostCheck(stepping);
+    }
+
+    bool StateMachine::executePreCheck( bool stepping )
+    {
         TRACE_INIT();
-        // This function has great resposibility, since it acts like
-        // a scheduler for pending requests. It tries to devise what to
-        // do on basis of the contents of variables (like current*, next,...).
-        // This is a somewhat
-        // fragile implementation but requires very little bookkeeping.
-        // if returns true : a transition (exit/entry) is done
-        // and a new state may be requested.
 
         if ( inError() )
             return false;
 
-        // first try to finish the current entry program, if any:
+//        TRACE("executePreCheck..." );
+        // first try to finish the current entry program (this only happens if entry was not atomically implemented, ie yielding):
         if ( currentEntry ) {
             TRACE("Executing entry program of '"+ (current ? current->getName() : "(null)") +"'" );
             if ( this->executeProgram(currentEntry, stepping) == false )
@@ -1021,6 +1035,25 @@ namespace RTT {
             }
         }
 
+        // Run is executed before the transitions.
+        if ( currentRun ) {
+            TRACE("Executing run program of '"+ current->getName() +"'" );
+            if ( this->executeProgram(currentRun, stepping) == false )
+                return true;
+            // done.
+            TRACE("Finished  run program of '"+ (current ? current->getName() : "(null)") +"'" );
+        }
+        return true;
+    }
+
+    bool StateMachine::executePostCheck( bool stepping )
+    {
+        TRACE_INIT();
+
+        if ( inError() )
+            return false;
+
+//        TRACE("executePostCheck..." );
         // if a transition has been scheduled, proceed directly instead of doing a run:
         if ( currentTrans ) {
             TRACE("Executing transition program from '"+ (current ? current->getName() : "(null)") + "' to '"+ ( next ? next->getName() : "(null)")+"'" );
@@ -1074,7 +1107,12 @@ namespace RTT {
 
             current = next;
             enterState(next);
+            runState(next);
             enableEvents(next);
+        } else {
+            // schedule a new run of the current state
+            if (current)
+                runState(current);
         }
 
         // finally, execute the current Entry of the new state:
@@ -1107,18 +1145,6 @@ namespace RTT {
                 currentProg = currentRun;
                 return false;
             }
-        }
-
-        // Run is executed before the transitions.
-        if ( currentRun ) {
-            TRACE("Executing run program of '"+ (current ? current->getName() : "(null)") +"'" );
-            if ( this->executeProgram(currentRun, stepping) == false )
-                return false;
-            // done.
-            TRACE("Finished  run program of '"+ (current ? current->getName() : "(null)") +"'" );
-            // in stepping mode, delay 'true' one executePending().
-            if ( stepping )
-                return false;
         }
 
         return true; // all pending is done
@@ -1216,7 +1242,7 @@ namespace RTT {
         if ( !inError() ) {
             enableEvents(current);
 
-            if ( this->executePending() ) {
+            if ( this->executePreCheck() ) {
                 smStatus = Status::active;
                 TRACE("Activated.");
             } else {

--- a/rtt/scripting/StateMachine.hpp
+++ b/rtt/scripting/StateMachine.hpp
@@ -380,19 +380,28 @@ namespace RTT
         bool requestStateChange( StateInterface * s_n );
 
         /**
-         * Execute any pending State (exit, entry, handle) programs.
-         * You must executePending, before calling requestState() or
-         * requestNextState(). You should only call requestState() or requestNextState()
-         * if executePending returns true.
-         *
-         * Due to the pending requests, the currentState() may have changed.
+         * Returns executePreCheck() && executePostCheck()
+         */
+        bool executePending(bool stepping = false);
+
+        /**
+         * Execute only 'yielded entry' and run state programs before any state transitions are checked.
          *
          * @param stepping provide true if the pending programs should
          * be executed one step at a time.
-         * @retval true if nothing was pending @retval false if there was
-         * some program executing.
+         * @retval true if run was running or pending.
+         * @retval false only if the entry program is yielding.
          */
-        bool executePending( bool stepping = false );
+        bool executePreCheck( bool stepping = false );
+        /**
+         * Execute only transition, handle or exit/entry state programs after any state transitions are checked.
+         *
+         * @param stepping provide true if the pending programs should
+         * be executed one step at a time.
+         * @retval true if nothing was pending
+         * @retval false if there was some program executing.
+         */
+        bool executePostCheck( bool stepping = false );
 
         /**
          * Express a precondition for entering a state.  The

--- a/tests/corba_test.cpp
+++ b/tests/corba_test.cpp
@@ -46,7 +46,10 @@ public:
         pint1("pint1", "", 3), pdouble1(new Property<double>("pdouble1", "", -3.0)),
         aint1(3), adouble1(-3.0), wait(0)
     {
-    // connect DataPorts
+        // check operations (moved from OperationCallerComponent constructor for reuseability in corba-ipc-server)
+        BOOST_REQUIRE( caller->ready() );
+
+        // connect DataPorts
         mi1 = new InputPort<double> ("mi");
         mo1 = new OutputPort<double> ("mo");
 

--- a/tests/operations_fixture.cpp
+++ b/tests/operations_fixture.cpp
@@ -32,6 +32,59 @@ using namespace boost;
 using namespace RTT;
 using namespace RTT::detail;
 
+class OperationCallerComponent : public TaskContext
+{
+    TaskContext* mtc;
+public:
+    OperationCallerComponent(TaskContext* tc) : TaskContext("caller"), mtc(tc) {
+
+        // calls own thread operations :
+        opc0 = tc->provides("methods")->getOperation("o0");
+        opc0.setCaller( this->engine() );
+        opc1 = tc->provides("methods")->getOperation("o1");
+        opc1.setCaller( this->engine() );
+        // client thread :
+        opc2 = tc->provides("methods")->getOperation("m2");
+        opc2.setCaller( this->engine() );
+        opc3 = tc->provides("methods")->getOperation("m3");
+        opc3.setCaller( this->engine() );
+
+        BOOST_REQUIRE( opc0.ready() );
+        BOOST_REQUIRE( opc1.ready() );
+        BOOST_REQUIRE( opc2.ready() );
+        BOOST_REQUIRE( opc3.ready() );
+
+        // four combinations are possible:
+        this->addOperation("o0", &OperationCallerComponent::m0, this, OwnThread);
+        this->addOperation("o1", &OperationCallerComponent::m1, this, ClientThread);
+        this->addOperation("o2", &OperationCallerComponent::m2, this, OwnThread);
+        this->addOperation("o3", &OperationCallerComponent::m3, this, ClientThread);
+
+    }
+
+    void updateHook() {
+        // m0 and m2 are executed in OwnThread
+        // where m0 calls an OwnThread op of 'tc' and m2 calls a ClientThread op of 'tc'.
+
+        // m1 and m3 are executed in ClientThread (so in GlobalEE when being sent),
+        // where m1 calls an OwnThread op of 'tc' and m3 calls a ClientThread op of 'tc'.
+        // but do set the caller to this component.
+    }
+
+    // plain argument tests:
+    double m0(void) { return opc0(); }
+    double m1(int i) { return opc1(i); }
+    double m2(int i, double d) { return opc2(i,d); }
+    double m3(int i, double d, bool c) { return opc3(i,d,c); }
+
+    OperationCaller<double(void)> opc0;
+    OperationCaller<double(int)> opc1;
+    OperationCaller<double(int,double)> opc2;
+    OperationCaller<double(int,double,bool)> opc3;
+
+};
+
+
 OperationsFixture::OperationsFixture()
 {
     ret = 0.0;
@@ -39,7 +92,7 @@ OperationsFixture::OperationsFixture()
     tc = new TaskContext("root");
     this->createOperationCallerFactories(tc);
     tc->provides()->addAttribute("ret", ret );
-    caller = new TaskContext("caller");
+    caller = new OperationCallerComponent(tc);
     caller->start();
     tc->start();
 }

--- a/tests/operations_fixture.cpp
+++ b/tests/operations_fixture.cpp
@@ -49,11 +49,6 @@ public:
         opc3 = tc->provides("methods")->getOperation("m3");
         opc3.setCaller( this->engine() );
 
-        BOOST_REQUIRE( opc0.ready() );
-        BOOST_REQUIRE( opc1.ready() );
-        BOOST_REQUIRE( opc2.ready() );
-        BOOST_REQUIRE( opc3.ready() );
-
         // four combinations are possible:
         this->addOperation("o0", &OperationCallerComponent::m0, this, OwnThread);
         this->addOperation("o1", &OperationCallerComponent::m1, this, ClientThread);
@@ -69,6 +64,17 @@ public:
         // m1 and m3 are executed in ClientThread (so in GlobalEE when being sent),
         // where m1 calls an OwnThread op of 'tc' and m3 calls a ClientThread op of 'tc'.
         // but do set the caller to this component.
+    }
+
+    bool ready() {
+        BOOST_REQUIRE( opc0.ready() );
+        BOOST_REQUIRE( opc1.ready() );
+        BOOST_REQUIRE( opc2.ready() );
+        BOOST_REQUIRE( opc3.ready() );
+        return opc0.ready() &&
+               opc1.ready() &&
+               opc2.ready() &&
+               opc3.ready();
     }
 
     // plain argument tests:

--- a/tests/state_test.cpp
+++ b/tests/state_test.cpp
@@ -697,10 +697,10 @@ BOOST_AUTO_TEST_CASE( testStateOperations)
      StateMachinePtr sm = sa->getStateMachine("x");
      BOOST_REQUIRE( sm );
      sm->trace(true);
-     OperationCaller<bool(StateMachine*)> act = tc->provides("x")->getOperation("activate");
-     OperationCaller<bool(StateMachine*)> autom = tc->provides("x")->getOperation("automatic");
-     BOOST_CHECK( act(sm.get()) );
-     BOOST_CHECK( autom(sm.get()) );
+     OperationCaller<bool(StateMachinePtr)> act = tc->provides("x")->getOperation("activate");
+     OperationCaller<bool(StateMachinePtr)> autom = tc->provides("x")->getOperation("automatic");
+     BOOST_CHECK( act(sm) );
+     BOOST_CHECK( autom(sm) );
 
      sleep(1); // we must allow the thread to transition...
 
@@ -1854,12 +1854,12 @@ void StateTest::runState(const std::string& name, TaskContext* tc, bool trace, b
     StateMachine::ChildList children = sm->getChildren();
     for( StateMachine::ChildList::iterator it = children.begin(); it != children.end(); ++it)
         (*it)->trace(trace);
-    OperationCaller<bool(StateMachine*)> act = tc->provides(name)->getOperation("activate");
-    OperationCaller<bool(StateMachine*)> autom = tc->provides(name)->getOperation("automatic");
-    BOOST_CHECK( act(sm.get()) );
+    OperationCaller<bool(StateMachinePtr)> act = tc->provides(name)->getOperation("activate");
+    OperationCaller<bool(StateMachinePtr)> autom = tc->provides(name)->getOperation("automatic");
+    BOOST_CHECK( act(sm) );
     BOOST_CHECK( SimulationThread::Instance()->run(1) );
     BOOST_CHECK_MESSAGE( sm->isActive(), "Error : Activate Command for '"+sm->getName()+"' did not have effect." );
-    BOOST_CHECK( autom(sm.get()) || !test  );
+    BOOST_CHECK( autom(sm) || !test  );
 
     BOOST_CHECK( SimulationThread::Instance()->run(runs) );
 }

--- a/tests/state_test.cpp
+++ b/tests/state_test.cpp
@@ -953,7 +953,7 @@ BOOST_AUTO_TEST_CASE( testStateSubStateVars)
         + "     set y1.t = -1.0 \n"
         + " }\n"
         + " exit {\n"
-        + "     do y1.start()\n"
+        + "     do test.assert( y1.start() )\n"
         + " }\n"
         + " transitions {\n"
         + "     select TEST\n"
@@ -1078,9 +1078,9 @@ BOOST_AUTO_TEST_CASE( testStateOperationSignalTransition )
     string prog = string("StateMachine X {\n")
         + " var   double et = 0.0\n"
         + " initial state INIT {\n"
-        + "    transition o_event(et) select FINI\n" // test signal transition
+        + "    transition o_event(et) { test.assert(et == 3.33); } select FINI\n" // test signal transition
         + " }\n"
-        + " final state FINI {} \n"
+        + " final state FINI { entry { test.assert( et == 3.33);} } \n"
         + "}\n"
         + "RootMachine X x()\n";
     this->parseState( prog, tc );
@@ -1435,6 +1435,7 @@ BOOST_AUTO_TEST_CASE( testStateEvents)
 #ifdef ORO_SIGNALLING_OPERATIONS
         + "   transition o_event(et_local)\n"
         + "      if ( et_local == 3.0 ) then { do log(\"Local ISPOSITIVE->INIT Transition for o_event == \" + et_local);} select INIT\n"
+        + "         else { do log(\"Invalid et_local: \"+et_local); } \n"
 #endif
         + " }\n"
         + " state TESTSELF {\n"
@@ -1453,13 +1454,13 @@ BOOST_AUTO_TEST_CASE( testStateEvents)
         + " }\n" // 40
         + string("StateMachine X {\n") // 1
         + " SubMachine Y y1()\n"
-        + " initial state INIT {\n"
+        + " initial state XINIT {\n"
         + " entry {\n"
         + "     do y1.trace(true)\n"
         + "     do y1.activate()\n"
         + "     do y1.start()\n"
         + "     do yield\n"
-        + " }"
+        + " }\n"
         + " run {\n"
 
         + "     do d_event_source.write(-1.0)\n" // 11
@@ -1470,8 +1471,8 @@ BOOST_AUTO_TEST_CASE( testStateEvents)
         + "     do b_event_source.write( true )\n" // go to INIT.
         + "     do yield\n"
         + "     do test.assert( y1.inState(\"INIT\") )\n"
-
         + "     do d_event_source.write(+1.0)\n" // 21
+
         + "     do nothing\n"
         + "     do test.assert( !y1.inState(\"INIT\") )\n"
         + "     do test.assert( y1.inState(\"ISPOSITIVE\") )\n"
@@ -1481,11 +1482,11 @@ BOOST_AUTO_TEST_CASE( testStateEvents)
         + "     do test.assert( y1.inState(\"ISPOSITIVE\") )\n"
         + "     do b_event_source.write( true )\n" // go to INIT.
         + "     do yield\n"
-
         + "     do test.assert( y1.inState(\"INIT\") )\n" // 31
 #ifdef ORO_SIGNALLING_OPERATIONS
         // test operation
         + "     do d_event_source.write(+1.0)\n"
+
         + "     do nothing\n"
         + "     do test.assert( !y1.inState(\"INIT\") )\n"
         + "     do test.assert( y1.inState(\"ISPOSITIVE\") )\n"
@@ -1518,16 +1519,16 @@ BOOST_AUTO_TEST_CASE( testStateEvents)
         + "     do test.assert( y1.inState(\"INIT\") ) /* last */\n"
         + " }\n"
         + " transitions {\n"
-        + "     select FINI\n"
+        + "     select XFINI\n"
         + " }\n"
         + " }\n"
-        + " final state FINI {\n"
+        + " final state XFINI {\n"
         + " entry {\n"
         + "     do y1.deactivate()\n"
         //+ "     do test.assert(false)\n"
         + " }\n"
         + " transitions {\n"
-        + "     select INIT\n"
+        + "     select XINIT\n"
         + " }\n"
         + " }\n"
         + " }\n"
@@ -1834,6 +1835,9 @@ void StateTest::runState(const std::string& name, TaskContext* tc, bool trace, b
     StateMachinePtr sm = sa->getStateMachine(name);
     BOOST_REQUIRE( sm );
     sm->trace(trace);
+    StateMachine::ChildList children = sm->getChildren();
+    for( StateMachine::ChildList::iterator it = children.begin(); it != children.end(); ++it)
+        (*it)->trace(trace);
     OperationCaller<bool(StateMachine*)> act = tc->provides(name)->getOperation("activate");
     OperationCaller<bool(StateMachine*)> autom = tc->provides(name)->getOperation("automatic");
     BOOST_CHECK( act(sm.get()) );

--- a/tests/state_test.cpp
+++ b/tests/state_test.cpp
@@ -833,7 +833,7 @@ BOOST_AUTO_TEST_CASE( testStateYieldbySend )
         + "       do test.assert(false); }\n"
         + " transition o_event(d) select NEXT;\n"
         + " transitions {\n"
-        + "       select FINI\n"
+        + "       if test.i == 10 then select FINI\n"
         + " }\n"
         + " }\n"
         + " state NEXT {\n" // Success state.

--- a/tests/state_test.cpp
+++ b/tests/state_test.cpp
@@ -15,7 +15,7 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-
+#define ORO_SIGNALLING_OPERATIONS
 #include "unit.hpp"
 
 #include <rtt-config.h>
@@ -827,7 +827,8 @@ BOOST_AUTO_TEST_CASE( testStateYieldbySend )
         + " initial state INIT {\n"
         + " var double d = 0.0\n"
         + " run { do o_event.send(1.0); test.i = 5; do test.assert(test.i == 5);\n" // asynchronous send on o_event, so signal must be processed when we return.
-        + "       do yield;\n"
+        + "       do yield;\n" // o_event still in the message queue
+        + "       do yield;\n" // o_event should have been processed.
         + "       test.i = 10;\n"
         + "       do test.assert(false); }\n"
         + " transition o_event(d) select NEXT;\n"
@@ -1077,10 +1078,25 @@ BOOST_AUTO_TEST_CASE( testStateOperationSignalTransition )
     // test event reception from own component
     string prog = string("StateMachine X {\n")
         + " var   double et = 0.0\n"
+        + " var   int cnt = 0, check_exit = 0, check_exit2 = 0, check_run = 0, check_entry = 0, check_trans = 0, check_trans2 = 0\n"
         + " initial state INIT {\n"
-        + "    transition o_event(et) { test.assert(et == 3.33); } select FINI\n" // test signal transition
+        + "    transition o_event(et) { cnt=cnt+1; check_trans = cnt; test.assert(et == 3.33); } select CHECKER\n" // test signal transition
+        + "    exit { cnt=cnt+1; check_exit = cnt; }\n"
         + " }\n"
-        + " final state FINI { entry { test.assert( et == 3.33);} } \n"
+        + " state CHECKER {\n"
+        + "    entry { cnt=cnt+1; check_entry = cnt; test.assert( et == 3.33); } \n"
+        + "    run { cnt=cnt+1; check_run = cnt; }\n"
+        + "    exit { cnt=cnt+1; check_exit2 = cnt; }\n"
+        + "    transition { cnt=cnt+1; check_trans2 = cnt; } select FINI\n"
+        + " }\n"
+        + "final state FINI { entry {\n"
+        + "        test.assertEqual( check_trans, 1 );\n"
+        + "        test.assertEqual( check_exit, 2 );\n"
+        + "        test.assertEqual( check_entry, 3 );\n"
+        + "        test.assertEqual( check_run, 4 );\n"
+        + "        test.assertEqual( check_trans2, 5 );\n"
+        + "        test.assertEqual( check_exit2, 6 );\n"
+        + "  } } \n"
         + "}\n"
         + "RootMachine X x()\n";
     this->parseState( prog, tc );


### PR DESCRIPTION
This PR modifies the state machine execution logic in a non-backwards compatible way, but does introduce clear semantics of what is done when and in which step of the TaskContext.

Open questions:
* Shouldn't events be enabled already in entry{} ?
  * today they are not, and since we sleep after entry{} there's no way to intercept an event that came in during entry{} and respond to that. So the thing causing the event needs to move into run{}, but then a default transition will be taken if present because the event did not have time yet to be processed if it's send().
* Should the user have the choice where the SM goes to sleep ? 
  * between exit{} and entry{}
  * between entry{} and run{}
  * between run{} and transitions {}

