### PR TITLE
fix race conditions between stop() and the runtime error state

### DIFF
--- a/rtt/ExecutionEngine.cpp
+++ b/rtt/ExecutionEngine.cpp
@@ -378,7 +378,7 @@ namespace RTT
                 )
             }
             // in case start() or updateHook() called error(), this will be called:
-            if (  taskc->mTaskState == TaskCore::RunTimeError ) {
+            if (taskc->mTaskState == TaskCore::RunTimeError && taskc->mTargetState >= TaskCore::Running) {
                 TRY (
                     taskc->errorHook();
                 ) CATCH(std::exception const& e,
@@ -408,7 +408,7 @@ namespace RTT
                     (*it)->exception(); // calls stopHook,cleanupHook
                 )
             }
-            if (  (*it)->mTaskState == TaskCore::RunTimeError ){
+            if ((*it)->mTaskState == TaskCore::RunTimeError && (*it)->mTargetState == TaskCore::RunTimeError){
                 TRY (
                     (*it)->errorHook();
                 ) CATCH(std::exception const& e,

--- a/rtt/base/TaskCore.cpp
+++ b/rtt/base/TaskCore.cpp
@@ -182,7 +182,7 @@ namespace RTT {
             mTargetState = mTaskState = mInitialState;
             return true;
         }
-        if (mTaskState == RunTimeError ) {
+        if (mTaskState == RunTimeError && mTargetState >= Running) {
             mTargetState = mTaskState = Running;
             return true;
         }

--- a/tests/taskstates_test.cpp
+++ b/tests/taskstates_test.cpp
@@ -637,5 +637,89 @@ BOOST_AUTO_TEST_CASE( testExecutionEngine)
     tsim->run(0);
 }
 
+class calling_error_does_not_override_a_stop_transition_Task : public RTT::TaskContext
+{
+public:
+    calling_error_does_not_override_a_stop_transition_Task()
+        : TaskContext("test") {}
+    void updateHook() { error(); }
+    void errorHook() {
+        while(getTargetState() != Stopped);
+        error();
+        trigger();
+    }
+};
+BOOST_AUTO_TEST_CASE(calling_error_does_not_override_a_stop_transition)
+{
+    for (int i = 0; i < 100; ++i)
+    {
+        calling_error_does_not_override_a_stop_transition_Task task;
+        task.start();
+        usleep(100);
+        task.stop();
+        BOOST_REQUIRE_EQUAL(RTT::TaskContext::Stopped, task.getTaskState());
+        BOOST_REQUIRE_EQUAL(RTT::TaskContext::Stopped, task.getTargetState());
+    }
+}
+
+class calling_recover_does_not_override_a_stop_transition_Task : public RTT::TaskContext
+{
+public:
+    bool mRecovered;
+    TaskState mTargetState;
+    calling_recover_does_not_override_a_stop_transition_Task()
+        : TaskContext("test"), mRecovered(true) {} // true is an error
+    void updateHook() { error(); }
+    void errorHook() {
+        while(getTargetState() != Stopped);
+        mRecovered = recover();
+        trigger();
+    }
+};
+BOOST_AUTO_TEST_CASE(calling_recover_does_not_override_a_stop_transition)
+{
+    for (int i = 0; i < 100; ++i)
+    {
+        calling_recover_does_not_override_a_stop_transition_Task task;
+        task.start();
+        usleep(100);
+        task.stop();
+        BOOST_REQUIRE_EQUAL(RTT::TaskContext::Stopped, task.getTaskState());
+        BOOST_REQUIRE_EQUAL(RTT::TaskContext::Stopped, task.getTargetState());
+        BOOST_REQUIRE(!task.mRecovered);
+    }
+}
+
+class errorHook_is_not_called_after_an_exit_transition_Task : public RTT::TaskContext
+{
+public:
+    TimeService::ticks lastErrorHook;
+    TimeService::ticks lastStopHook;
+
+    errorHook_is_not_called_after_an_exit_transition_Task()
+        : TaskContext("test") {}
+    void updateHook() { error(); }
+    void errorHook() {
+        usleep(100);
+        lastErrorHook = TimeService::Instance()->getTicks();
+        trigger();
+    }
+    void stopHook() {
+        lastStopHook = TimeService::Instance()->getTicks();
+        usleep(100);
+    }
+};
+BOOST_AUTO_TEST_CASE(testErrorHook_is_not_called_during_stop)
+{
+    for (int i = 0; i < 100; ++i)
+    {
+        errorHook_is_not_called_after_an_exit_transition_Task task;
+        task.start();
+        usleep(100);
+        task.stop();
+        BOOST_REQUIRE(task.lastErrorHook < task.lastStopHook);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
stop() does a synchronization point by stopping the activity, but
then starts it right away. Given that the EE was not checking against
mTargetState when deciding to call errorHook(), there was a chance
that errorHook was called during or after stopHook.

Moreover, while error() was checking that mTargetState was a runtime
state, recover() was not, which could lead to a call to recover()
overriding mTargetState during the stop, leaving the task stopped
but in an inconsistent state.

The tests loop because of the racy nature of the problem. On my machine,
with the timing setup and 100 tries, I was getting more than 50% hits.