### PR TITLE
State machine bug fixes

### DIFF
--- a/rtt/scripting/StateMachine.cpp
+++ b/rtt/scripting/StateMachine.cpp
@@ -1214,8 +1214,6 @@ namespace RTT {
 
         // execute the entry program of the initial state.
         if ( !inError() ) {
-            enableEvents(current);
-
             if ( this->executePending() ) {
                 smStatus = Status::active;
                 TRACE("Activated.");

--- a/rtt/types/TypeInfoRepository.cpp
+++ b/rtt/types/TypeInfoRepository.cpp
@@ -53,7 +53,7 @@ namespace RTT
     using namespace detail;
 
     namespace {
-        boost::shared_ptr<TypeInfoRepository> typerepos;
+        static boost::shared_ptr<TypeInfoRepository> typerepos;
     }
 
     TypeInfoRepository::TypeInfoRepository()

--- a/rtt/types/TypeInfoRepository.cpp
+++ b/rtt/types/TypeInfoRepository.cpp
@@ -53,7 +53,7 @@ namespace RTT
     using namespace detail;
 
     namespace {
-        static boost::shared_ptr<TypeInfoRepository> typerepos;
+        boost::shared_ptr<TypeInfoRepository> typerepos;
     }
 
     TypeInfoRepository::TypeInfoRepository()

--- a/tests/corba_test.cpp
+++ b/tests/corba_test.cpp
@@ -46,7 +46,10 @@ public:
         pint1("pint1", "", 3), pdouble1(new Property<double>("pdouble1", "", -3.0)),
         aint1(3), adouble1(-3.0), wait(0)
     {
-    // connect DataPorts
+        // check operations (moved from OperationCallerComponent constructor for reuseability in corba-ipc-server)
+        BOOST_REQUIRE( caller->ready() );
+
+        // connect DataPorts
         mi1 = new InputPort<double> ("mi");
         mo1 = new OutputPort<double> ("mo");
 

--- a/tests/operations_fixture.cpp
+++ b/tests/operations_fixture.cpp
@@ -32,6 +32,59 @@ using namespace boost;
 using namespace RTT;
 using namespace RTT::detail;
 
+class OperationCallerComponent : public TaskContext
+{
+    TaskContext* mtc;
+public:
+    OperationCallerComponent(TaskContext* tc) : TaskContext("caller"), mtc(tc) {
+
+        // calls own thread operations :
+        opc0 = tc->provides("methods")->getOperation("o0");
+        opc0.setCaller( this->engine() );
+        opc1 = tc->provides("methods")->getOperation("o1");
+        opc1.setCaller( this->engine() );
+        // client thread :
+        opc2 = tc->provides("methods")->getOperation("m2");
+        opc2.setCaller( this->engine() );
+        opc3 = tc->provides("methods")->getOperation("m3");
+        opc3.setCaller( this->engine() );
+
+        BOOST_REQUIRE( opc0.ready() );
+        BOOST_REQUIRE( opc1.ready() );
+        BOOST_REQUIRE( opc2.ready() );
+        BOOST_REQUIRE( opc3.ready() );
+
+        // four combinations are possible:
+        this->addOperation("o0", &OperationCallerComponent::m0, this, OwnThread);
+        this->addOperation("o1", &OperationCallerComponent::m1, this, ClientThread);
+        this->addOperation("o2", &OperationCallerComponent::m2, this, OwnThread);
+        this->addOperation("o3", &OperationCallerComponent::m3, this, ClientThread);
+
+    }
+
+    void updateHook() {
+        // m0 and m2 are executed in OwnThread
+        // where m0 calls an OwnThread op of 'tc' and m2 calls a ClientThread op of 'tc'.
+
+        // m1 and m3 are executed in ClientThread (so in GlobalEE when being sent),
+        // where m1 calls an OwnThread op of 'tc' and m3 calls a ClientThread op of 'tc'.
+        // but do set the caller to this component.
+    }
+
+    // plain argument tests:
+    double m0(void) { return opc0(); }
+    double m1(int i) { return opc1(i); }
+    double m2(int i, double d) { return opc2(i,d); }
+    double m3(int i, double d, bool c) { return opc3(i,d,c); }
+
+    OperationCaller<double(void)> opc0;
+    OperationCaller<double(int)> opc1;
+    OperationCaller<double(int,double)> opc2;
+    OperationCaller<double(int,double,bool)> opc3;
+
+};
+
+
 OperationsFixture::OperationsFixture()
 {
     ret = 0.0;
@@ -39,7 +92,7 @@ OperationsFixture::OperationsFixture()
     tc = new TaskContext("root");
     this->createOperationCallerFactories(tc);
     tc->provides()->addAttribute("ret", ret );
-    caller = new TaskContext("caller");
+    caller = new OperationCallerComponent(tc);
     caller->start();
     tc->start();
 }

--- a/tests/operations_fixture.cpp
+++ b/tests/operations_fixture.cpp
@@ -49,11 +49,6 @@ public:
         opc3 = tc->provides("methods")->getOperation("m3");
         opc3.setCaller( this->engine() );
 
-        BOOST_REQUIRE( opc0.ready() );
-        BOOST_REQUIRE( opc1.ready() );
-        BOOST_REQUIRE( opc2.ready() );
-        BOOST_REQUIRE( opc3.ready() );
-
         // four combinations are possible:
         this->addOperation("o0", &OperationCallerComponent::m0, this, OwnThread);
         this->addOperation("o1", &OperationCallerComponent::m1, this, ClientThread);
@@ -69,6 +64,17 @@ public:
         // m1 and m3 are executed in ClientThread (so in GlobalEE when being sent),
         // where m1 calls an OwnThread op of 'tc' and m3 calls a ClientThread op of 'tc'.
         // but do set the caller to this component.
+    }
+
+    bool ready() {
+        BOOST_REQUIRE( opc0.ready() );
+        BOOST_REQUIRE( opc1.ready() );
+        BOOST_REQUIRE( opc2.ready() );
+        BOOST_REQUIRE( opc3.ready() );
+        return opc0.ready() &&
+               opc1.ready() &&
+               opc2.ready() &&
+               opc3.ready();
     }
 
     // plain argument tests:

--- a/tests/state_test.cpp
+++ b/tests/state_test.cpp
@@ -953,7 +953,7 @@ BOOST_AUTO_TEST_CASE( testStateSubStateVars)
         + "     set y1.t = -1.0 \n"
         + " }\n"
         + " exit {\n"
-        + "     do y1.start()\n"
+        + "     do test.assert( y1.start() )\n"
         + " }\n"
         + " transitions {\n"
         + "     select TEST\n"
@@ -1078,9 +1078,9 @@ BOOST_AUTO_TEST_CASE( testStateOperationSignalTransition )
     string prog = string("StateMachine X {\n")
         + " var   double et = 0.0\n"
         + " initial state INIT {\n"
-        + "    transition o_event(et) select FINI\n" // test signal transition
+        + "    transition o_event(et) { test.assert(et == 3.33); } select FINI\n" // test signal transition
         + " }\n"
-        + " final state FINI {} \n"
+        + " final state FINI { entry { test.assert( et == 3.33);} } \n"
         + "}\n"
         + "RootMachine X x()\n";
     this->parseState( prog, tc );
@@ -1435,6 +1435,7 @@ BOOST_AUTO_TEST_CASE( testStateEvents)
 #ifdef ORO_SIGNALLING_OPERATIONS
         + "   transition o_event(et_local)\n"
         + "      if ( et_local == 3.0 ) then { do log(\"Local ISPOSITIVE->INIT Transition for o_event == \" + et_local);} select INIT\n"
+        + "         else { do log(\"Invalid et_local: \"+et_local); } \n"
 #endif
         + " }\n"
         + " state TESTSELF {\n"
@@ -1453,13 +1454,13 @@ BOOST_AUTO_TEST_CASE( testStateEvents)
         + " }\n" // 40
         + string("StateMachine X {\n") // 1
         + " SubMachine Y y1()\n"
-        + " initial state INIT {\n"
+        + " initial state XINIT {\n"
         + " entry {\n"
         + "     do y1.trace(true)\n"
         + "     do y1.activate()\n"
         + "     do y1.start()\n"
         + "     do yield\n"
-        + " }"
+        + " }\n"
         + " run {\n"
 
         + "     do d_event_source.write(-1.0)\n" // 11
@@ -1470,8 +1471,8 @@ BOOST_AUTO_TEST_CASE( testStateEvents)
         + "     do b_event_source.write( true )\n" // go to INIT.
         + "     do yield\n"
         + "     do test.assert( y1.inState(\"INIT\") )\n"
-
         + "     do d_event_source.write(+1.0)\n" // 21
+
         + "     do nothing\n"
         + "     do test.assert( !y1.inState(\"INIT\") )\n"
         + "     do test.assert( y1.inState(\"ISPOSITIVE\") )\n"
@@ -1481,11 +1482,11 @@ BOOST_AUTO_TEST_CASE( testStateEvents)
         + "     do test.assert( y1.inState(\"ISPOSITIVE\") )\n"
         + "     do b_event_source.write( true )\n" // go to INIT.
         + "     do yield\n"
-
         + "     do test.assert( y1.inState(\"INIT\") )\n" // 31
 #ifdef ORO_SIGNALLING_OPERATIONS
         // test operation
         + "     do d_event_source.write(+1.0)\n"
+
         + "     do nothing\n"
         + "     do test.assert( !y1.inState(\"INIT\") )\n"
         + "     do test.assert( y1.inState(\"ISPOSITIVE\") )\n"
@@ -1518,16 +1519,16 @@ BOOST_AUTO_TEST_CASE( testStateEvents)
         + "     do test.assert( y1.inState(\"INIT\") ) /* last */\n"
         + " }\n"
         + " transitions {\n"
-        + "     select FINI\n"
+        + "     select XFINI\n"
         + " }\n"
         + " }\n"
-        + " final state FINI {\n"
+        + " final state XFINI {\n"
         + " entry {\n"
         + "     do y1.deactivate()\n"
         //+ "     do test.assert(false)\n"
         + " }\n"
         + " transitions {\n"
-        + "     select INIT\n"
+        + "     select XINIT\n"
         + " }\n"
         + " }\n"
         + " }\n"
@@ -1834,6 +1835,9 @@ void StateTest::runState(const std::string& name, TaskContext* tc, bool trace, b
     StateMachinePtr sm = sa->getStateMachine(name);
     BOOST_REQUIRE( sm );
     sm->trace(trace);
+    StateMachine::ChildList children = sm->getChildren();
+    for( StateMachine::ChildList::iterator it = children.begin(); it != children.end(); ++it)
+        (*it)->trace(trace);
     OperationCaller<bool(StateMachine*)> act = tc->provides(name)->getOperation("activate");
     OperationCaller<bool(StateMachine*)> autom = tc->provides(name)->getOperation("automatic");
     BOOST_CHECK( act(sm.get()) );

--- a/tests/state_test.cpp
+++ b/tests/state_test.cpp
@@ -697,10 +697,10 @@ BOOST_AUTO_TEST_CASE( testStateOperations)
      StateMachinePtr sm = sa->getStateMachine("x");
      BOOST_REQUIRE( sm );
      sm->trace(true);
-     OperationCaller<bool(StateMachine*)> act = tc->provides("x")->getOperation("activate");
-     OperationCaller<bool(StateMachine*)> autom = tc->provides("x")->getOperation("automatic");
-     BOOST_CHECK( act(sm.get()) );
-     BOOST_CHECK( autom(sm.get()) );
+     OperationCaller<bool(StateMachinePtr)> act = tc->provides("x")->getOperation("activate");
+     OperationCaller<bool(StateMachinePtr)> autom = tc->provides("x")->getOperation("automatic");
+     BOOST_CHECK( act(sm) );
+     BOOST_CHECK( autom(sm) );
 
      sleep(1); // we must allow the thread to transition...
 
@@ -1838,12 +1838,12 @@ void StateTest::runState(const std::string& name, TaskContext* tc, bool trace, b
     StateMachine::ChildList children = sm->getChildren();
     for( StateMachine::ChildList::iterator it = children.begin(); it != children.end(); ++it)
         (*it)->trace(trace);
-    OperationCaller<bool(StateMachine*)> act = tc->provides(name)->getOperation("activate");
-    OperationCaller<bool(StateMachine*)> autom = tc->provides(name)->getOperation("automatic");
-    BOOST_CHECK( act(sm.get()) );
+    OperationCaller<bool(StateMachinePtr)> act = tc->provides(name)->getOperation("activate");
+    OperationCaller<bool(StateMachinePtr)> autom = tc->provides(name)->getOperation("automatic");
+    BOOST_CHECK( act(sm) );
     BOOST_CHECK( SimulationThread::Instance()->run(1) );
     BOOST_CHECK_MESSAGE( sm->isActive(), "Error : Activate Command for '"+sm->getName()+"' did not have effect." );
-    BOOST_CHECK( autom(sm.get()) || !test  );
+    BOOST_CHECK( autom(sm) || !test  );
 
     BOOST_CHECK( SimulationThread::Instance()->run(runs) );
 }


### PR DESCRIPTION
This PR contains a subset of the patches in #135, that only fix bugs and do not change the execution semantics of Orocos state machines. We consider to only include those in the 2.9 release but not yet the new execution logic.

167076a68ced2fad11a0998ef4df76ade1b31200 solves an issue where the entry program of a state can be aborted by an event in some cases. dc1b39b86334ac0a6a897590dce689b8195e7ccd removes a duplicate call to `enableEvents()`, which would trigger an assert if RTT is compiled in debug mode. The other two are minor patches for the unit tests.
