### PR TITLE
macosx: Add static casts to slience C++11 narrowing errors

### DIFF
--- a/rtt/os/macosx/fosi.h
+++ b/rtt/os/macosx/fosi.h
@@ -167,7 +167,15 @@ extern "C"
     static inline int rtos_sem_wait_timed(rt_sem_t* m, NANO_TIME delay )
     {
         TIME_SPEC delayvl = ticks2timespec(delay);
-        mach_timespec_t mach_delayvl = { delayvl.tv_sec, delayvl.tv_nsec };
+        mach_timespec_t mach_delayvl = {
+#ifdef __cplusplus
+            static_cast<unsigned int>(delayvl.tv_sec),
+            static_cast<clock_res_t> (delayvl.tv_nsec)
+#else
+            delayvl.tv_sec,
+            delayvl.tv_nsec
+#endif
+                                        };
 
         return semaphore_timedwait( *m, mach_delayvl);
     }
@@ -202,7 +210,15 @@ extern "C"
         assert( 0 <= delayvl.tv_nsec);
         assert( delayvl.tv_nsec < 1000000000 );
 
-        mach_timespec_t mach_delayvl = { delayvl.tv_sec, delayvl.tv_nsec };
+        mach_timespec_t mach_delayvl = {
+#ifdef __cplusplus
+            static_cast<unsigned int>(delayvl.tv_sec),
+            static_cast<clock_res_t> (delayvl.tv_nsec)
+#else
+            delayvl.tv_sec,
+            delayvl.tv_nsec
+#endif
+                                        };
         int rc = semaphore_timedwait( *m, mach_delayvl);
         // map to return values from gnulinux, and expected by the calling layer
         return (KERN_OPERATION_TIMED_OUT == rc ? -1 : 0);


### PR DESCRIPTION
It appears that recent updates to Xcode make the compiler more wary ... fix the resulting errors. Tested with Xcode 8.2.1 on OS X 10.11
