### PR TITLE
omit linker flag  in presence of -fsanitize

### DIFF
--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -68,7 +68,9 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
 
   # This is for not allowing undefined symbols when using gcc
   if (CMAKE_COMPILER_IS_GNUCXX AND NOT APPLE)
-    SET(USE_OROCOS_LDFLAGS_OTHER "-Wl,-z,defs")
+    if (NOT CMAKE_CXX_FLAGS MATCHES "-fsanitize")
+      SET(USE_OROCOS_LDFLAGS_OTHER "-Wl,-z,defs")
+    endif()
   else (CMAKE_COMPILER_IS_GNUCXX AND NOT APPLE)
     SET(USE_OROCOS_LDFLAGS_OTHER " ")
   endif (CMAKE_COMPILER_IS_GNUCXX AND NOT APPLE)


### PR DESCRIPTION
In gcc environment orocos is compiled with linker option `-z defs` to ensure that all symbols in linked object files are defined. This is perfectly fine.
However, when used with [`AddressSanitizer`](https://github.com/google/sanitizers/wiki/AddressSanitizer) (option -fsanitize=address), the linker fails with lots of undefined symbols, because gcc/ld don't link shared libraries against `libasan`. This is only done for executables.

Hence, to enable linking, the linker option `-z defs` needs to be omitted when address sanitizer is used.
This patch solved the issue for me. However, checking `CMAKE_CXX_FLAGS` might not be the best option. Alternatively, I considered `CMAKE_SHARED_LINKER_FLAGS`. However, in both case there are several version of these variables depending on the choosen `CMAKE_BUILD_TYPE`.
