### PR TITLE
Added method setDataSource() and assignment operator to the PropertyBase interface

### DIFF
--- a/rtt/base/PropertyBase.hpp
+++ b/rtt/base/PropertyBase.hpp
@@ -76,6 +76,12 @@ namespace RTT
         PropertyBase();
 
         /**
+         * Mirror another PropertyBase (name, description and value).
+         * @param source A pointer to the property to mirror.
+         */
+        virtual PropertyBase& operator=( PropertyBase* source ) = 0;
+
+        /**
          * Get the name of the property.
          * @return name of the property.
          */
@@ -187,10 +193,17 @@ namespace RTT
         virtual PropertyBase* create() const = 0;
 
         /**
-         * Get a internal::DataSource through which this PropertyBase can be
-         * manipulated.
+         * Get an assignable base::DataSource through which this PropertyBase
+         * can be manipulated.
          */
         virtual DataSourceBase::shared_ptr getDataSource() const = 0;
+
+        /**
+         * Assign an external assignable base::DataSource to this property.
+         * @param dsb The other data source
+         * @return false if the Properties are of different type.
+         */
+        virtual bool setDataSource( const DataSourceBase::shared_ptr& dsb ) = 0;
 
         /**
          * Returns the type of this PropertyBase. Uses the

--- a/tests/property_test.cpp
+++ b/tests/property_test.cpp
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE( testCopyUpdateLink )
     BOOST_REQUIRE_EQUAL( pi2->get(), pi1->get() );
     BOOST_REQUIRE_EQUAL( pi1ref->getName(), pi1->getName() );
     BOOST_REQUIRE_EQUAL( pi1ref->getDescription(), pi1->getDescription() );
-    BOOST_REQUIRE_NE( pi2->getDataSource(), pi1->getDataSource() );
+    BOOST_REQUIRE_NE( pi2->getDataSource().get(), pi1->getDataSource().get() );
     *pi1 = intref;
 
     // update with PropertyBase pointer
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE( testCopyUpdateLink )
     BOOST_REQUIRE_EQUAL( pi2->get(), pi1->get() );
     BOOST_REQUIRE_EQUAL( pi1ref->getName(), pi1->getName() );
     BOOST_REQUIRE_EQUAL( pi1ref->getDescription(), pi1->getDescription() );
-    BOOST_REQUIRE_NE( pi2->getDataSource(), pi1->getDataSource() );
+    BOOST_REQUIRE_NE( pi2->getDataSource().get(), pi1->getDataSource().get() );
     *pi1 = intref;
 
     // copy semantics
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE( testCopyUpdateLink )
     BOOST_REQUIRE_EQUAL( pi2->get(), pi1->get() );
     BOOST_REQUIRE_EQUAL( pi2ref->getName(), pi1->getName() );
     BOOST_REQUIRE_EQUAL( pi2ref->getDescription(), pi1->getDescription() );
-    BOOST_REQUIRE_NE( pi2->getDataSource(), pi1->getDataSource() );
+    BOOST_REQUIRE_NE( pi2->getDataSource().get(), pi1->getDataSource().get() );
     pi1->copy( *pi1ref );
 
     // copy with PropertyBase pointer
@@ -142,11 +142,11 @@ BOOST_AUTO_TEST_CASE( testCopyUpdateLink )
     BOOST_REQUIRE_EQUAL( pi2->get(), pi1->get() );
     BOOST_REQUIRE_EQUAL( pi2ref->getName(), pi1->getName() );
     BOOST_REQUIRE_EQUAL( pi2ref->getDescription(), pi1->getDescription() );
-    BOOST_REQUIRE_NE( pi2->getDataSource(), pi1->getDataSource() );
+    BOOST_REQUIRE_NE( pi2->getDataSource().get(), pi1->getDataSource().get() );
     pi1->copy( pi1ref );
 
     RTT::Property<int> pi1orig = pi1;
-    BOOST_REQUIRE_EQUAL( pi1orig.getDataSource(), pi1->getDataSource() );
+    BOOST_REQUIRE_EQUAL( pi1orig.getDataSource().get(), pi1->getDataSource().get() );
 
     // link semantics with PropertyBase pointer assignment
     *pi1 = pib2;
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE( testCopyUpdateLink )
     BOOST_REQUIRE_EQUAL( pi2->get(), pi1->get() );
     BOOST_REQUIRE_EQUAL( pi2ref->getName(), pi1->getName() );
     BOOST_REQUIRE_EQUAL( pi2ref->getDescription(), pi1->getDescription() );
-    BOOST_REQUIRE_EQUAL( pi2->getDataSource(), pi1->getDataSource() );
+    BOOST_REQUIRE_EQUAL( pi2->getDataSource().get(), pi1->getDataSource().get() );
     *pi1 = pi1orig;
 
     // link semantics with setDataSource() method (value only)
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE( testCopyUpdateLink )
     BOOST_REQUIRE_EQUAL( pi2->get(), pi1->get() );
     BOOST_REQUIRE_EQUAL( pi1ref->getName(), pi1->getName() );
     BOOST_REQUIRE_EQUAL( pi1ref->getDescription(), pi1->getDescription() );
-    BOOST_REQUIRE_EQUAL( pi2->getDataSource(), pi1->getDataSource() );
+    BOOST_REQUIRE_EQUAL( pi2->getDataSource().get(), pi1->getDataSource().get() );
     BOOST_CHECK( pi1->setDataSource( pi1orig.getDataSource() ) );
 }
 
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE( testCopyUpdateLinkChar )
     BOOST_REQUIRE_EQUAL( pc2.get(), pc1.get() );
     BOOST_REQUIRE_EQUAL( pc1ref.getName(), pc1.getName() );
     BOOST_REQUIRE_EQUAL( pc1ref.getDescription(), pc1.getDescription() );
-    BOOST_REQUIRE_NE( pc2.getDataSource(), pc1.getDataSource() );
+    BOOST_REQUIRE_NE( pc2.getDataSource().get(), pc1.getDataSource().get() );
     pc1 = 'e';
 
     // update with PropertyBase pointer
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE( testCopyUpdateLinkChar )
     BOOST_REQUIRE_EQUAL( pc2.get(), pc1.get() );
     BOOST_REQUIRE_EQUAL( pc1ref.getName(), pc1.getName() );
     BOOST_REQUIRE_EQUAL( pc1ref.getDescription(), pc1.getDescription() );
-    BOOST_REQUIRE_NE( pc2.getDataSource(), pc1.getDataSource() );
+    BOOST_REQUIRE_NE( pc2.getDataSource().get(), pc1.getDataSource().get() );
     pc1 = 'l';
 
     // copy semantics
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE( testCopyUpdateLinkChar )
     BOOST_REQUIRE_EQUAL( pc2.get(), pc1.get() );
     BOOST_REQUIRE_EQUAL( pc2ref.getName(), pc1.getName() );
     BOOST_REQUIRE_EQUAL( pc2ref.getDescription(), pc1.getDescription() );
-    BOOST_REQUIRE_NE( pc2.getDataSource(), pc1.getDataSource() );
+    BOOST_REQUIRE_NE( pc2.getDataSource().get(), pc1.getDataSource().get() );
     pc1.copy( pc1ref );
 
     // copy with PropertyBase pointer
@@ -201,11 +201,11 @@ BOOST_AUTO_TEST_CASE( testCopyUpdateLinkChar )
     BOOST_REQUIRE_EQUAL( pc2.get(), pc1.get() );
     BOOST_REQUIRE_EQUAL( pc2ref.getName(), pc1.getName() );
     BOOST_REQUIRE_EQUAL( pc2ref.getDescription(), pc1.getDescription() );
-    BOOST_REQUIRE_NE( pc2.getDataSource(), pc1.getDataSource() );
+    BOOST_REQUIRE_NE( pc2.getDataSource().get(), pc1.getDataSource().get() );
     pc1.copy( pc1ref );
 
     RTT::Property<char> pc1orig = &pc1;
-    BOOST_REQUIRE_EQUAL( pc1orig.getDataSource(), pc1.getDataSource() );
+    BOOST_REQUIRE_EQUAL( pc1orig.getDataSource().get(), pc1.getDataSource().get() );
 
     // link semantics with PropertyBase pointer assignment
     pc1 = pcb2;
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE( testCopyUpdateLinkChar )
     BOOST_REQUIRE_EQUAL( pc2.get(), pc1.get() );
     BOOST_REQUIRE_EQUAL( pc2ref.getName(), pc1.getName() );
     BOOST_REQUIRE_EQUAL( pc2ref.getDescription(), pc1.getDescription() );
-    BOOST_REQUIRE_EQUAL( pc2.getDataSource(), pc1.getDataSource() );
+    BOOST_REQUIRE_EQUAL( pc2.getDataSource().get(), pc1.getDataSource().get() );
     pc1 = &pc1orig;
 
     // link semantics with setDataSource() method (value only)
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE( testCopyUpdateLinkChar )
     BOOST_REQUIRE_EQUAL( pc2.get(), pc1.get() );
     BOOST_REQUIRE_EQUAL( pc1ref.getName(), pc1.getName() );
     BOOST_REQUIRE_EQUAL( pc1ref.getDescription(), pc1.getDescription() );
-    BOOST_REQUIRE_EQUAL( pc2.getDataSource(), pc1.getDataSource() );
+    BOOST_REQUIRE_EQUAL( pc2.getDataSource().get(), pc1.getDataSource().get() );
     BOOST_CHECK( pc1.setDataSource( pc1orig.getDataSource() ) );
 }
 

--- a/tests/property_test.cpp
+++ b/tests/property_test.cpp
@@ -106,8 +106,10 @@ bool operator==(const std::vector<double>& a, const std::vector<double>& b)
 
 BOOST_FIXTURE_TEST_SUITE( PropertyTestSuite, PropertyTest )
 
-BOOST_AUTO_TEST_CASE( testCopyUpdate )
+BOOST_AUTO_TEST_CASE( testCopyUpdateLink )
 {
+    RTT::base::PropertyBase* pib2 = pi2;
+
     *pi1 = intref;
     *pi2 = 0;
 
@@ -116,68 +118,117 @@ BOOST_AUTO_TEST_CASE( testCopyUpdate )
     BOOST_REQUIRE_EQUAL( pi2->get(), pi1->get() );
     BOOST_REQUIRE_EQUAL( pi1ref->getName(), pi1->getName() );
     BOOST_REQUIRE_EQUAL( pi1ref->getDescription(), pi1->getDescription() );
-    *pi2 = 0;
+    BOOST_REQUIRE_NE( pi2->getDataSource(), pi1->getDataSource() );
+    *pi1 = intref;
 
-    // update with PropertyBase.
-    BOOST_CHECK( pi1->update( pi2 ) );
+    // update with PropertyBase pointer
+    BOOST_CHECK( pi1->update( static_cast< PropertyBase* >(pi2) ) );
     BOOST_REQUIRE_EQUAL( pi2->get(), pi1->get() );
     BOOST_REQUIRE_EQUAL( pi1ref->getName(), pi1->getName() );
     BOOST_REQUIRE_EQUAL( pi1ref->getDescription(), pi1->getDescription() );
-    *pi2 = 0;
+    BOOST_REQUIRE_NE( pi2->getDataSource(), pi1->getDataSource() );
+    *pi1 = intref;
 
     // copy semantics
     pi1->copy( *pi2 );
     BOOST_REQUIRE_EQUAL( pi2->get(), pi1->get() );
     BOOST_REQUIRE_EQUAL( pi2ref->getName(), pi1->getName() );
     BOOST_REQUIRE_EQUAL( pi2ref->getDescription(), pi1->getDescription() );
+    BOOST_REQUIRE_NE( pi2->getDataSource(), pi1->getDataSource() );
     pi1->copy( *pi1ref );
 
-    // copy with PropertyBase.
-    BOOST_CHECK( pi1->copy( pi2 ) );
+    // copy with PropertyBase pointer
+    BOOST_CHECK( pi1->copy( pib2 ) );
     BOOST_REQUIRE_EQUAL( pi2->get(), pi1->get() );
     BOOST_REQUIRE_EQUAL( pi2ref->getName(), pi1->getName() );
     BOOST_REQUIRE_EQUAL( pi2ref->getDescription(), pi1->getDescription() );
+    BOOST_REQUIRE_NE( pi2->getDataSource(), pi1->getDataSource() );
     pi1->copy( pi1ref );
+
+    RTT::Property<int> pi1orig = pi1;
+    BOOST_REQUIRE_EQUAL( pi1orig.getDataSource(), pi1->getDataSource() );
+
+    // link semantics with PropertyBase pointer assignment
+    *pi1 = pib2;
+    BOOST_CHECK( pi1->ready() );
+    BOOST_REQUIRE_EQUAL( pi2->get(), pi1->get() );
+    BOOST_REQUIRE_EQUAL( pi2ref->getName(), pi1->getName() );
+    BOOST_REQUIRE_EQUAL( pi2ref->getDescription(), pi1->getDescription() );
+    BOOST_REQUIRE_EQUAL( pi2->getDataSource(), pi1->getDataSource() );
+    *pi1 = pi1orig;
+
+    // link semantics with setDataSource() method (value only)
+    BOOST_CHECK( pi1->setDataSource( pi2->getDataSource() ) );
+    BOOST_REQUIRE_EQUAL( pi2->get(), pi1->get() );
+    BOOST_REQUIRE_EQUAL( pi1ref->getName(), pi1->getName() );
+    BOOST_REQUIRE_EQUAL( pi1ref->getDescription(), pi1->getDescription() );
+    BOOST_REQUIRE_EQUAL( pi2->getDataSource(), pi1->getDataSource() );
+    BOOST_CHECK( pi1->setDataSource( pi1orig.getDataSource() ) );
 }
 
-BOOST_AUTO_TEST_CASE( testCopyUpdateChar )
+BOOST_AUTO_TEST_CASE( testCopyUpdateLinkChar )
 {
-    pc2 = 'H';
     PropertyBase* pcb2 = &pc2;
+
+    pc2 = 'H';
 
     // update semantics
     pc1.update( pc2 );
     BOOST_REQUIRE_EQUAL( pc2.get(), pc1.get() );
     BOOST_REQUIRE_EQUAL( pc1ref.getName(), pc1.getName() );
     BOOST_REQUIRE_EQUAL( pc1ref.getDescription(), pc1.getDescription() );
-    pc2 = 'e';
+    BOOST_REQUIRE_NE( pc2.getDataSource(), pc1.getDataSource() );
+    pc1 = 'e';
 
-    // update with PropertyBase.
+    // update with PropertyBase pointer
     BOOST_CHECK( pc1.update( pcb2 ) );
     BOOST_REQUIRE_EQUAL( pc2.get(), pc1.get() );
     BOOST_REQUIRE_EQUAL( pc1ref.getName(), pc1.getName() );
     BOOST_REQUIRE_EQUAL( pc1ref.getDescription(), pc1.getDescription() );
-    pc2 = 'l';
+    BOOST_REQUIRE_NE( pc2.getDataSource(), pc1.getDataSource() );
+    pc1 = 'l';
 
     // copy semantics
     pc1.copy( pc2 );
     BOOST_REQUIRE_EQUAL( pc2.get(), pc1.get() );
     BOOST_REQUIRE_EQUAL( pc2ref.getName(), pc1.getName() );
     BOOST_REQUIRE_EQUAL( pc2ref.getDescription(), pc1.getDescription() );
+    BOOST_REQUIRE_NE( pc2.getDataSource(), pc1.getDataSource() );
     pc1.copy( pc1ref );
 
-    // copy with PropertyBase.
+    // copy with PropertyBase pointer
     BOOST_CHECK( pc1.copy( pcb2 ) );
     BOOST_REQUIRE_EQUAL( pc2.get(), pc1.get() );
     BOOST_REQUIRE_EQUAL( pc2ref.getName(), pc1.getName() );
     BOOST_REQUIRE_EQUAL( pc2ref.getDescription(), pc1.getDescription() );
+    BOOST_REQUIRE_NE( pc2.getDataSource(), pc1.getDataSource() );
     pc1.copy( pc1ref );
+
+    RTT::Property<char> pc1orig = &pc1;
+    BOOST_REQUIRE_EQUAL( pc1orig.getDataSource(), pc1.getDataSource() );
+
+    // link semantics with PropertyBase pointer assignment
+    pc1 = pcb2;
+    BOOST_CHECK( pc1.ready() );
+    BOOST_REQUIRE_EQUAL( pc2.get(), pc1.get() );
+    BOOST_REQUIRE_EQUAL( pc2ref.getName(), pc1.getName() );
+    BOOST_REQUIRE_EQUAL( pc2ref.getDescription(), pc1.getDescription() );
+    BOOST_REQUIRE_EQUAL( pc2.getDataSource(), pc1.getDataSource() );
+    pc1 = &pc1orig;
+
+    // link semantics with setDataSource() method (value only)
+    BOOST_CHECK( pc1.setDataSource( pc2.getDataSource() ) );
+    BOOST_REQUIRE_EQUAL( pc2.get(), pc1.get() );
+    BOOST_REQUIRE_EQUAL( pc1ref.getName(), pc1.getName() );
+    BOOST_REQUIRE_EQUAL( pc1ref.getDescription(), pc1.getDescription() );
+    BOOST_REQUIRE_EQUAL( pc2.getDataSource(), pc1.getDataSource() );
+    BOOST_CHECK( pc1.setDataSource( pc1orig.getDataSource() ) );
 }
 
-BOOST_AUTO_TEST_CASE( testUpdateCharClone )
+BOOST_AUTO_TEST_CASE( testCreateUpdateChar )
 {
     PropertyBag target;
-    // step 1 : clone a new instance (non deep copy)
+    // step 1 : create a new instance (non deep copy)
     PropertyBase* temp = pc1.create();
     // step 2 : deep copy clone with original, will never fail.
     BOOST_CHECK( temp->update( &pc1 ) );


### PR DESCRIPTION
These new methods can be used to "link" a property to another without having to know the exact derived type, e.g.:

```cpp
bool linkProperty(RTT::base::PropertyBase *target,
                  const RTT::base::PropertyBase *source) {
    return target->setDataSource(source->getDataSource());
    // or
    *target = source;
    return target.ready();
}
```

```cpp
// create another property b which mirrors a
RTT::Property<double> a("a", "example property", 5.0);
RTT::PropertyBase *b = a->create();
*b = a;  // or linkProperty(b, &a)
assert(b.getDataSource() == a.getDataSource());
```

It should be noted that the assignment `*b = a` in the above example is equivalent to `b = a->copy()` because `PropertyBase::copy()` introduced in 44b9970e9685b9b812ddce1e8cc8c9b400553d54 also has linking semantics (shared data source). This is in fact inconsistent with the `PropertyBase::copy(const PropertyBase *)` or `DataSourceBase::copy()` methods which have deep-copy semantics -- so probably a candidate for removal in 2.9? The only usage of `PropertyBase::copy()` within RTT itself is [PropertyBag assignment](https://github.com/orocos-toolchain/rtt/blob/a37947a06a448dd9d8a8376e67ff1e5c8266e354/rtt/PropertyBag.cpp#L227), which is supposed to have linking semantics, too, and which has a slightly different behavior for owned vs. non-owned properties.

The `RTT::Property<T>::Property(base::PropertyBase *)` constructor and assignment operator have been updated to call the new method for consistency reasons. The patch is not ABI compatible. That's why I would like to integrate it before an official 2.9 release.

We would need this feature to build an application-wide, consolidated property tree which also allows for dynamic updates (with manual coordination).