### PR TITLE
Fix mqueue transport and corba ipc tests

### DIFF
--- a/rtt/transports/mqueue/MQSendRecv.cpp
+++ b/rtt/transports/mqueue/MQSendRecv.cpp
@@ -199,33 +199,63 @@ bool MQSendRecv::mqReady(base::DataSourceBase::shared_ptr ds, base::ChannelEleme
         //
         // The output port implementation guarantees that there will be one
         // after the connection is ready
-        struct timespec abs_timeout;
-        clock_gettime(CLOCK_REALTIME, &abs_timeout);
-        abs_timeout.tv_nsec += Seconds_to_nsecs(0.5);
-        abs_timeout.tv_sec += abs_timeout.tv_nsec / (1000*1000*1000);
-        abs_timeout.tv_nsec = abs_timeout.tv_nsec % (1000*1000*1000);
-        //abs_timeout.tv_sec +=1;
-        ssize_t ret = mq_timedreceive(mqdes, buf, max_size, 0, &abs_timeout);
-        if (ret != -1)
-        {
-            if (mtransport.updateFromBlob((void*) buf, ret, ds, marshaller_cookie))
-            {
-                minit_done = true;
-                // ok, now we can add the dispatcher.
-                Dispatcher::Instance()->addQueue(mqdes, chan);
-                return true;
-            }
-            else
-            {
-                log(Error) << "Failed to initialize MQ Channel Element with initial data sample." << endlog();
+        struct timeval timeout;  /* Timeout for select */
+        fd_set socks;
+        FD_ZERO(&socks);
+        while (1) { /* select loop */
+            FD_SET(mqdes, &socks);
+            timeout.tv_sec = 0;
+            timeout.tv_usec = 500000;
+
+            /* The first argument to select is the highest file
+                descriptor value plus 1.*/
+
+            int readsocks = select(mqdes + 1, &socks, (fd_set *) 0,
+              (fd_set *) 0, &timeout);
+
+            /* select() returns the number of sockets that had
+                things going on with them -- i.e. they're readable. */
+
+            /* Once select() returns, the original fd_set has been
+                modified so it now reflects the state of why select()
+                woke up. i.e. If file descriptor 4 was originally in
+                the fd_set, and then it became readable, the fd_set
+                contains file descriptor 4 in it. */
+
+            if (readsocks < 0) {
+                log(Error) << "Failed to receive initial data sample for MQ Channel Element (select): " << strerror(errno) << endlog();
                 return false;
             }
-        }
-        else
-        {
-            log(Error) << "Failed to receive initial data sample for MQ Channel Element: " << strerror(errno) << endlog();
-            return false;
-        }
+            else if (readsocks == 0) {
+                log(Error) << "Failed to receive initial data sample for MQ Channel Element: timed out" << endlog();
+                return false;
+            } else { // readsocks > 0
+                ssize_t ret = mq_receive(mqdes, buf, max_size, 0);
+                if (ret != -1)
+                {
+                    if (mtransport.updateFromBlob((void*) buf, ret, ds, marshaller_cookie))
+                    {
+                        minit_done = true;
+                        // ok, now we can add the dispatcher.
+                        Dispatcher::Instance()->addQueue(mqdes, chan);
+                        return true;
+                    }
+                    else
+                    {
+                        log(Error) << "Failed to initialize MQ Channel Element with initial data sample." << endlog();
+                        return false;
+                    }
+                }
+                else if (errno == EAGAIN) {
+                    // nop
+                }
+                else
+                {
+                    log(Error) << "Failed to receive initial data sample for MQ Channel Element (mq_receive): " << strerror(errno) << endlog();
+                    return false;
+                }
+            }
+        } /* while(1) */
     }
     else
     {
@@ -239,7 +269,7 @@ bool MQSendRecv::mqReady(base::DataSourceBase::shared_ptr ds, base::ChannelEleme
 bool MQSendRecv::mqRead(RTT::base::DataSourceBase::shared_ptr ds)
 {
     int bytes = 0;
-    if ((bytes = mq_receive(mqdes, buf, max_size, 0)) == -1)
+    if ((bytes = mq_receive(mqdes, buf, max_size, 0)) <= 0)
     {
         //log(Debug) << "Tried read on empty mq!" <<endlog();
         return false;

--- a/tests/corba_ipc_server.cpp
+++ b/tests/corba_ipc_server.cpp
@@ -61,6 +61,7 @@ public:
         this->start();
         addOperation("callBackPeer", &TheServer::callBackPeer, this,ClientThread);
         addOperation("callBackPeerOwn", &TheServer::callBackPeer, this,OwnThread);
+        addOperation("resetCallBackPeer", &TheServer::resetCallBackPeer, this,OwnThread);
     }
     ~TheServer() {
         this->stop();
@@ -68,8 +69,10 @@ public:
 
     void updateHook(){
         double d = 123456.789;
-        mi1.read(d);
-        mo1.write(d);
+        FlowStatus fs = NoData;
+        while( (fs = mi1.read(d, false)) == NewData ) {
+            mo1.write(d);
+        }
     }
 
     corba::TaskContextServer* ts;
@@ -93,6 +96,13 @@ public:
 			log(Info) << "Server finishes send back peer:" << count << endlog();
 		}
 		log(Info) << "Server finishes callBackPeer():" << count << endlog();
+    }
+
+    void resetCallBackPeer() {
+        log(Info) << "Server resets callBackPeer state." <<endlog();
+        cbcount = 0;
+        is_calling = false;
+        is_sending = false;
     }
 
 };

--- a/tests/corba_ipc_server.cpp
+++ b/tests/corba_ipc_server.cpp
@@ -50,10 +50,10 @@ public:
     // Ports
     InputPort<double>  mi1;
     OutputPort<double> mo1;
-    bool is_calling, is_sending;
-    int cbcount;
+    enum { INITIAL, CALL, SEND, FINAL } callBackPeer_step;
+    int callBackPeer_count;
 
-    TheServer(string name) : TaskContext(name), mi1("mi"), mo1("mo"), is_calling(false), is_sending(false), cbcount(0) {
+    TheServer(string name) : TaskContext(name), mi1("mi"), mo1("mo"), callBackPeer_step(INITIAL), callBackPeer_count(0) {
         ports()->addEventPort( mi1 );
         ports()->addPort( mo1 );
         this->createOperationCallerFactories( this );
@@ -78,31 +78,32 @@ public:
     corba::TaskContextServer* ts;
 
     void callBackPeer(TaskContext* peer, string const& opname) {
-    	int count = ++cbcount;
-    	log(Info) << "Server executes callBackPeer():"<< count <<endlog();
-    	OperationCaller<void(TaskContext*, string const&)> op1 (peer->getOperation(opname), this->engine());
-		if (!is_calling) {
-			is_calling = true;
-			log(Info) << "Server calls back peer:" << count << endlog();
-			op1(this, "callBackPeerOwn");
-			log(Info) << "Server finishes call back peer:" << count << endlog();
-		}
+        OperationCaller<void(TaskContext*, string const&)> op1(peer->getOperation(opname), this->engine());
+        int count = ++callBackPeer_count;
 
-		if (!is_sending) {
-			is_sending = true;
-			log(Info) << "Server sends back peer:" << count << endlog();
-			SendHandle<void(TaskContext*, string const&)> handle = op1.send(
-					this, "callBackPeer");
-			log(Info) << "Server finishes send back peer:" << count << endlog();
-		}
-		log(Info) << "Server finishes callBackPeer():" << count << endlog();
+        if (callBackPeer_step == INITIAL) callBackPeer_step = CALL;
+
+        log(Info) << "Server executes callBackPeer():"<< count <<endlog();
+        if (callBackPeer_step == CALL) {
+            callBackPeer_step = SEND;
+            log(Info) << "Server calls back peer:" << count << endlog();
+            op1(this, "callBackPeerOwn");
+            log(Info) << "Server finishes call back peer:" << count << endlog();
+        }
+        else if (callBackPeer_step == SEND) {
+            callBackPeer_step = FINAL;
+            log(Info) << "Server sends back peer:" << count << endlog();
+            SendHandle<void(TaskContext*, string const&)> handle = op1.send(
+                                                                       this, "callBackPeer");
+            log(Info) << "Server finishes send back peer:" << count << endlog();
+        }
+        log(Info) << "Server finishes callBackPeer():" << count << endlog();
     }
 
     void resetCallBackPeer() {
         log(Info) << "Server resets callBackPeer state." <<endlog();
-        cbcount = 0;
-        is_calling = false;
-        is_sending = false;
+        callBackPeer_count = 0;
+        callBackPeer_step = INITIAL;
     }
 
 };

--- a/tests/corba_ipc_test.cpp
+++ b/tests/corba_ipc_test.cpp
@@ -77,7 +77,14 @@ public:
 
     void callBackPeer(TaskContext* peer, string const& opname) {
 	OperationCaller<void(TaskContext*, string const&)> op1( peer->getOperation(opname), this->engine());
+        OperationCaller<void()> resetCallBackPeer( peer->getOperation("resetCallBackPeer"), this->engine());
 	int count = ++cbcount;
+
+        if (!is_calling) {
+            log(Info) << "Test resets server." <<endlog();
+            resetCallBackPeer();
+        }
+
 	log(Info) << "Test executes callBackPeer():"<< count <<endlog();
 	if (!is_calling) {
 		is_calling = true;
@@ -289,6 +296,7 @@ BOOST_AUTO_TEST_CASE( testRemoteOperationCallerCallback )
     sleep(1); //asyncronous processing...
     BOOST_CHECK( is_calling );
     BOOST_CHECK( is_sending );
+    BOOST_CHECK_EQUAL( cbcount, 3 );
     BOOST_CHECK( handle.ready() );
     BOOST_CHECK_EQUAL( handle.collectIfDone(), SendSuccess );
 }
@@ -639,7 +647,7 @@ BOOST_AUTO_TEST_CASE( testBufferHalfs )
     // Check read of new data
     mo->write( 6.33 );
     mo->write( 3.33 );
-    wait_for_equal( cce->read( sample.out(), true), CNewData, 5 );
+    wait_for_equal( cce->read( sample.out(), true), CNewData, 10 );
     sample >>= result;
     BOOST_CHECK_EQUAL( result, 6.33);
     wait_for_equal( cce->read( sample.out(), true ), CNewData, 10 );

--- a/tests/corba_ipc_test.cpp
+++ b/tests/corba_ipc_test.cpp
@@ -62,10 +62,9 @@ public:
     // Ports
     InputPort<double>*  mi;
     OutputPort<double>* mo;
-    bool is_calling, is_sending;
+    enum { INITIAL, CALL, SEND, FINAL } callBackPeer_step;
+    int callBackPeer_count;
     SendHandle<void(TaskContext*, string const&)> handle;
-
-    int wait, cbcount;
 
     void setUp();
     void tearDown();
@@ -76,30 +75,30 @@ public:
     void testPortDisconnected();
 
     void callBackPeer(TaskContext* peer, string const& opname) {
-	OperationCaller<void(TaskContext*, string const&)> op1( peer->getOperation(opname), this->engine());
+        OperationCaller<void(TaskContext*, string const&)> op1( peer->getOperation(opname), this->engine());
         OperationCaller<void()> resetCallBackPeer( peer->getOperation("resetCallBackPeer"), this->engine());
-	int count = ++cbcount;
+        int count = ++callBackPeer_count;
 
-        if (!is_calling) {
+        if (callBackPeer_step == INITIAL) {
             log(Info) << "Test resets server." <<endlog();
             resetCallBackPeer();
+            callBackPeer_step = CALL;
         }
 
-	log(Info) << "Test executes callBackPeer():"<< count <<endlog();
-	if (!is_calling) {
-		is_calling = true;
-		log(Info) << "Test calls server:" << count <<endlog();
-		op1(this, "callBackPeer");
-		log(Info) << "Test finishes server call:"<<count <<endlog();
-	}
-
-	if (!is_sending) {
-		is_sending = true;
-		log(Info) << "Test sends server:"<<count <<endlog();
-		handle = op1.send(this, "callBackPeerOwn");
-		log(Info) << "Test finishes server send:"<< count <<endlog();
-	}
-	log(Info) << "Test finishes callBackPeer():"<< count <<endlog();
+        log(Info) << "Test executes callBackPeer():"<< count <<endlog();
+        if (callBackPeer_step == CALL) {
+            callBackPeer_step = SEND;
+            log(Info) << "Test calls server:" << count <<endlog();
+            op1(this, "callBackPeer");
+            log(Info) << "Test finishes server call:"<<count <<endlog();
+        }
+        else if (callBackPeer_step == SEND) {
+            callBackPeer_step = FINAL;
+            log(Info) << "Test sends server:"<<count <<endlog();
+            handle = op1.send(this, "callBackPeerOwn");
+            log(Info) << "Test finishes server send:"<< count <<endlog();
+        }
+        log(Info) << "Test finishes callBackPeer():"<< count <<endlog();
     }
 
 };
@@ -121,8 +120,8 @@ CorbaTest::setUp()
     t2 = 0;
     ts2 = ts = 0;
     tp2 = tp = 0;
-    wait = cbcount = 0;
-    is_calling = false, is_sending = false;
+    callBackPeer_count = 0;
+    callBackPeer_step = INITIAL;
 
     addOperation("callBackPeer", &CorbaTest::callBackPeer, this,ClientThread);
     addOperation("callBackPeerOwn", &CorbaTest::callBackPeer, this,OwnThread);
@@ -149,26 +148,30 @@ void CorbaTest::new_data_listener(base::PortInterface* port)
 }
 
 
-#define ASSERT_PORT_SIGNALLING(code, read_port) \
-    signalled_port = 0; wait = 0;\
+#define ASSERT_PORT_SIGNALLING(code, read_port) do { \
+    signalled_port = 0; \
+    int wait = 0; \
     code; \
     while (read_port != signalled_port && wait++ != 5) \
-    usleep(100000); \
-    BOOST_CHECK( read_port == signalled_port );
+        usleep(100000); \
+    BOOST_CHECK( read_port == signalled_port ); \
+} while(0)
 
-bool wait_for_helper;
-#define wait_for( cond, times ) \
-    wait = 0; \
+#define wait_for( cond, times ) do { \
+    bool wait_for_helper; \
+    int wait = 0; \
     while( (wait_for_helper = !(cond)) && wait++ != times ) \
-      usleep(100000); \
-    if (wait_for_helper) BOOST_CHECK( cond );
+        usleep(100000); \
+    if (wait_for_helper) BOOST_CHECK( cond ); \
+} while(0)
 
-#define wait_for_equal( a, b, times ) \
-    wait = 0; \
+#define wait_for_equal( a, b, times ) do { \
+    bool wait_for_helper; \
+    int wait = 0; \
     while( (wait_for_helper = ((a) != (b))) && wait++ != times ) \
-      usleep(100000); \
-    if (wait_for_helper) BOOST_CHECK_EQUAL( a, b );
-
+        usleep(100000); \
+    if (wait_for_helper) BOOST_CHECK_EQUAL( a, b ); \
+} while(0)
 
 void CorbaTest::testPortDataConnection()
 {
@@ -183,7 +186,7 @@ void CorbaTest::testPortDataConnection()
     BOOST_CHECK_EQUAL( mi->read(value), NoData );
 
     // Check if writing works (including signalling)
-    ASSERT_PORT_SIGNALLING(mo->write(1.0), mi)
+    ASSERT_PORT_SIGNALLING(mo->write(1.0), mi);
     BOOST_CHECK( mi->read(value) );
     BOOST_CHECK_EQUAL( 1.0, value );
     ASSERT_PORT_SIGNALLING(mo->write(2.0), mi);
@@ -292,11 +295,11 @@ BOOST_AUTO_TEST_CASE( testRemoteOperationCallerCallback )
     BOOST_REQUIRE( RTT::internal::DataSourceTypeInfo<TaskContext*>::getTypeInfo() !=  RTT::internal::DataSourceTypeInfo<UnknownType>::getTypeInfo());
     BOOST_REQUIRE( RTT::internal::DataSourceTypeInfo<TaskContext*>::getTypeInfo()->getProtocol(ORO_CORBA_PROTOCOL_ID) != 0 );
 
+    BOOST_REQUIRE_EQUAL( callBackPeer_step, INITIAL );
     this->callBackPeer(tp, "callBackPeer");
     sleep(1); //asyncronous processing...
-    BOOST_CHECK( is_calling );
-    BOOST_CHECK( is_sending );
-    BOOST_CHECK_EQUAL( cbcount, 3 );
+    BOOST_CHECK_EQUAL( callBackPeer_step, FINAL );
+    BOOST_CHECK_EQUAL( callBackPeer_count, 3 );
     BOOST_CHECK( handle.ready() );
     BOOST_CHECK_EQUAL( handle.collectIfDone(), SendSuccess );
 }

--- a/tests/corba_mqueue_ipc_server.cpp
+++ b/tests/corba_mqueue_ipc_server.cpp
@@ -52,8 +52,10 @@ public:
 
     void updateHook(){
         double d = 123456.789;
-        mi1.read(d);
-        mo1.write(d);
+        FlowStatus fs = NoData;
+        while( (fs = mi1.read(d, false)) == NewData ) {
+            mo1.write(d);
+        }
     }
 
     corba::TaskContextServer* ts;


### PR DESCRIPTION
There was a regression in the mqueue transport from https://github.com/orocos-toolchain/rtt/commit/a34a19ad740fc15a81574ade66c5266fdf340576. The inputReady() call on the receiving side of the channel did not block anymore on the data sample being received and therefore the `corba_mqueue_ipc_test` can fail depending on the number of CPUs available and load.

Furthermore I improved both tests that involve IPC, the `corba_ipc_test` and `corba_mqueue_ipc_test` to be more resilient against execution under high CPU load or on slow machines. Additionally, a `resetCallBackPeer()` method has been introduced in order to allow multiple executions of the test (the client) against the same running server process.

This PR will hopefully fix the [test errors on Travis](https://travis-ci.org/orocos-toolchain/rtt/builds/111562655) for the toolchain-2.9 branch.