### PR TITLE
pluginloader: fixed segfault if a service plugin refuses to create a service instance to be loaded into the global service

### DIFF
--- a/rtt/plugin/PluginLoader.cpp
+++ b/rtt/plugin/PluginLoader.cpp
@@ -371,9 +371,15 @@ bool PluginLoader::loadService(string const& servicename, TaskContext* tc) {
                 }
             } else {
                 // loadPlugin( 0 ) was already called. So drop the service in the global service.
-                if (it->is_service)
+                if (it->is_service) {
                     try {
-                        return internal::GlobalService::Instance()->addService( it->createService()  );
+                        Service::shared_ptr service = it->createService();
+                        if (service) {
+                            return internal::GlobalService::Instance()->addService( service );
+                        } else {
+                            log(Error) << "Service " << servicename << " cannot be loaded into the global service." << endlog();
+                            return false;
+                        }
                     } catch(std::exception& e) {
                         log(Error) << "Service "<< servicename <<" threw an exception during loading in global service." << endlog();
                         log(Error) << "Exception: "<< e.what() << endlog();
@@ -382,10 +388,14 @@ bool PluginLoader::loadService(string const& servicename, TaskContext* tc) {
                         log(Error) << "Service "<< servicename <<" threw an unknown exception during loading in global service. " << endlog();
                         return false;
                     }
-                log(Error) << "Plugin "<< servicename << " was found, but it's not a Service." <<endlog();
+                } else {
+                    log(Error) << "Plugin "<< servicename << " was found, but it's not a Service." <<endlog();
+                    return false;
+                }
             }
         }
     }
+
     log(Error) << "No such service or plugin: '"<< servicename << "'"<< endlog();
     return false;
 }


### PR DESCRIPTION
Originally reported in orocos-toolchain/ocl#40.

To reproduce:

```
$ deployer
import("rtt_rosdeployment")
require("rosdeployment")
```

The problem is that `createService()` returns a null pointer in [rtt_rosdeployment_service.cpp](https://github.com/orocos/rtt_ros_integration/blob/indigo-devel/rtt_rosdeployment/src/rtt_rosdeployment_service.cpp) and the PluginLoader did not catch this case before forwarding it to `Service::addService()`.
