### PR TITLE
Fixed build when sequential activity is used by default

### DIFF
--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -340,7 +340,7 @@ namespace RTT
         if ( new_act == 0) {
 #if defined(ORO_ACT_DEFAULT_SEQUENTIAL)
             new_act = new SequentialActivity();
-#elseif defined(ORO_ACT_DEFAULT_ACTIVITY)
+#elif defined(ORO_ACT_DEFAULT_ACTIVITY)
             new_act = new Activity();
 #endif
         }


### PR DESCRIPTION
Build fails when configured to use sequential activity by default, trivial fix