### PR TITLE
logger: Ensure that the notification of real-time logging being enabl…

### DIFF
--- a/rtt/Logger.cpp
+++ b/rtt/Logger.cpp
@@ -363,8 +363,9 @@ namespace RTT
     }
 
     void Logger::allowRealTime() {
-        *this << Logger::Warning << "Enabling Real-Time Logging !" <<Logger::endl;
+        // re-enable and then log, otherwise you might not get the log event!
         d->allowRT = true;
+        *this << Logger::Warning << "Enabling Real-Time Logging !" <<Logger::endl;
     }
     void Logger::disallowRealTime() {
         *this << Logger::Warning << "Disabling Real-Time Logging !" <<Logger::endl;


### PR DESCRIPTION
The notification that real-time logging was enabled can be lost due to the sequence of "log then enable". The fix is to "enable then log", which ensures that the notification comes out if the log level is currently RealTime.