### PR TITLE
Travis: switch to containerized build environment and add clang and C++11 jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,34 @@
-sudo: required
 dist: trusty
-language:
-  - cpp
+sudo: false
+
+language: cpp
 compiler:
+  - clang
   - gcc
-before_install:
-  # Update package indexes and install dependencies
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq -y libxml-xpath-perl libboost-all-dev omniorb omniidl omniorb-nameserver libomniorb4-dev pkg-config
+
+addons:
+  apt:
+    packages:
+      - libxml-xpath-perl
+      - libboost-all-dev
+      - omniorb
+      - omniidl
+      - omniorb-nameserver
+      - libomniorb4-dev
+      - pkg-config
+
+env:
+  global:
+    - EXTRA_CMAKE_ARGS="-DENABLE_TESTS=ON -DENABLE_CORBA=ON -DCORBA_IMPLEMENTATION=OMNIORB"
+    - CFLAGS="-std=c99 -Wall -Wextra -Wno-unused-parameter"
+    - CXXFLAGS="-std=c++11 -Wall -Wextra -Wno-unused-parameter"
+    - BOOST_TEST_LOG_LEVEL=message
 
 install:
-  - export EXTRA_CMAKE_ARGS="-DENABLE_TESTS=ON -DENABLE_CORBA=ON -DCORBA_IMPLEMENTATION=OMNIORB"
-  - export CFLAGS="-std=c99 -Wall -Wextra -Wno-unused-parameter"
-  - export CXXFLAGS="-std=c++11 -Wall -Wextra -Wno-unused-parameter"
   - mkdir -p build && cd build
   - cmake .. -DCMAKE_INSTALL_PREFIX=$(pwd)/install $EXTRA_CMAKE_ARGS
   - make -j2 install
 
 script:
   # Run tests
-  - export BOOST_TEST_LOG_LEVEL=message
   - make -j1 check

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,11 @@ addons:
 env:
   global:
     - EXTRA_CMAKE_ARGS="-DENABLE_TESTS=ON -DENABLE_CORBA=ON -DCORBA_IMPLEMENTATION=OMNIORB"
-    - CFLAGS="-std=c99 -Wall -Wextra -Wno-unused-parameter"
-    - CXXFLAGS="-std=c++11 -Wall -Wextra -Wno-unused-parameter"
     - BOOST_TEST_LOG_LEVEL=message
+  matrix:
+    - CXXFLAGS="-std=c++03 -Wall -Wextra -Wno-unused-parameter" CFLAGS="-std=c99 -Wall -Wextra -Wno-unused-parameter"
+    - CXXFLAGS="-std=c++11 -Wall -Wextra -Wno-unused-parameter" CFLAGS="-std=c99 -Wall -Wextra -Wno-unused-parameter"
+
 
 install:
   - mkdir -p build && cd build


### PR DESCRIPTION
Example build: https://travis-ci.org/orocos-toolchain/rtt/builds/189295270

Travis supports [containerized builds](https://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/) since 2 years, which improve build times. With the apt add-on it is also possible to install system dependencies without the need for sudo.

I also added a build matrix to test clang and gcc builds with and without c++11 enabled. We might also include Mac OS X here.

We are already running integration tests for the toolchain for the orocos_toolchain repository, but without unit tests: https://github.com/orocos-toolchain/orocos_toolchain/pull/15 (only log4cpp, rtt and ocl)