### PR TITLE
Moved instantiation of DataSource template types for bool and std::string from the typekit to the core library

### DIFF
--- a/rtt/internal/DataSource.hpp
+++ b/rtt/internal/DataSource.hpp
@@ -236,5 +236,15 @@ namespace RTT
 #ifndef ORO_CORELIB_DATASOURCES_HPP
 #include "DataSource.inl"
 #endif
+
+/*
+ * Extern template declarations for core data source types
+ * (instantiated in DataSources.cpp)
+ */
+RTT_EXT_IMPL template class RTT_API RTT::internal::DataSource< bool >;
+RTT_EXT_IMPL template class RTT_API RTT::internal::AssignableDataSource< bool >;
+RTT_EXT_IMPL template class RTT_API RTT::internal::DataSource< std::string >;
+RTT_EXT_IMPL template class RTT_API RTT::internal::AssignableDataSource< std::string >;
+
 #endif
 

--- a/rtt/internal/DataSources.hpp
+++ b/rtt/internal/DataSources.hpp
@@ -103,18 +103,6 @@ namespace RTT
     };
 
     /**
-     * Specialisation for std::string to keep capacity when set( ... ) is called.
-     */
-    template<>
-    RTT_API void ValueDataSource<std::string>::set(  AssignableDataSource<std::string>::param_t t );
-
-    /**
-     * Specialisation for std::string to keep capacity when clone() is called.
-     */
-    template<>
-    RTT_API ValueDataSource<std::string>::ValueDataSource(std::string t );
-
-    /**
      * A DataSource which holds a constant value and
      * returns it in its get() method. It can not be changed after creation.
      * @param T Any type of data, except being a non-const reference.
@@ -882,5 +870,15 @@ namespace RTT
 
 #include "DataSources.inl"
 
-#endif
+/*
+ * Extern template declarations for core data source types
+ * (instantiated in DataSources.cpp)
+ */
+RTT_EXT_IMPL template class RTT::internal::ValueDataSource< bool >;
+RTT_EXT_IMPL template class RTT::internal::ConstantDataSource< bool >;
+RTT_EXT_IMPL template class RTT::internal::ReferenceDataSource< bool >;
+RTT_EXT_IMPL template class RTT::internal::ValueDataSource< std::string >;
+RTT_EXT_IMPL template class RTT::internal::ConstantDataSource< std::string >;
+RTT_EXT_IMPL template class RTT::internal::ReferenceDataSource< std::string >;
 
+#endif

--- a/rtt/internal/DataSources.inl
+++ b/rtt/internal/DataSources.inl
@@ -16,6 +16,12 @@ namespace RTT
     {
     }
 
+    /**
+     * Specialisation for std::string to keep capacity when clone() is called.
+     */
+    template<>
+    ValueDataSource<std::string>::ValueDataSource(std::string t );
+
     template<typename T>
     ValueDataSource<T>::ValueDataSource( )
         : mdata()
@@ -27,6 +33,12 @@ namespace RTT
     {
         mdata = t;
     }
+
+    /**
+     * Specialisation for std::string to keep capacity when set( ... ) is called.
+     */
+    template<>
+    void ValueDataSource<std::string>::set(  AssignableDataSource<std::string>::param_t t );
 
     template<typename T>
     ValueDataSource<T>* ValueDataSource<T>::clone() const

--- a/rtt/rt_string.cpp
+++ b/rtt/rt_string.cpp
@@ -1,11 +1,11 @@
 /***************************************************************************
-  tag: Peter Soetens  Mon Jun 26 13:25:56 CEST 2006  DataSources.cxx
+  tag: The SourceWorks  Tue Sep 7 00:55:19 CEST 2010  rt_string.hpp
 
-                        DataSources.cxx -  description
+                        rt_string.hpp -  description
                            -------------------
-    begin                : Mon June 26 2006
-    copyright            : (C) 2006 Peter Soetens
-    email                : peter.soetens@fmtc.be
+    begin                : Tue September 07 2010
+    copyright            : (C) 2010 The SourceWorks
+    email                : peter@thesourceworks.com
 
  ***************************************************************************
  *   This library is free software; you can redistribute it and/or         *
@@ -35,42 +35,13 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "rt_string.hpp"
 
-#include "DataSources.hpp"
-
-namespace RTT {
-    namespace internal { 
-
-    /**
-     * Specialisation for std::string to keep capacity when set( ... ) is called.
+namespace std
+{
+    /*
+     * Explicit template instantiation
      */
-    template<>
-    void ValueDataSource<std::string>::set( AssignableDataSource<std::string>::param_t t )
-    {
-        mdata = t.c_str();
-    }
-
-    /**
-     * Specialisation for std::string to keep capacity when clone() is called.
-     */
-    template<>
-    ValueDataSource<std::string>::ValueDataSource( std::string t )
-        : mdata( t.c_str() )
-    {
-    }
-    }
+    template class basic_string<char, char_traits<char>, RTT::os::rt_allocator<char> >;
+    template class basic_ostringstream<char, char_traits<char>, RTT::os::rt_allocator<char> >;
 }
-
-/*
- * Explicit template instantiation for core data source types
- */
-template class RTT::internal::DataSource< bool >;
-template class RTT::internal::AssignableDataSource< bool >;
-template class RTT::internal::ValueDataSource< bool >;
-template class RTT::internal::ConstantDataSource< bool >;
-template class RTT::internal::ReferenceDataSource< bool >;
-template class RTT::internal::DataSource< std::string >;
-template class RTT::internal::AssignableDataSource< std::string >;
-template class RTT::internal::ValueDataSource< std::string >;
-template class RTT::internal::ConstantDataSource< std::string >;
-template class RTT::internal::ReferenceDataSource< std::string >;

--- a/rtt/rt_string.hpp
+++ b/rtt/rt_string.hpp
@@ -40,6 +40,7 @@
 #define _RTT_RT_STRING_HPP 1
 
 #include "os/oro_allocator.hpp"
+#include "rtt-config.h"
 #include <string>
 #include <sstream>
 
@@ -63,6 +64,15 @@ namespace RTT
      std::string s1("Hello world");
      OCL::String s2(s1.c_str());
      */
+}
+
+namespace std
+{
+    /**
+     * Extern template declaration
+     */
+    RTT_EXT_IMPL template class basic_string<char, char_traits<char>, RTT::os::rt_allocator<char> >;
+    RTT_EXT_IMPL template class basic_ostringstream<char, char_traits<char>, RTT::os::rt_allocator<char> >;
 }
 
 #endif

--- a/rtt/rtt-config.h.in
+++ b/rtt/rtt-config.h.in
@@ -60,10 +60,13 @@
    // Use RTT_HIDE to explicitly hide a symbol
 #  define RTT_HIDE   __attribute__((visibility("hidden")))
 
+#  define RTT_EXT_IMPL extern
+
 # else
 #  define RTT_API
 #  define RTT_EXPORT __attribute__((visibility("default")))
 #  define RTT_HIDE   __attribute__((visibility("hidden")))
+#  define RTT_EXT_IMPL extern
 # endif
 #else
    // Win32 and NOT GNU
@@ -72,15 +75,18 @@
 #   define RTT_API    __declspec(dllexport)
 #   define RTT_EXPORT __declspec(dllexport)
 #   define RTT_HIDE   
+#   define RTT_EXT_IMPL extern
 #  else
 #   define RTT_API	 __declspec(dllimport)
 #   define RTT_EXPORT __declspec(dllexport)
 #   define RTT_HIDE 
+#   define RTT_EXT_IMPL extern
 #  endif
 # else
 #  define RTT_API
 #  define RTT_EXPORT
 #  define RTT_HIDE
+#  define RTT_EXT_IMPL
 # endif
 #endif
 

--- a/rtt/typekit/RTTTypes.hpp
+++ b/rtt/typekit/RTTTypes.hpp
@@ -18,11 +18,6 @@
 #endif
 
 #ifdef CORELIB_DATASOURCE_HPP
-    RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::DataSource< bool >;
-    RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::AssignableDataSource< bool >;
-#endif
-
-#ifdef CORELIB_DATASOURCE_HPP
     RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::DataSource< RTT::FlowStatus >;
     RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::AssignableDataSource< RTT::FlowStatus >;
 #endif

--- a/rtt/typekit/Types.hpp
+++ b/rtt/typekit/Types.hpp
@@ -41,11 +41,6 @@
     RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::Attribute< int >;
 #endif
 
-#ifdef ORO_CORELIB_DATASOURCES_HPP
-    RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::ValueDataSource< bool >;
-    RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::ConstantDataSource< bool >;
-    RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::ReferenceDataSource< bool >;
-#endif
 #ifdef ORO_OUTPUT_PORT_HPP
     RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::OutputPort< bool >;
 #endif
@@ -148,19 +143,6 @@
 #endif
 
 
-// Disable string for now, we have specilisations in DataSources.hpp which 
-// confuse our logic or our compiler:
-#if 0
-#ifdef CORELIB_DATASOURCE_HPP
-    RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::DataSource< std::string >;
-    RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::AssignableDataSource< std::string >;
-#endif
-#ifdef ORO_CORELIB_DATASOURCES_HPP
-    RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::ValueDataSource< std::string >;
-    RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::ConstantDataSource< std::string >;
-    RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::ReferenceDataSource< std::string >;
-#endif
-#endif
 #ifdef ORO_OUTPUT_PORT_HPP
     RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::OutputPort< std::string >;
 #endif
@@ -198,18 +180,12 @@
 #endif
 
 
-RTT_TYPEKIT_EXT_TMPL template class std::basic_string<char, std::char_traits<char>, RTT::os::rt_allocator<char> >;
-
 #ifdef CORELIB_DATASOURCE_HPP
-#if 0
-RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::DataSource< RTT::rt_string >;
-#endif
+    RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::DataSource< RTT::rt_string >;
     RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::AssignableDataSource< RTT::rt_string >;
 #endif
 #ifdef ORO_CORELIB_DATASOURCES_HPP
-#if 0
     RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::ValueDataSource< RTT::rt_string >;
-#endif
     RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::ConstantDataSource< RTT::rt_string >;
     RTT_TYPEKIT_EXT_TMPL template class RTT_TYPEKIT_API RTT::internal::ReferenceDataSource< RTT::rt_string >;
 #endif

--- a/rtt/typekit/Types.inc
+++ b/rtt/typekit/Types.inc
@@ -1,29 +1,22 @@
-
-// bool needs a special treatment, since the GCC compiler already
-// instantiates it when it sees a line like DataSource<bool>::shared_ptr...
-// So we need to put it before the ports/Operations code which contains lots of these.
 #include "../internal/DataSource.hpp"
 #include "../internal/DataSources.hpp"
-  namespace RTT { namespace internal { 
-    template class RTT_EXPORT DataSource< bool >; 
-    template class RTT_EXPORT AssignableDataSource< bool >; 
-    template class RTT_EXPORT ReferenceDataSource< bool >; 
-    }}
 
 #include "../InputPort.hpp"
 #include "../OutputPort.hpp"
 #include "../Attribute.hpp"
 #include "../Property.hpp"
 
-  namespace RTT { namespace internal { 
-    template class RTT_EXPORT ValueDataSource< bool >; 
-    template class RTT_EXPORT ConstantDataSource< bool >; 
-    } 
+  namespace RTT {
     template class RTT_EXPORT OutputPort< bool >; 
     template class RTT_EXPORT InputPort< bool >; 
     template class RTT_EXPORT Property< bool >; 
     template class RTT_EXPORT Attribute< bool >; 
-    }
+
+    template class RTT_EXPORT OutputPort< std::string >;
+    template class RTT_EXPORT InputPort< std::string >;
+    template class RTT_EXPORT Property< std::string >;
+    template class RTT_EXPORT Attribute< std::string >;
+  }
 
 #define RTT_EXPORT_TEMPLATE_TYPE( TYPE ) \
   namespace RTT { namespace internal { \
@@ -39,17 +32,14 @@
     template class RTT_EXPORT Attribute< TYPE >; \
     }
 
-//RTT_EXPORT_TEMPLATE_TYPE(bool)
 RTT_EXPORT_TEMPLATE_TYPE(double)
 RTT_EXPORT_TEMPLATE_TYPE(int)
 RTT_EXPORT_TEMPLATE_TYPE(unsigned int)
 RTT_EXPORT_TEMPLATE_TYPE(float)
 RTT_EXPORT_TEMPLATE_TYPE(char)
-RTT_EXPORT_TEMPLATE_TYPE(std::string)
 
 #include <rtt/rt_string.hpp>
 
-template class std::basic_string<char, std::char_traits<char>, RTT::os::rt_allocator<char> >;
 RTT_EXPORT_TEMPLATE_TYPE(RTT::rt_string)
 
 


### PR DESCRIPTION
This is for consistency reasons and to avoid duplicate code generation.
The RTT core already uses various bool and std::string data sources internally and hence already has
instantiations of these template classes. This patch adds extern template declarations to the DataSource.hpp and DataSources.hpp headers and removes them from the typekit headers.

Also the instantiation of the rt_string and rt_ostringstream classes (not of the respective RTT template
instantiations) has been moved from the typekit to the core library for similar reasons.

This patch removes the GCC compiler warning `type attributes ignored after type is already defined [-Wattributes]` while compiling the typekit library (from Types.inc) because of inconsistent visibility attributes.
