### PR TITLE
Fixed typekit for bool sequences

### DIFF
--- a/rtt/types/SequenceTypeInfoBase.cpp
+++ b/rtt/types/SequenceTypeInfoBase.cpp
@@ -48,5 +48,12 @@ namespace RTT
                 return false;
             return cont[index];
         }
+
+        bool get_container_item_copy(const std::vector<bool> & cont, int index)
+        {
+            if (index >= (int) (cont.size()) || index < 0)
+                return false;
+            return cont[index];
+        }
     }
 }


### PR DESCRIPTION
This PR adds the missing implementation of specialized method `RTT::types::get_container_item_copy(const std::vector<bool> & cont, int index)` required by `SequenceTypeInfo<T>` implementation for type `std::vector<bool>`.

The default RTT typekit does not contain type `std::vector<bool>` and therefore does not trigger this error.