### PR TITLE
corba: fixed hidden overloaded virtual functions in RemotePorts.hpp

### DIFF
--- a/rtt/transports/corba/RemotePorts.hpp
+++ b/rtt/transports/corba/RemotePorts.hpp
@@ -84,7 +84,8 @@ namespace RTT {
             bool connected() const;
             bool createStream( const ConnPolicy& policy );
             virtual bool addConnection(internal::ConnID* port_id, base::ChannelElementBase::shared_ptr channel_input, ConnPolicy const& policy);
-            void disconnect();
+            virtual void disconnect();
+            using PortClass::disconnect;
         };
 
         /**
@@ -104,9 +105,11 @@ namespace RTT {
             bool keepsLastWrittenValue() const;
             void keepLastWrittenValue(bool new_flag);
 
-            using base::OutputPortInterface::createConnection;
             virtual bool disconnect(PortInterface* port);
+            using RemotePort<base::OutputPortInterface>::disconnect;
+
             bool createConnection( base::InputPortInterface& sink, ConnPolicy const& policy );
+            using base::OutputPortInterface::createConnection;
 
             virtual base::DataSourceBase::shared_ptr getDataSource() const;
 
@@ -162,6 +165,7 @@ namespace RTT {
             base::PortInterface* antiClone() const;
 
             virtual bool disconnect(PortInterface* port);
+            using RemotePort<base::InputPortInterface>::disconnect;
 
             base::DataSourceBase* getDataSource();
 


### PR DESCRIPTION
This is a minor regression from https://github.com/orocos-toolchain/rtt/pull/142/commits/0db4e04b4cbaac2218f0d2a38a90671407d14f45 (#142).

Declaring `bool disconnect(PortInterface* port)` in `RemoteInputPort` and `RemoteOutputPort` without a using directive hides the overload `void RemotePort<PortClass>::disconnect()`. The classes are almost exclusively used internally and apparently this code path was not triggered.