### PR TITLE
Implement CORBA disconnect(port).

### DIFF
--- a/rtt/transports/corba/RemotePorts.hpp
+++ b/rtt/transports/corba/RemotePorts.hpp
@@ -85,7 +85,6 @@ namespace RTT {
             bool createStream( const ConnPolicy& policy );
             virtual bool addConnection(internal::ConnID* port_id, base::ChannelElementBase::shared_ptr channel_input, ConnPolicy const& policy);
             void disconnect();
-            bool disconnect(base::PortInterface* p);
         };
 
         /**
@@ -106,6 +105,7 @@ namespace RTT {
             void keepLastWrittenValue(bool new_flag);
 
             using base::OutputPortInterface::createConnection;
+            virtual bool disconnect(PortInterface* port);
             bool createConnection( base::InputPortInterface& sink, ConnPolicy const& policy );
 
             virtual base::DataSourceBase::shared_ptr getDataSource() const;
@@ -160,6 +160,8 @@ namespace RTT {
 
             base::PortInterface* clone() const;
             base::PortInterface* antiClone() const;
+
+            virtual bool disconnect(PortInterface* port);
 
             base::DataSourceBase* getDataSource();
 

--- a/tests/corba_test.cpp
+++ b/tests/corba_test.cpp
@@ -598,6 +598,95 @@ BOOST_AUTO_TEST_CASE( testPortProxying )
     mo2->disconnect();
 }
 
+BOOST_AUTO_TEST_CASE( testRemotePortDisconnect )
+{
+    ts  = corba::TaskContextServer::Create( tc, false ); //no-naming
+    tp  = corba::TaskContextProxy::Create( ts->server(), true );
+    ts2  = corba::TaskContextServer::Create( t2, false ); //no-naming
+    tp2  = corba::TaskContextProxy::Create( ts2->server(), true );
+
+    // Create a default CORBA policy specification
+    RTT::ConnPolicy policy = ConnPolicy::data();
+    policy.init = false;
+    policy.transport = ORO_CORBA_PROTOCOL_ID; // force creation of non-local connections
+
+    base::PortInterface* untyped_port;
+
+    //mi1
+    untyped_port = tp->ports()->getPort("mi");
+    BOOST_CHECK(untyped_port);
+    base::InputPortInterface* read_port1 = dynamic_cast<base::InputPortInterface*>(tp->ports()->getPort("mi"));
+    BOOST_CHECK(read_port1);
+
+    //mi2
+    untyped_port = tp2->ports()->getPort("mi");
+    BOOST_CHECK(untyped_port);
+    base::InputPortInterface* read_port2 = dynamic_cast<base::InputPortInterface*>(tp2->ports()->getPort("mi"));
+    BOOST_CHECK(read_port2);
+
+    //mo2
+    untyped_port = tp2->ports()->getPort("mo");
+    BOOST_CHECK(untyped_port);
+    base::OutputPortInterface* write_port2 = dynamic_cast<base::OutputPortInterface*>(tp2->ports()->getPort("mo"));
+    BOOST_CHECK(write_port2);
+
+    //mo1
+    untyped_port = tp->ports()->getPort("mo");
+    BOOST_CHECK(untyped_port);
+    base::OutputPortInterface* write_port1 = dynamic_cast<base::OutputPortInterface*>(tp->ports()->getPort("mo"));
+    BOOST_CHECK(write_port1);
+
+    // Just make sure 'read_port' and 'write_port' are actually proxies and not
+    // the real thing
+    BOOST_CHECK(dynamic_cast<corba::RemoteInputPort*>(read_port1));
+    BOOST_CHECK(dynamic_cast<corba::RemoteInputPort*>(read_port2));
+    BOOST_CHECK(dynamic_cast<corba::RemoteOutputPort*>(write_port1));
+    BOOST_CHECK(dynamic_cast<corba::RemoteOutputPort*>(write_port2));
+
+    //create remote connections:
+    write_port2->connectTo(read_port1, policy);
+    BOOST_CHECK(read_port1->connected());
+    BOOST_CHECK(write_port2->connected());
+
+    //second connection to this input port
+    write_port1->connectTo(read_port1, policy);
+    BOOST_CHECK(write_port1->connected());
+
+    //disconnect single port connection (both remote), same tcs object.
+    write_port1->disconnect(read_port1);
+    BOOST_CHECK(read_port1->connected());
+    BOOST_CHECK(!write_port1->connected());
+
+    //disconnect single port connection, both remote, different tcs.
+    write_port2->disconnect(read_port1);
+    BOOST_CHECK(!read_port1->connected());
+
+    //check disconnecting call on reader port. (build connection again beforehand).
+    write_port2->connectTo(read_port1, policy);
+    BOOST_CHECK(read_port1->connected());
+    BOOST_CHECK(write_port2->connected());
+    BOOST_CHECK(read_port1->disconnect(write_port2));
+    BOOST_CHECK(!read_port1->connected());
+    BOOST_CHECK(!write_port2->connected());
+
+    //check connect and disconnect certain port, remote output to local input
+    //should give false cause not supported yet!
+    write_port2->connectTo(mi1, policy);
+    BOOST_CHECK(mi1->connected());
+    BOOST_CHECK(write_port2->connected());
+    BOOST_CHECK(!write_port2->disconnect(mi1));
+    mi1->disconnect(); //remove all connections works, so required for cleanup.
+
+    //check disconnect remote input port from local output port.
+    mo2->connectTo(read_port1, policy);
+    BOOST_CHECK(read_port1->connected());
+    BOOST_CHECK(mo2->connected());
+    BOOST_CHECK(read_port1->disconnect(mo2));
+    BOOST_CHECK(!mo2->connected());
+    BOOST_CHECK(!read_port1->connected());
+
+}
+
 BOOST_AUTO_TEST_CASE( testDataHalfs )
 {
     double result;


### PR DESCRIPTION
Disconnect from certain port.

Implementing the previous missing function to disconnect RTT::corba::RemoteOutputPort and RTT::corba::RemoteInputPorts from a certain given remote port.
(instead of disconnect all).