### PR TITLE
Fixed decomposition of PropertyBags which contain types that implement the TemplateCompositionFactory interface

### DIFF
--- a/rtt/types/PropertyComposition.cpp
+++ b/rtt/types/PropertyComposition.cpp
@@ -71,6 +71,7 @@ bool RTT::types::decomposePropertyBag( PropertyBag const& sourcebag, PropertyBag
         if ( isbag.ready() ) {
             // create an empty instance to recurse in:
             Property<PropertyBag>* newtarget = new Property<PropertyBag>(isbag.getName(), isbag.getDescription() );
+            newtarget->value().setType( isbag.rvalue().getType() );
             target.ownProperty( newtarget );
             if ( decomposePropertyBag(isbag.value(), newtarget->value() ) == false) {
                 assert(false && "internal error in decomposePropertyBag."); // this is a best effort function.
@@ -92,6 +93,7 @@ bool RTT::types::decomposePropertyBag( PropertyBag const& sourcebag, PropertyBag
                         // property bag ? -> further decompose
                         // create an empty instance to recurse in:
                         Property<PropertyBag>* newtarget = new Property<PropertyBag>((*sit)->getName(), (*sit)->getDescription() );
+                        newtarget->value().setType( bagds->rvalue().getType() );
                         target.ownProperty( newtarget );
                         if ( decomposePropertyBag(bagds->rvalue(), newtarget->value() ) == false) {
                             assert(false && "internal error in decomposePropertyBag."); // this is a best effort function.

--- a/tests/property_composition_test.cpp
+++ b/tests/property_composition_test.cpp
@@ -93,6 +93,7 @@ BOOST_AUTO_TEST_CASE( testDecomposeComposeVector )
 
     Property<PropertyBag> decomposed = target.getPropertyType<PropertyBag>("pv");
     BOOST_REQUIRE( decomposed.ready() );
+    BOOST_CHECK_EQUAL( decomposed.value().getType(), "array" );
 
     // check that target bag has equal number of decomposed elements:
     BOOST_CHECK_EQUAL( decomposed.getDescription(), pv.getDescription() );


### PR DESCRIPTION
The method `types::decomposePropertyBag()` did not retain the type of the PropertyBag returned by `types::TypeInfo::decomposeType()` for each individual property and therefore the subsequent composition did not recognize the original type. For example, the KDL typekit implements composition and decomposition using that method (in [kdlTypekit.hpp:163](https://github.com/orocos/rtt_geometry/blob/indigo-devel/kdl_typekit/src/kdlTypekit.hpp#L163) and [motionproperties.cpp:380ff.](https://github.com/orocos/rtt_geometry/blob/indigo-devel/kdl_typekit/src/motionproperties.cpp#L380)). The fallback method of property decomposition implemented in `types::propertyDecomposition()` using `getMember()` is not affected by this issue and sets the type of the target bag correctly.

The updated test in RTT cannot easily cover this case, because no RTT core typekit implements the TemplateCompositionFactory interface.