### PR TITLE
property: remove copy() method and allow to construct or create a property with a custom data source

### DIFF
--- a/rtt/PropertyBag.cpp
+++ b/rtt/PropertyBag.cpp
@@ -233,7 +233,7 @@ namespace RTT
 
         for( const_iterator i = orig.mproperties.begin(); i != orig.mproperties.end(); ++i) {
             if ( orig.ownsProperty( *i ) ) {
-                PropertyBase* copy = (*i)->copy();
+                PropertyBase* copy = (*i)->create( (*i)->getDataSource() );
                 this->ownProperty( copy );
             } else {
                 this->add( *i );

--- a/rtt/base/PropertyBase.hpp
+++ b/rtt/base/PropertyBase.hpp
@@ -173,18 +173,18 @@ namespace RTT
         virtual PropertyBase* clone() const = 0;
 
         /**
-         * Deliver a shallow copy of this PropertyBase with a shared
-         * DataSource. The original may be deleted and the clone can be
-         * transparantly used in its place or vice versa.
-         */
-        virtual PropertyBase* copy() const = 0;
-
-        /**
          * Create a new default instance of the PropertyBase.
          * This is a factory method to 'make something of the same type'.
          * The new PropertyBase has the same name and description as this.
          */
         virtual PropertyBase* create() const = 0;
+
+        /**
+         * Create a new instance of the PropertyBase with a custom data source.
+         * This is a factory method to 'make something of the same type'.
+         * The new PropertyBase has the same name and description as this.
+         */
+        virtual PropertyBase* create( const base::DataSourceBase::shared_ptr& datasource ) const = 0;
 
         /**
          * Get a internal::DataSource through which this PropertyBase can be


### PR DESCRIPTION
Following my suggestion in #158, this patch removes the `RTT::base::PropertyBase::copy()` method and introduces

[PropertyBag assignment](https://github.com/orocos-toolchain/rtt/blob/953c0ec5960cf148ed78b784a5767b78c5254044/rtt/PropertyBag.cpp#L227) is supposed to have linking semantics (changing the value of a property in the copy also changes the value in the original bag), which is important for property composition and decomposition.

The `PropertyBase::copy()` method introduced in 44b9970e9685b9b812ddce1e8cc8c9b400553d54 had this linking semantics and was used for PropertyBag assignment, but the term `copy` was actually always associated with deep-copy semantics in RTT, like in PropertyBase::copy(const PropertyBase *) or in DataSourceBase::copy().

This patch introduces an alternative signature for the create() method, which accepts a custom data source instead of creating a default-initialized ValueDataSource. PropertyBag assignment now calls this `PropertyBase::create(const DataSourceBase::shared_ptr&)` method with the DataSource of the original property to be linked.

This reverts commit 44b9970e9685b9b812ddce1e8cc8c9b400553d54.
