### PR TITLE
plugin: do not log during destruction of the PluginLoader singleton

### DIFF
--- a/rtt/plugin/PluginLoader.cpp
+++ b/rtt/plugin/PluginLoader.cpp
@@ -318,8 +318,8 @@ namespace {
 
 static boost::shared_ptr<PluginLoader> instance2;
 
-PluginLoader::PluginLoader() { log(Debug) <<"PluginLoader Created" <<endlog(); }
-PluginLoader::~PluginLoader(){ log(Debug) <<"PluginLoader Destroyed" <<endlog(); }
+PluginLoader::PluginLoader() {}
+PluginLoader::~PluginLoader(){}
 
 
 boost::shared_ptr<PluginLoader> PluginLoader::Instance() {


### PR DESCRIPTION
... as this might trigger the creation of a new Logger instance during static destruction.