### PR TITLE
boost 1.61 support

### DIFF
--- a/rtt/transports/mqueue/binary_data_archive.hpp
+++ b/rtt/transports/mqueue/binary_data_archive.hpp
@@ -85,9 +85,9 @@
 #include <boost/serialization/item_version_type.hpp>
 #endif
 
-#if BOOST_VERSION >= 105900
+#ifndef BOOST_PFTO
 //Partial Function Template Ordering removed from boost in 1.59, setting it to nothing seems to work
-//(was also done in <boost/ptfo.hpp> itself)
+//(was also done in <boost/ptfo.hpp> itself, header removed from 1.59)
 //and keeps its functionality for older boost versions
 #define BOOST_PFTO
 #endif

--- a/rtt/transports/mqueue/binary_data_archive.hpp
+++ b/rtt/transports/mqueue/binary_data_archive.hpp
@@ -85,6 +85,13 @@
 #include <boost/serialization/item_version_type.hpp>
 #endif
 
+#if BOOST_VERSION >= 105900
+//Partial Function Template Ordering removed from boost in 1.59, setting it to nothing seems to work
+//(was also done in <boost/ptfo.hpp> itself)
+//and keeps its functionality for older boost versions
+#define BOOST_PFTO
+#endif
+
 namespace RTT
 {
     namespace mqueue
@@ -205,7 +212,7 @@ namespace RTT
              * @return *this
              */
             template<class T>
-#if BOOST_VERSION >= 106200
+#if BOOST_VERSION >= 106100
             void load_override(const boost::serialization::array_wrapper<T> &t, int)
             {
                 boost::serialization::array_wrapper<T> tmp(t.address(), t.count());
@@ -330,7 +337,7 @@ namespace RTT
              * The optimized save_array dispatches to save_binary
              */
             template<class ValueType>
-#if BOOST_VERSION >= 106200
+#if BOOST_VERSION >= 106100
             void load_array(boost::serialization::array_wrapper<ValueType>& a,
 #else
             void load_array(boost::serialization::array<ValueType>& a,
@@ -524,7 +531,7 @@ namespace RTT
              * The optimized save_array dispatches to save_binary
              */
             template<class ValueType>
-#if BOOST_VERSION >= 106200
+#if BOOST_VERSION >= 106100
             void save_array(boost::serialization::array_wrapper<ValueType> const& a,
 #else
             void save_array(boost::serialization::array<ValueType> const& a,

--- a/rtt/types/carray.hpp
+++ b/rtt/types/carray.hpp
@@ -97,7 +97,7 @@ namespace RTT
              * the original data.
              * @param orig
              */
-#if BOOST_VERSION >= 106200
+#if BOOST_VERSION >= 106100
             carray( boost::serialization::array_wrapper<T> const& orig)
 #else
             carray( boost::serialization::array<T> const& orig)
@@ -167,7 +167,7 @@ namespace RTT
              * @param orig
              */
             template <class OtherT>
-#if BOOST_VERSION >= 106200
+#if BOOST_VERSION >= 106100
             const carray<T>& operator=( boost::serialization::array_wrapper<OtherT> const& orig ) {
 #else
             const carray<T>& operator=( boost::serialization::array<OtherT> const& orig ) {

--- a/rtt/types/type_discovery.hpp
+++ b/rtt/types/type_discovery.hpp
@@ -293,7 +293,7 @@ namespace RTT
              * @return *this
              */
             template<class T>
-#if BOOST_VERSION >= 106200
+#if BOOST_VERSION >= 106100
             type_discovery &load_a_type(const boost::serialization::array_wrapper<T> &t, boost::mpl::false_)
 #else
             type_discovery &load_a_type(const boost::serialization::array<T> &t, boost::mpl::false_)

--- a/tests/mqueue_archive_test.cpp
+++ b/tests/mqueue_archive_test.cpp
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE( testFixedStringBinaryDataArchive )
     rtos_enable_rt_warning();
     io::stream<io::array_source>  inbuf(sink,1000);
     binary_data_iarchive in( inbuf ); // +0 alloc
-#if BOOST_VERSION >= 106200
+#if BOOST_VERSION >= 106100
     boost::serialization::array_wrapper<char> ma = boost::serialization::make_array(c, 10);
 #else
     boost::serialization::array<char> ma = boost::serialization::make_array(c, 10);


### PR DESCRIPTION
Partial Function Template Ordering was removed from boost in 1.59, the according define BOOST_PFTO also.

I am not really sure if the define is the correct way to solve it, bur at lease the functionality doesn't change for users with older boost versions

Also changed some ifdefs, from checking against 1.62 to 1.61 (current default in ubuntu 16.10)

I wonder how it compiled against 1.62 before, somebody might have done it as the boost::serialization::array_wrapper defines were already here