### PR TITLE
corba: use oneway for signalling the remote on pull channels

### DIFF
--- a/rtt/transports/corba/DataFlow.idl
+++ b/rtt/transports/corba/DataFlow.idl
@@ -79,7 +79,7 @@ module RTT
          * is available for reading.
          * @return false if this channel became invalidated.
          */
-        boolean remoteSignal();
+        oneway void remoteSignal();
 
         /**
          * Used by the 'remote' side to inform this channel element

--- a/rtt/transports/corba/RemoteChannelElement.hpp
+++ b/rtt/transports/corba/RemoteChannelElement.hpp
@@ -114,10 +114,10 @@ namespace RTT {
             /**
              * CORBA IDL function.
              */
-            CORBA::Boolean remoteSignal() ACE_THROW_SPEC ((
+            void remoteSignal() ACE_THROW_SPEC ((
           	      CORBA::SystemException
           	    ))
-            { return base::ChannelElement<T>::signal(); }
+            { base::ChannelElement<T>::signal(); }
 
             bool signal()
             {
@@ -141,7 +141,7 @@ namespace RTT {
                 // in push mode, transfer all data, in pull mode, only signal once for each sample.
                 if ( pull ) {
                     try
-                    { valid = remote_side->remoteSignal(); }
+                    { remote_side->remoteSignal(); }
 #ifdef CORBA_IS_OMNIORB
                     catch(CORBA::SystemException& e)
                     {


### PR DESCRIPTION
Signal order does not matter, so we can safely use oneway.

This "unblocks" the CORBA dispatchers on pull connections, something I always assumed had been fixed a while ago (I remember a patchset to avoid signalling pull connections that are not going to an event port). The latter would have been a better solution, but this is really a low-hanging fruit with great effect.