### PR TITLE
Fixed potential memory allocation problem in ConnectionManager

### DIFF
--- a/rtt/internal/ConnectionManager.cpp
+++ b/rtt/internal/ConnectionManager.cpp
@@ -60,6 +60,7 @@ namespace RTT
 
         ConnectionManager::ConnectionManager(PortInterface* port)
             : mport(port)
+            , cur_channel(NULL)
         {
         }
 
@@ -89,9 +90,9 @@ namespace RTT
         void ConnectionManager::updateCurrentChannel(bool reset_current)
         {
             if (connections.empty())
-                cur_channel = ChannelDescriptor();
+                cur_channel = NULL;
             else if (reset_current)
-                cur_channel = connections.front();
+                cur_channel = &(connections.front());
         }
 
         bool ConnectionManager::disconnect(PortInterface* port)
@@ -116,7 +117,7 @@ namespace RTT
             std::list<ChannelDescriptor> all_connections;
             { RTT::os::MutexLock lock(connection_lock);
                 all_connections.splice(all_connections.end(), connections);
-                cur_channel = ChannelDescriptor();
+                cur_channel = NULL;
             }
             std::for_each(all_connections.begin(), all_connections.end(),
                     boost::bind(&ConnectionManager::eraseConnection, this, _1));
@@ -130,9 +131,9 @@ namespace RTT
         { RTT::os::MutexLock lock(connection_lock);
             assert(conn_id);
             ChannelDescriptor descriptor = boost::make_tuple(conn_id, channel, policy);
-            if (connections.empty())
-                cur_channel = descriptor;
-            connections.push_back(descriptor);
+            connections.insert(connections.end(), descriptor);
+            if (connections.size() == 1)
+                cur_channel = &(connections.front());
         }
 
         bool ConnectionManager::removeConnection(ConnID* conn_id)
@@ -145,7 +146,7 @@ namespace RTT
                     return false;
                 descriptor = *conn_it;
                 connections.erase(conn_it);
-                updateCurrentChannel( cur_channel.get<1>() == descriptor.get<1>() );
+                updateCurrentChannel( cur_channel && (cur_channel->get<1>() == descriptor.get<1>()) );
             }
 
             // disconnect needs to know if we're from Out->In (forward) or from In->Out

--- a/rtt/internal/ConnectionManager.hpp
+++ b/rtt/internal/ConnectionManager.hpp
@@ -145,34 +145,34 @@ namespace RTT
             template<typename Pred>
             void select_reader_channel(Pred pred, bool copy_old_data) {
                 RTT::os::MutexLock lock(connection_lock);
-                std::pair<bool, ChannelDescriptor> new_channel =
+                ChannelDescriptor *new_channel =
                     find_if(pred, copy_old_data);
-                if (new_channel.first)
+                if (new_channel)
                 {
                     // We don't clear the current channel (to get it to NoData state), because there is a race
                     // between find_if and this line. We have to accept (in other parts of the code) that eventually,
                     // all channels return 'OldData'.
-                    cur_channel = new_channel.second;
+                    cur_channel = new_channel;
                 }
             }
 
             template<typename Pred>
-            std::pair<bool, ChannelDescriptor> find_if(Pred pred, bool copy_old_data) {
+            ChannelDescriptor *find_if(Pred pred, bool copy_old_data) {
                 // We only copy OldData in the initial read of the current channel.
                 // if it has no new data, the search over the other channels starts,
                 // but no old data is needed.
-                ChannelDescriptor channel = cur_channel;
-                if ( channel.get<1>() )
-                    if ( pred( copy_old_data, channel ) )
-                        return std::make_pair(true, channel);
+                ChannelDescriptor *channel = cur_channel;
+                if ( channel )
+                    if ( pred( copy_old_data, *channel ) )
+                        return channel;
 
                 std::list<ChannelDescriptor>::iterator result;
                 for (result = connections.begin(); result != connections.end(); ++result) {
-                    if (result->get<1>() == cur_channel.get<1>()) continue;
+                    if (cur_channel && (result->get<1>() == cur_channel->get<1>())) continue;
                     if ( pred(false, *result) == true)
-                        return std::make_pair(true, *result);
+                        return &(*result);
                 }
-                return std::make_pair(false, ChannelDescriptor());
+                return NULL;
             }
 
             /**
@@ -187,7 +187,7 @@ namespace RTT
              * @return
              */
             base::ChannelElementBase* getCurrentChannel() const {
-                return cur_channel.get<1>().get();
+                return cur_channel ? cur_channel->get<1>().get() : NULL;
             }
 
             /**
@@ -254,7 +254,7 @@ namespace RTT
             /**
              * Optimisation in case only one channel is to be managed.
              */
-            ChannelDescriptor cur_channel;
+            ChannelDescriptor *cur_channel;
 
             /**
              * Lock that should be taken before the list of connections is


### PR DESCRIPTION
The ConnectionManager is responsible for selecting the next channel to read if an InputPort has multiple connections, which are managed in a list of `ChannelDescriptor` instances. The `ChannelDescriptor` contains the ConnPolicy of the connection, which in turn contains a `std::string` element `name_id`. Copying `ChannelDescriptor` instances is therefore not real-time safe. Luckily it is not required and we can work with a pointer (or iterator) to the current channel.

It should be noted that most implementations of `std::string` usually do not reallocate once its internal buffer is big enough to hold all potential values (all `name_id`s of connected channels). So the risk that reassigning the `std::string` element in `cur_channel` is causing heap allocations in critical paths is quite minimal. See also http://info.prelert.com/blog/cpp-stdstring-implementations.