### PR TITLE
env-hooks: install env-hook to etc/orocos/OROCOS_TARGET/profile.d

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,14 @@ INSTALL(FILES UseOROCOS-RTT.cmake UseOROCOS-RTT-helpers.cmake config/cmake_unins
 # Install package.xml
 INSTALL(FILES package.xml DESTINATION share/rtt)
 
-# Install an env-hook if catkin is found
+# Install an env-hook in etc/orocos/${OROCOS_TARGET}/profile.d
+configure_file(env-hooks/00.rtt.sh.in ${CMAKE_CURRENT_BINARY_DIR}/env-hooks/00.rtt.sh @ONLY)
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/env-hooks/00.rtt.sh
+  DESTINATION etc/orocos/${OROCOS_TARGET}/profile.d
+)
+
+# Install a catkin env-hook if catkin is installed
 find_package(catkin QUIET)
 if(catkin_FOUND)
   catkin_add_env_hooks(00.rtt SHELLS sh DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)

--- a/env-hooks/00.rtt.sh.in
+++ b/env-hooks/00.rtt.sh.in
@@ -1,4 +1,16 @@
 #!/bin/sh
-export OROCOS_TARGET=@OROCOS_TARGET@
-export RTT_COMPONENT_PATH=`echo $CMAKE_PREFIX_PATH | sed 's!:!/lib/orocos:!g' | sed 's!$!/lib/orocos!'`
 
+: ${OROCOS_TARGET:=@OROCOS_TARGET@}
+
+for path in `echo $CMAKE_PREFIX_PATH | tr : ' '` "@CMAKE_INSTALL_PREFIX@"; do
+  if [ ! -d "$path/lib/orocos" ]; then
+    continue
+  elif [ -z "$RTT_COMPONENT_PATH" ]; then
+    RTT_COMPONENT_PATH="$path/lib/orocos"
+  elif ! echo "$RTT_COMPONENT_PATH" | grep -q "$path/lib/orocos"; then
+    RTT_COMPONENT_PATH="$RTT_COMPONENT_PATH:$path/lib/orocos"
+  fi
+done
+
+export OROCOS_TARGET
+export RTT_COMPONENT_PATH


### PR DESCRIPTION
The env-hook sets the OROCOS_TARGET environment variable if not set and adds the lib/orocos directory of the install-space and all entries of the CMAKE_PREFIX_PATH (for catkin workspaces) to the
RTT_COMPONENT_PATH.

The scripts in etc/orocos/OROCOS_TARGET/profile.de will be sourced in lexical order by a new [setup.sh](https://github.com/meyerj/orocos_toolchain/blob/installation-script/setup.sh)
script located in the orocos_toolchain repository.
