### PR TITLE
corba: revert oneway writes and fixed connection cleanup and TAO builds

### DIFF
--- a/config/FindTAO.cmake
+++ b/config/FindTAO.cmake
@@ -193,7 +193,7 @@ MACRO(ORO_ADD_CORBA_SERVERS _sources _headers)
       GET_FILENAME_COMPONENT(_filedir ${_tmp_FILE} PATH)
 
       SET(_server  ${CMAKE_CURRENT_BINARY_DIR}/${_basename}S.cpp)
-      SET(_serverh ${CMAKE_CURRENT_BINARY_DIR}/${_basename}S.h ${CMAKE_CURRENT_BINARY_DIR}/${_basename}S.inl)
+      SET(_serverh ${CMAKE_CURRENT_BINARY_DIR}/${_basename}S.h)
 
       set(DEFINE_TAO "-DCORBA_IS_TAO")
       # From TAO 1.5 onwards, the _T files are no longer generated

--- a/rtt/transports/corba/CMakeLists.txt
+++ b/rtt/transports/corba/CMakeLists.txt
@@ -10,20 +10,26 @@ IF(ENABLE_CORBA)
   OPTION(PLUGINS_CORBA_PORTS_DISABLE_SIGNAL "Do not send remote signals for ports to the client side." OFF)
   if (PLUGINS_CORBA_PORTS_DISABLE_SIGNAL)
     MESSAGE("Disabled remote signalling in CORBA Transport library.")
-    ADD_DEFINITIONS( -DCORBA_PORTS_DISABLE_SIGNAL )
   endif (PLUGINS_CORBA_PORTS_DISABLE_SIGNAL)
+  set(RTT_CORBA_PORTS_DISABLE_SIGNAL ${PLUGINS_CORBA_PORTS_DISABLE_SIGNAL})  # for rtt-corba-config.h
+
+  OPTION(PLUGINS_CORBA_PORTS_WRITE_ONEWAY "Use oneway calls for port writes." OFF)
+  if (PLUGINS_CORBA_PORTS_WRITE_ONEWAY)
+    MESSAGE("Enabled oneway port writes in CORBA Transport library.")
+  endif (PLUGINS_CORBA_PORTS_WRITE_ONEWAY)
+  set(RTT_CORBA_PORTS_WRITE_ONEWAY ${PLUGINS_CORBA_PORTS_WRITE_ONEWAY})  # for rtt-corba-config.h
 
   OPTION(PLUGINS_CORBA_SEND_ONEWAY_OPERATIONS "Send oneway operations if collect arity is zero." OFF)
   if (PLUGINS_CORBA_SEND_ONEWAY_OPERATIONS)
     MESSAGE("Enabled oneway operation sending in CORBA Transport library.")
-    ADD_DEFINITIONS( -DCORBA_SEND_ONEWAY_OPERATIONS )
   endif (PLUGINS_CORBA_SEND_ONEWAY_OPERATIONS)
+  set(RTT_CORBA_SEND_ONEWAY_OPERATIONS ${PLUGINS_CORBA_SEND_ONEWAY_OPERATIONS})  # for rtt-corba-config.h
 
   OPTION(PLUGINS_CORBA_NO_CHECK_OPERATIONS "Check operation signature when constructing remote operation callers." OFF)
   if (PLUGINS_CORBA_NO_CHECK_OPERATIONS)
     MESSAGE("Disabled operation signature checking in CORBA Transport library.")
-    ADD_DEFINITIONS( -DCORBA_NO_CHECK_OPERATIONS )
   endif (PLUGINS_CORBA_NO_CHECK_OPERATIONS)
+  set(RTT_CORBA_NO_CHECK_OPERATIONS ${PLUGINS_CORBA_NO_CHECK_OPERATIONS})  # for rtt-corba-config.h
 
   # Clang 2.9 needs this in order to get around undefined symbols of inlined operator>>= functions !
   GET_FILENAME_COMPONENT(CORBA_CXX_NAME "${CMAKE_CXX_COMPILER}" NAME)

--- a/rtt/transports/corba/CorbaLib.cpp
+++ b/rtt/transports/corba/CorbaLib.cpp
@@ -115,11 +115,10 @@ namespace RTT {
 
             virtual base::ChannelElementBase* buildDataStorage(ConnPolicy const& policy) const { return 0; }
 
-            virtual CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface*, ::PortableServer::POA* poa, bool, bool, bool) const {
+            virtual CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface*, ::PortableServer::POA* poa, const ConnPolicy &) const {
                 Logger::In in("CorbaFallBackProtocol");
                 log(Error) << "Could create Channel : data type not known to CORBA Transport." <<Logger::endl;
                 return 0;
-
             }
 
             virtual base::ChannelElementBase* buildChannelOutput(base::InputPortInterface& port,

--- a/rtt/transports/corba/CorbaOperationCallerFactory.cpp
+++ b/rtt/transports/corba/CorbaOperationCallerFactory.cpp
@@ -274,7 +274,7 @@ public:
 };
 
 base::DataSourceBase::shared_ptr CorbaOperationCallerFactory::produce(const std::vector<base::DataSourceBase::shared_ptr>& args, ExecutionEngine* caller) const {
-#ifndef CORBA_NO_CHECK_OPERATIONS
+#ifndef RTT_CORBA_NO_CHECK_OPERATIONS
     corba::CAnyArguments_var nargs = new corba::CAnyArguments();
     nargs->length( args.size() );
 
@@ -288,14 +288,14 @@ base::DataSourceBase::shared_ptr CorbaOperationCallerFactory::produce(const std:
         DataSourceBase::shared_ptr tryout = ti->buildValue();
         ctt->updateAny(tryout, nargs[i]);
     }
-#endif // CORBA_NO_CHECK_OPERATIONS
+#endif
 
     // check argument types and produce:
     try {
-#ifndef CORBA_NO_CHECK_OPERATIONS
+#ifndef RTT_CORBA_NO_CHECK_OPERATIONS
         // will throw if wrong args.
         mfact->checkOperation(method.c_str(), nargs.in() );
-#endif // CORBA_NO_CHECK_OPERATIONS
+#endif
         // convert returned any to local type:
         const types::TypeInfo* ti = this->getArgumentType(0);
         if ( ti ) {
@@ -326,7 +326,7 @@ base::DataSourceBase::shared_ptr CorbaOperationCallerFactory::produce(const std:
 }
 
 base::DataSourceBase::shared_ptr CorbaOperationCallerFactory::produceSend(const std::vector<base::DataSourceBase::shared_ptr>& args, ExecutionEngine* caller) const {
-#ifndef CORBA_NO_CHECK_OPERATIONS
+#ifndef RTT_CORBA_NO_CHECK_OPERATIONS
     corba::CAnyArguments_var nargs = new corba::CAnyArguments();
     nargs->length( args.size() );
     for (size_t i=0; i < args.size(); ++i ) {
@@ -337,15 +337,16 @@ base::DataSourceBase::shared_ptr CorbaOperationCallerFactory::produceSend(const 
         DataSourceBase::shared_ptr tryout = ti->buildValue();
         ctt->updateAny(tryout, nargs[i]);
     }
-#endif // CORBA_NO_CHECK_OPERATIONS
+#endif
+
     try {
-#ifndef CORBA_NO_CHECK_OPERATIONS
+#ifndef RTT_CORBA_NO_CHECK_OPERATIONS
         // will throw if wrong args.
         mfact->checkOperation(method.c_str(), nargs.inout() );
-#endif // CORBA_NO_CHECK_OPERATIONS
+#endif
         // Will return a CSendHandle_var:
         DataSource<CSendHandle_var>::shared_ptr result = new ValueDataSource<CSendHandle_var>();
-#ifdef CORBA_SEND_ONEWAY_OPERATIONS
+#ifdef RTT_CORBA_SEND_ONEWAY_OPERATIONS
         bool oneway = (mdescription && mdescription->send_oneway);
 #else
         bool oneway = false;

--- a/rtt/transports/corba/CorbaTemplateProtocol.hpp
+++ b/rtt/transports/corba/CorbaTemplateProtocol.hpp
@@ -69,8 +69,8 @@ namespace RTT
            */
           typedef typename Property<T>::DataSourceType PropertyType;
 
-          CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface* sender, PortableServer::POA_ptr poa, bool is_pull, bool is_mandatory, bool is_signalling) const
-          { return new RemoteChannelElement<T>(*this, sender, poa, is_pull, is_mandatory, is_signalling); }
+          CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface* sender, PortableServer::POA_ptr poa, const ConnPolicy &policy) const
+          { return new RemoteChannelElement<T>(*this, sender, poa, policy); }
 
           /**
            * Create an transportable object for a \a protocol which contains the value of \a source.

--- a/rtt/transports/corba/CorbaTypeTransporter.hpp
+++ b/rtt/transports/corba/CorbaTypeTransporter.hpp
@@ -83,7 +83,7 @@ namespace RTT {
 	     * @param poa The POA to manage the server code.
 	     * @return the created CChannelElement_i.
 	     */
-        virtual CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface* sender, ::PortableServer::POA* poa, bool is_pull, bool is_mandatory, bool is_signalling) const = 0;
+        virtual CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface* sender, ::PortableServer::POA* poa, const ConnPolicy &policy) const = 0;
 
 	    /**
 	     * The CORBA transport does not support creating 'CORBA' streams.

--- a/rtt/transports/corba/DataFlow.idl
+++ b/rtt/transports/corba/DataFlow.idl
@@ -73,8 +73,14 @@ module RTT
 
         /**
          * Writes into this Channel Element.
+         * @return NotConnected if the channel became invalid
          */
-        oneway void write(in any sample);
+        CWriteStatus write(in any sample);
+
+        /**
+         * Writes into this Channel Element (one-way)
+         */
+        oneway void writeOneway(in any sample);
 
         /**
          * Disconnect and dispose this object.

--- a/rtt/transports/corba/DataFlowI.cpp
+++ b/rtt/transports/corba/DataFlowI.cpp
@@ -142,8 +142,8 @@ PortableServer::POA_ptr CDataFlowInterface_i::_default_POA()
 }
 
 CDataFlowInterface::CPortNames * CDataFlowInterface_i::getPorts() ACE_THROW_SPEC ((
-	      CORBA::SystemException
-	    ))
+          CORBA::SystemException
+        ))
 {
     ::RTT::DataFlowInterface::PortNames ports = mdf->getPortNames();
 
@@ -157,8 +157,8 @@ CDataFlowInterface::CPortNames * CDataFlowInterface_i::getPorts() ACE_THROW_SPEC
 }
 
 CDataFlowInterface::CPortDescriptions* CDataFlowInterface_i::getPortDescriptions() ACE_THROW_SPEC ((
-	      CORBA::SystemException
-	    ))
+          CORBA::SystemException
+        ))
 {
     RTT::DataFlowInterface::PortNames ports = mdf->getPortNames();
     RTT::corba::CDataFlowInterface::CPortDescriptions_var result = new RTT::corba::CDataFlowInterface::CPortDescriptions();
@@ -193,9 +193,9 @@ CDataFlowInterface::CPortDescriptions* CDataFlowInterface_i::getPortDescriptions
 }
 
 CPortType CDataFlowInterface_i::getPortType(const char * port_name) ACE_THROW_SPEC ((
-	      CORBA::SystemException
-	      ,::RTT::corba::CNoSuchPortException
-	    ))
+          CORBA::SystemException
+          ,::RTT::corba::CNoSuchPortException
+        ))
 {
     PortInterface* p = mdf->getPort(port_name);
     if (p == 0)
@@ -207,9 +207,9 @@ CPortType CDataFlowInterface_i::getPortType(const char * port_name) ACE_THROW_SP
 }
 
 char* CDataFlowInterface_i::getDataType(const char * port_name) ACE_THROW_SPEC ((
-	      CORBA::SystemException
-	      ,::RTT::corba::CNoSuchPortException
-	    ))
+          CORBA::SystemException
+          ,::RTT::corba::CNoSuchPortException
+        ))
 {
     PortInterface* p = mdf->getPort(port_name);
     if ( p == 0)
@@ -218,9 +218,9 @@ char* CDataFlowInterface_i::getDataType(const char * port_name) ACE_THROW_SPEC (
 }
 
 CORBA::Boolean CDataFlowInterface_i::isConnected(const char * port_name) ACE_THROW_SPEC ((
-	      CORBA::SystemException
-	      ,::RTT::corba::CNoSuchPortException
-	    ))
+          CORBA::SystemException
+          ,::RTT::corba::CNoSuchPortException
+        ))
 {
     PortInterface* p = mdf->getPort(port_name);
     if (p == 0)
@@ -241,9 +241,9 @@ void CDataFlowInterface_i::deregisterChannel(CChannelElement_ptr channel)
 }
 
 void CDataFlowInterface_i::disconnectPort(const char * port_name) ACE_THROW_SPEC ((
-	      CORBA::SystemException
-	      ,::RTT::corba::CNoSuchPortException
-	    ))
+          CORBA::SystemException
+          ,::RTT::corba::CNoSuchPortException
+        ))
 {
     PortInterface* p = mdf->getPort(port_name);
     if (p == 0) {
@@ -257,9 +257,9 @@ void CDataFlowInterface_i::disconnectPort(const char * port_name) ACE_THROW_SPEC
 bool CDataFlowInterface_i::removeConnection(
         const char* local_port,
         CDataFlowInterface_ptr remote_interface, const char* remote_port) ACE_THROW_SPEC ((
-        	      CORBA::SystemException
-        	      ,::RTT::corba::CNoSuchPortException
-        	    ))
+          CORBA::SystemException
+          ,::RTT::corba::CNoSuchPortException
+        ))
 {
     PortInterface* port = mdf->getPort(local_port);
     // CORBA does not support disconnecting from the input port
@@ -294,9 +294,9 @@ bool CDataFlowInterface_i::removeConnection(
 
 ::CORBA::Boolean CDataFlowInterface_i::createStream( const char* port,
                                RTT::corba::CConnPolicy & policy) ACE_THROW_SPEC ((
-                               	      CORBA::SystemException
-                               	      ,::RTT::corba::CNoSuchPortException
-                               	    ))
+          CORBA::SystemException
+          ,::RTT::corba::CNoSuchPortException
+        ))
 {
     PortInterface* p = mdf->getPort(port);
     if (p == 0) {
@@ -314,9 +314,9 @@ bool CDataFlowInterface_i::removeConnection(
 }
 
 void CDataFlowInterface_i::removeStream( const char* port, const char* stream_name) ACE_THROW_SPEC ((
-	      CORBA::SystemException
-	      ,::RTT::corba::CNoSuchPortException
-	    ))
+          CORBA::SystemException
+          ,::RTT::corba::CNoSuchPortException
+        ))
 {
     PortInterface* p = mdf->getPort(port);
     if (p == 0) {
@@ -331,11 +331,11 @@ void CDataFlowInterface_i::removeStream( const char* port, const char* stream_na
 
 CChannelElement_ptr CDataFlowInterface_i::buildChannelOutput(
         const char* port_name, CConnPolicy & corba_policy) ACE_THROW_SPEC ((
-         	      CORBA::SystemException
-         	      ,::RTT::corba::CNoCorbaTransport
-                  ,::RTT::corba::CNoSuchPortException
-                  ,::RTT::corba::CInvalidArgument
-         	    ))
+          CORBA::SystemException
+          ,::RTT::corba::CNoCorbaTransport
+          ,::RTT::corba::CNoSuchPortException
+          ,::RTT::corba::CInvalidArgument
+        ))
 {
     Logger::In in("CDataFlowInterface_i::buildChannelOutput");
     InputPortInterface* port = dynamic_cast<InputPortInterface*>(mdf->getPort(port_name));
@@ -431,11 +431,11 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelOutput(
  */
 CChannelElement_ptr CDataFlowInterface_i::buildChannelInput(
         const char* port_name, CConnPolicy & corba_policy) ACE_THROW_SPEC ((
-        	      CORBA::SystemException
-        	      ,::RTT::corba::CNoCorbaTransport
-        	      ,::RTT::corba::CNoSuchPortException
-                  ,::RTT::corba::CInvalidArgument
-        	    ))
+          CORBA::SystemException
+          ,::RTT::corba::CNoCorbaTransport
+          ,::RTT::corba::CNoSuchPortException
+          ,::RTT::corba::CInvalidArgument
+        ))
 {
     Logger::In in("CDataFlowInterface_i::buildChannelInput");
     // First check validity of user input...
@@ -516,7 +516,11 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelInput(
     return this_element->_this();
 }
 
-::CORBA::Boolean CDataFlowInterface_i::createSharedConnection(const char* port_name, ::RTT::corba::CConnPolicy& corba_policy)
+::CORBA::Boolean CDataFlowInterface_i::createSharedConnection(const char* port_name, ::RTT::corba::CConnPolicy& corba_policy) ACE_THROW_SPEC ((
+          CORBA::SystemException
+          ,::RTT::corba::CNoSuchPortException
+          ,::RTT::corba::CInvalidArgument
+        ))
 {
     Logger::In in("CDataFlowInterface_i::createSharedConnection");
     InputPortInterface* port = dynamic_cast<InputPortInterface*>(mdf->getPort(port_name));
@@ -551,9 +555,9 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelInput(
 ::CORBA::Boolean CDataFlowInterface_i::createConnection(
         const char* writer_port, CDataFlowInterface_ptr reader_interface,
         const char* reader_port, CConnPolicy & policy) ACE_THROW_SPEC ((
-        	      CORBA::SystemException
-        	      ,::RTT::corba::CNoSuchPortException
-        	    ))
+          CORBA::SystemException
+          ,::RTT::corba::CNoSuchPortException
+        ))
 {
     Logger::In in("CDataFlowInterface_i::createConnection");
     OutputPortInterface* writer = dynamic_cast<OutputPortInterface*>(mdf->getPort(writer_port));
@@ -607,15 +611,21 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelInput(
 
 // standard constructor
 CRemoteChannelElement_i::CRemoteChannelElement_i(RTT::corba::CorbaTypeTransporter const& transport,
-	  PortableServer::POA_ptr poa)
+    PortableServer::POA_ptr poa)
     : transport(transport)
     , mpoa(PortableServer::POA::_duplicate(poa))
     , mdataflow(0)
-    { }
+{}
 CRemoteChannelElement_i::~CRemoteChannelElement_i() {}
+
 PortableServer::POA_ptr CRemoteChannelElement_i::_default_POA()
-{ return PortableServer::POA::_duplicate(mpoa); }
+{
+    return PortableServer::POA::_duplicate(mpoa);
+}
+
 void CRemoteChannelElement_i::setRemoteSide(CRemoteChannelElement_ptr remote) ACE_THROW_SPEC ((
-	      CORBA::SystemException
-	    ))
-{ this->remote_side = RTT::corba::CRemoteChannelElement::_duplicate(remote); }
+          CORBA::SystemException
+        ))
+{
+    this->remote_side = RTT::corba::CRemoteChannelElement::_duplicate(remote);
+}

--- a/rtt/transports/corba/DataFlowI.cpp
+++ b/rtt/transports/corba/DataFlowI.cpp
@@ -380,14 +380,8 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelOutput(
         if (!end) throw CInvalidArgument();
     }
 
-#ifndef CORBA_PORTS_DISABLE_SIGNAL
-    bool is_signalling = true;
-#else
-    bool is_signalling = false;
-#endif
-
     CRemoteChannelElement_i* this_element =
-        transporter->createChannelElement_i(mdf, mpoa, corba_policy.pull, corba_policy.mandatory, is_signalling);
+        transporter->createChannelElement_i(mdf, mpoa, policy2);
     this_element->setCDataFlowInterface(this);
 
     /*
@@ -470,12 +464,7 @@ CChannelElement_ptr CDataFlowInterface_i::buildChannelInput(
 
     // The channel element that exposes our channel in CORBA
     CRemoteChannelElement_i* this_element;
-#ifndef CORBA_PORTS_DISABLE_SIGNAL
-    bool is_signalling = true;
-#else
-    bool is_signalling = false;
-#endif
-    PortableServer::ServantBase_var servant = this_element = transporter->createChannelElement_i(mdf, mpoa, corba_policy.pull, corba_policy.mandatory, is_signalling);
+    PortableServer::ServantBase_var servant = this_element = transporter->createChannelElement_i(mdf, mpoa, policy2);
     this_element->setCDataFlowInterface(this);
     assert( dynamic_cast<ChannelElementBase*>(this_element) );
 

--- a/rtt/transports/corba/DataFlowI.h
+++ b/rtt/transports/corba/DataFlowI.h
@@ -165,31 +165,31 @@ namespace RTT {
 
             // methods corresponding to defined IDL attributes and operations
             RTT::corba::CDataFlowInterface::CPortNames* getPorts() ACE_THROW_SPEC ((
-            	      CORBA::SystemException
-            	    ));
+                      CORBA::SystemException
+                    ));
             RTT::corba::CDataFlowInterface::CPortDescriptions* getPortDescriptions() ACE_THROW_SPEC ((
-            	      CORBA::SystemException
-            	    ));
+                      CORBA::SystemException
+                    ));
             RTT::corba::CPortType getPortType(const char* port_name) ACE_THROW_SPEC ((
-          	      CORBA::SystemException
-          	      ,::RTT::corba::CNoSuchPortException
-          	    ));
+                      CORBA::SystemException
+                      ,::RTT::corba::CNoSuchPortException
+                    ));
             char* getDataType(const char* port_name) ACE_THROW_SPEC ((
-            	      CORBA::SystemException
-            	      ,::RTT::corba::CNoSuchPortException
-            	    ));
+                      CORBA::SystemException
+                      ,::RTT::corba::CNoSuchPortException
+                    ));
             ::CORBA::Boolean isConnected(const char* port_name) ACE_THROW_SPEC ((
-            	      CORBA::SystemException
-            	      ,::RTT::corba::CNoSuchPortException
-            	    ));
+                      CORBA::SystemException
+                      ,::RTT::corba::CNoSuchPortException
+                    ));
             void disconnectPort(const char* port_name) ACE_THROW_SPEC ((
-            	      CORBA::SystemException
-            	      ,::RTT::corba::CNoSuchPortException
-            	    ));
+                      CORBA::SystemException
+                      ,::RTT::corba::CNoSuchPortException
+                    ));
 
             CChannelElement_ptr buildChannelOutput(const char* input_port, RTT::corba::CConnPolicy& policy) ACE_THROW_SPEC ((
-            	      CORBA::SystemException
-            	      ,::RTT::corba::CNoCorbaTransport
+                      CORBA::SystemException
+                      ,::RTT::corba::CNoCorbaTransport
                       ,::RTT::corba::CNoSuchPortException
                       ,::RTT::corba::CInvalidArgument
                     ));
@@ -205,9 +205,9 @@ namespace RTT {
                                                CDataFlowInterface_ptr reader_interface,
                                                const char* reader_port,
                                                RTT::corba::CConnPolicy & policy) ACE_THROW_SPEC ((
-                                             	      CORBA::SystemException
-                                             	      ,::RTT::corba::CNoSuchPortException
-                                             	    ));
+                      CORBA::SystemException
+                      ,::RTT::corba::CNoSuchPortException
+                    ));
 
             ::CORBA::Boolean createSharedConnection(const char *input_port, RTT::corba::CConnPolicy& policy) ACE_THROW_SPEC ((
                       CORBA::SystemException
@@ -218,19 +218,20 @@ namespace RTT {
             bool removeConnection( const char* writer_port,
                                                CDataFlowInterface_ptr reader_interface,
                                                const char* reader_port) ACE_THROW_SPEC ((
-                                             	      CORBA::SystemException
-                                             	      ,::RTT::corba::CNoSuchPortException
-                                             	    ));
+                      CORBA::SystemException
+                      ,::RTT::corba::CNoSuchPortException
+                    ));
 
             ::CORBA::Boolean createStream( const char* port,
                                            RTT::corba::CConnPolicy & policy) ACE_THROW_SPEC ((
-                                         	      CORBA::SystemException
-                                         	      ,::RTT::corba::CNoSuchPortException
-                                         	    ));
+                      CORBA::SystemException
+                      ,::RTT::corba::CNoSuchPortException
+                    ));
+
             void removeStream( const char* port, const char* stream_name) ACE_THROW_SPEC ((
-          	      CORBA::SystemException
-          	      ,::RTT::corba::CNoSuchPortException
-          	    ));
+                      CORBA::SystemException
+                      ,::RTT::corba::CNoSuchPortException
+                    ));
         };
     }
 };

--- a/rtt/transports/corba/RemoteChannelElement.hpp
+++ b/rtt/transports/corba/RemoteChannelElement.hpp
@@ -48,40 +48,29 @@ namespace RTT {
 
     namespace corba {
 
-	/**
-	 * Implements the CRemoteChannelElement of the CORBA IDL interface.
-	 * It converts the C++ calls into CORBA calls and vice versa.
-	 * A read will cause a call to the remote channel (which is of the
-	 * same type of this RemoteChannelElement) which returns an Any
-	 * with the data. A similar mechanism is in place for a write.
-	 */
-	template<typename T>
-	class RemoteChannelElement 
-	    : public CRemoteChannelElement_i
-	    , public base::ChannelElement<T>
-	{
+    /**
+     * Implements the CRemoteChannelElement of the CORBA IDL interface.
+     * It converts the C++ calls into CORBA calls and vice versa.
+     * A read will cause a call to the remote channel (which is of the
+     * same type of this RemoteChannelElement) which returns an Any
+     * with the data. A similar mechanism is in place for a write.
+     */
+    template<typename T>
+    class RemoteChannelElement
+        : public CRemoteChannelElement_i
+        , public base::ChannelElement<T>
+    {
 
-	    /**
-	     * Becomes false if we couldn't transfer data to remote
-	     */
-	    bool valid;
-	    /**
-	     * In pull mode, we don't send data, just signal it and remote must read it back.
-	     */
-	    bool pull;
         /**
-         * In mandatory mode, we wait for a return value in write(). Otherwise, write one-way.
+         * Becomes false if we couldn't transfer data to remote
          */
-        bool mandatory;
+        bool valid;
 
-	    DataFlowInterface* msender;
+        DataFlowInterface* msender;
 
         PortableServer::ObjectId_var oid;
 
-        /**
-         * If signalling is false, no remoteSignal() calls will be forwarded to remote channel elements.
-         */
-        bool signalling;
+        ConnPolicy policy;
 
         public:
             /**
@@ -89,11 +78,11 @@ namespace RTT {
              * @param transport The type specific object that will be used to marshal the data.
              * @param poa The POA that manages the underlying CRemoteChannelElement_i.
              */
-            RemoteChannelElement(CorbaTypeTransporter const& transport, DataFlowInterface* sender, PortableServer::POA_ptr poa, bool is_pull, bool is_mandatory, bool is_signalling)
+            RemoteChannelElement(CorbaTypeTransporter const& transport, DataFlowInterface* sender, PortableServer::POA_ptr poa, const ConnPolicy &policy)
             : CRemoteChannelElement_i(transport, poa)
-            , valid(true), pull(is_pull), mandatory(is_mandatory)
+            , valid(true)
             , msender(sender)
-            , signalling(is_signalling)
+            , policy(policy)
             {
                 // Big note about cleanup: The RTT will dispose this object through
 	            // the ChannelElement<T> refcounting. So we only need to inform the
@@ -146,12 +135,12 @@ namespace RTT {
                     return;
                 //log(Debug) <<"transfering..." <<endlog();
                 // in push mode, transfer all data, in pull mode, only signal once for each sample.
-                if ( pull ) {
+                if ( policy.pull == ConnPolicy::PULL ) {
                     try
                     {
-                        if (signalling) {
-                            remote_side->remoteSignal();
-                        }
+#ifndef RTT_CORBA_PORTS_DISABLE_SIGNAL
+                        remote_side->remoteSignal();
+#endif
                     }
 #ifdef CORBA_IS_OMNIORB
                     catch(CORBA::SystemException& e)
@@ -349,8 +338,13 @@ namespace RTT {
                         return WriteFailure;
                     }
 
-                    remote_side->write(write_any);
+#ifndef RTT_CORBA_PORTS_WRITE_ONEWAY
+                    CWriteStatus cfs = remote_side->write(write_any);
+                    return (WriteStatus)cfs;
+#else
+                    remote_side->writeOneway(write_any);
                     return WriteSuccess;
+#endif
                 }
 #ifdef CORBA_IS_OMNIORB
                 catch(CORBA::SystemException& e)
@@ -369,16 +363,27 @@ namespace RTT {
             /**
              * CORBA IDL function.
              */
-            void write(const ::CORBA::Any& sample) ACE_THROW_SPEC ((
+            CWriteStatus write(const ::CORBA::Any& sample) ACE_THROW_SPEC ((
                     CORBA::SystemException
                   ))
             {
                 typename internal::ValueDataSource<T> value_data_source;
                 value_data_source.ref();
                 if (!transport.updateFromAny(&sample, &value_data_source)) {
-                    return;
+                    return CWriteFailure;
                 }
-                base::ChannelElement<T>::write(value_data_source.rvalue());
+                WriteStatus fs = base::ChannelElement<T>::write(value_data_source.rvalue());
+                return (CWriteStatus)fs;
+            }
+
+            /**
+             * CORBA IDL function.
+             */
+            void writeOneway(const ::CORBA::Any& sample) ACE_THROW_SPEC ((
+                    CORBA::SystemException
+                  ))
+            {
+                (void) write(sample);
             }
 
             virtual WriteStatus data_sample(typename base::ChannelElement<T>::param_t sample)

--- a/rtt/transports/corba/RemotePorts.cpp
+++ b/rtt/transports/corba/RemotePorts.cpp
@@ -157,14 +157,9 @@ RTT::base::ChannelElementBase::shared_ptr RemoteInputPort::buildRemoteChannelOut
 
     // Input side is now ok and waiting for us to complete. We build our corba channel element too
     // and connect it to the remote side and vice versa.
-#ifndef CORBA_PORTS_DISABLE_SIGNAL
-    bool is_signalling = true;
-#else
-    bool is_signalling = false;
-#endif
     CRemoteChannelElement_i*  local =
         static_cast<CorbaTypeTransporter*>(type->getProtocol(ORO_CORBA_PROTOCOL_ID))
-                            ->createChannelElement_i(output_port.getInterface(), mpoa, policy.pull, policy.mandatory, is_signalling);
+                            ->createChannelElement_i(output_port.getInterface(), mpoa, policy);
 
     CRemoteChannelElement_var proxy = local->_this();
     local->setRemoteSide(remote);

--- a/rtt/transports/corba/Service.idl
+++ b/rtt/transports/corba/Service.idl
@@ -17,6 +17,7 @@ module RTT
 
     interface CService;
     struct CServiceDescription;
+    typedef sequence<CService> CServices;
     typedef sequence<CServiceDescription> CServiceDescriptions;
 
     /**
@@ -32,7 +33,7 @@ module RTT
         CConfigurationInterface::CAttributeNames attributes;
         CDataFlowInterface::CPortDescriptions ports;
 
-        sequence<CService> children;
+        CServices children;
         CServiceDescriptions children_descriptions;
     };
 

--- a/rtt/transports/corba/ServiceRequester.idl
+++ b/rtt/transports/corba/ServiceRequester.idl
@@ -17,6 +17,7 @@ module RTT
 
     interface CServiceRequester;
     struct CServiceRequesterDescription;
+    typedef sequence<CServiceRequester> CServiceRequesters;
     typedef sequence<CServiceRequesterDescription> CServiceRequesterDescriptions;
 
     /**
@@ -28,7 +29,7 @@ module RTT
         string name;
         COperationCallerNames operationcallernames;
 
-        sequence<CServiceRequester> children;
+        CServiceRequesters children;
         CServiceRequesterDescriptions children_descriptions;
     };
 

--- a/rtt/transports/corba/rtt-corba-config.h.in
+++ b/rtt/transports/corba/rtt-corba-config.h.in
@@ -14,6 +14,13 @@
 
 #cmakedefine CORBA_TAO_HAS_MESSAGING
 
+// CORBA transport configuration
+#cmakedefine RTT_CORBA_PORTS_DISABLE_SIGNAL
+#cmakedefine RTT_CORBA_PORTS_WRITE_ONEWAY
+#cmakedefine RTT_CORBA_SEND_ONEWAY_OPERATIONS
+#cmakedefine RTT_CORBA_NO_CHECK_OPERATIONS
+
+
 //
 // See: <http://gcc.gnu.org/wiki/Visibility>
 //


### PR DESCRIPTION
This PR adds some patches that fix the behavior of the CORBA transport in the toolchain-2.9 branch, which is a merge of various features, especially the efficiency patches (#123) and the updated dataflow semantics (#114).

The first commit 63218b0 fixes an issue that broke the proper cleanup after one end of a CORBA connection terminates or crashes. Now the `RemoteChannelElement::write()` call would return the WriteStatus `NotConnected` and thus indirectly, via the dispatcher, cause the writing side to remove the connection from the port. This is basically the behavior of RTT versions before 2.9. It is up to the user to eventually reestablish broken connections if the port's write call returns `NotConnected` in case this is required.

The second commit f69a0b7 reintroduces the standard blocking two-ways CORBA calls unless RTT has been compiled with the cmake option `PLUGINS_CORBA_PORTS_WRITE_ONEWAY` enabled explicitly. See also discussion in #122 and #123 for further information on this issue. It is up to a future update to make this a run-time option, e.g. by adding a boolean field `reliable` to the ConnPolicy struct.

The last commit bc6503b fixes some small issues if RTT is compiled with TAO as underlying CORBA implementation and corrects some whitespace inconsistencies. It has been tested with TAO 2.3.1 and all the unit tests run successfully now.