### PR TITLE
gnulinux: use CLOCK_MONOTONIC for periodic tasks (fix #105)

### DIFF
--- a/rtt/os/gnulinux/fosi.h
+++ b/rtt/os/gnulinux/fosi.h
@@ -110,6 +110,19 @@ extern "C"
 #endif
     }
 
+    static inline NANO_TIME rtos_get_time_monotonic_ns( void )
+    {
+
+        TIME_SPEC tv;
+        clock_gettime(CLOCK_MONOTONIC, &tv);
+        // we can not include the C++ Time.hpp header !
+#ifdef __cplusplus
+        return NANO_TIME( tv.tv_sec ) * 1000000000LL + NANO_TIME( tv.tv_nsec );
+#else
+        return ( NANO_TIME ) ( tv.tv_sec * 1000000000LL ) + ( NANO_TIME ) ( tv.tv_nsec );
+#endif
+    }
+
     /**
      * This function should return ticks,
      * but we use ticks == nsecs in userspace

--- a/rtt/os/gnulinux/fosi_internal.cpp
+++ b/rtt/os/gnulinux/fosi_internal.cpp
@@ -225,7 +225,7 @@ namespace RTT
 	    // set period
 	    mytask->period = nanosecs;
 	    // set next wake-up time.
-	    mytask->periodMark = ticks2timespec( nano2ticks( rtos_get_time_ns() + nanosecs ) );
+	    mytask->periodMark = ticks2timespec( nano2ticks( rtos_get_time_monotonic_ns() + nanosecs ) );
 	}
 
 	INTERNAL_QUAL void rtos_task_set_period( RTOS_TASK* mytask, NANO_TIME nanosecs )
@@ -244,11 +244,11 @@ namespace RTT
             return 0;
 
         // record this to detect overrun.
-	    NANO_TIME now = rtos_get_time_ns();
+	    NANO_TIME now = rtos_get_time_monotonic_ns();
 	    NANO_TIME wake= task->periodMark.tv_sec * 1000000000LL + task->periodMark.tv_nsec;
 
         // inspired by nanosleep man page for this construct:
-        while ( clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &(task->periodMark), NULL) != 0 && errno == EINTR ) {
+        while ( clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &(task->periodMark), NULL) != 0 && errno == EINTR ) {
             errno = 0;
         }
 
@@ -265,7 +265,7 @@ namespace RTT
         else
         {
           TIME_SPEC ts = ticks2timespec( nano2ticks( task->period) );
-          TIME_SPEC now = ticks2timespec( rtos_get_time_ns() );
+          TIME_SPEC now = ticks2timespec( rtos_get_time_monotonic_ns() );
           NANO_TIME tn = (now.tv_nsec + ts.tv_nsec);
           task->periodMark.tv_nsec = tn % 1000000000LL;
           task->periodMark.tv_sec = ts.tv_sec + now.tv_sec + tn / 1000000000LL;


### PR DESCRIPTION
This PR applies the patch proposed by @rbrtslmn in #105.

It switches to use a monotonic clock source for periodic waiting in the gnulinux target, but it is also somehow incomplete because it does not fix the same issue for other broken targets (like MacOS), for waiting on condition variables and for RTT Timers.
