### PR TITLE
Fixed potential double deallocation and pool corruption for circular BufferLockFree

### DIFF
--- a/rtt/base/BufferLockFree.hpp
+++ b/rtt/base/BufferLockFree.hpp
@@ -170,8 +170,15 @@ namespace RTT
                     // pop & deallocate until we have free space.
                     Item* itmp = 0;
                     do {
-                        bufs.dequeue( itmp );
-                        mpool.deallocate( itmp );
+                        if ( bufs.dequeue( itmp ) ) {
+                            mpool.deallocate( itmp );
+                        } else {
+                            // Both operations, enqueue() and dequeue() failed on the buffer:
+                            // We could free the allocated pool item return false here,
+                            // but in fact this can only happen during massive concurrent
+                            // access to the circular buffer or in the trivial case that
+                            // the buffer size is zero. So just keep on trying...
+                        }
                     } while ( bufs.enqueue( mitem ) == false );
                 }
             }


### PR DESCRIPTION
The missing check of the return value of `bufs.dequeue()` let the buffers_test fail from time to time under high CPU load because of memory pool corruption due to double deallocation.

Merged to toolchain-2.9 in https://github.com/orocos-toolchain/rtt/commit/dcc7df5dd7685b167f337e29a8fb99000c757f84.