### PR TITLE
Fixed OperationInterfacePartFused for -std=c++11 builds with Boost 1.58 (master)

### DIFF
--- a/rtt/internal/FusedFunctorDataSource.hpp
+++ b/rtt/internal/FusedFunctorDataSource.hpp
@@ -507,7 +507,7 @@ namespace RTT
              * puts them into the assignable data sources and
              * executes the associated action.
              */
-            result_type invoke(typename SequenceFactory::data_type seq) {
+            result_type invoke(const typename SequenceFactory::data_type& seq) const {
                 if ( subscriber ) {
                     // asynchronous
                     shared_ptr sg = this->cloneRT();

--- a/rtt/internal/OperationInterfacePartFused.hpp
+++ b/rtt/internal/OperationInterfacePartFused.hpp
@@ -40,7 +40,6 @@
 #define ORO_OPERATION_INTERFACE_PART_FUSED_HPP
 
 
-#include <boost/config.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/function_types/result_type.hpp>
 #include <boost/function_types/parameter_types.hpp>
@@ -214,14 +213,14 @@ namespace RTT
                 if ( args.size() != OperationInterfacePartFused<Signature>::arity() ) throw wrong_number_of_args_exception(OperationInterfacePartFused<Signature>::arity(), args.size() );
                 // note: in boost 1.41.0+ the function make_unfused() is available.
 #if BOOST_VERSION >= 104100
-#if !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#if __cplusplus > 199711L
                 auto invoke_fused = boost::bind(&FusedMSignal<Signature>::invoke,
                                         boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
                                         boost::arg<1>()
                                     );
                 typedef typename boost::fusion::result_of::make_unfused< decltype(invoke_fused) >::type unfused_type;
                 return this->op->signals(boost::forward_adapter<unfused_type>(boost::fusion::make_unfused(invoke_fused)));
-#else // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#else // __cplusplus > 199711L
                 return this->op->signals(
                             boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
                                                                     boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
@@ -229,7 +228,7 @@ namespace RTT
                                                                     )
                                                         )
                             );
-#endif // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#endif // __cplusplus > 199711L
 #else // BOOST_VERSION >= 104100
                 return this->op->signals(
                             boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,
@@ -436,14 +435,14 @@ namespace RTT
                     a2.insert(a2.end(), args.begin(), args.end());
                     // note: in boost 1.41.0+ the function make_unfused() is available.
 #if BOOST_VERSION >= 104100
-#if !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#if __cplusplus > 199711L
                     auto invoke_fused = boost::bind(&FusedMSignal<Signature>::invoke,
                                             boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
                                             boost::arg<1>()
                                         );
                     typedef typename boost::fusion::result_of::make_unfused< decltype(invoke_fused) >::type unfused_type;
                     return this->op->signals(boost::forward_adapter<unfused_type>(boost::fusion::make_unfused(invoke_fused)));
-#else // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#else // __cplusplus > 199711L
                     return this->op->signals(
                                 boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
                                                                         boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
@@ -451,7 +450,7 @@ namespace RTT
                                                                         )
                                                             )
                                 );
-#endif // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#endif // __cplusplus > 199711L
 #else // BOOST_VERSION >= 104100
                     return this->op->signals(
                                 boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,

--- a/rtt/internal/OperationInterfacePartFused.hpp
+++ b/rtt/internal/OperationInterfacePartFused.hpp
@@ -227,7 +227,7 @@ namespace RTT
                                                                     boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
                                                                     boost::arg<1>()
                                                                     )
-                                                        ))
+                                                        )
                             );
 #endif // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
 #else // BOOST_VERSION >= 104100
@@ -449,8 +449,8 @@ namespace RTT
                                                                         boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
                                                                         boost::arg<1>()
                                                                         )
-                                                            ))
-//                                );
+                                                            )
+                                );
 #endif // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
 #else // BOOST_VERSION >= 104100
                     return this->op->signals(

--- a/rtt/internal/OperationInterfacePartFused.hpp
+++ b/rtt/internal/OperationInterfacePartFused.hpp
@@ -40,6 +40,7 @@
 #define ORO_OPERATION_INTERFACE_PART_FUSED_HPP
 
 
+#include <boost/config.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/function_types/result_type.hpp>
 #include <boost/function_types/parameter_types.hpp>
@@ -50,6 +51,7 @@
 #ifndef BOOST_FUSION_UNFUSED_MAX_ARITY
 #define BOOST_FUSION_UNFUSED_MAX_ARITY 7
 #endif
+#include <boost/functional/forward_adapter.hpp>
 #include <boost/fusion/functional/generation/make_unfused.hpp>
 #else
 // our code goes up to 7 FUSION_MAX_VECTOR_SIZE defaults to 10
@@ -57,10 +59,6 @@
 #define BOOST_FUSION_UNFUSED_GENERIC_MAX_ARITY 7
 #endif
 #include <boost/fusion/include/make_unfused_generic.hpp>
-#endif
-
-#ifndef USE_CPP11
-#include <boost/lambda/lambda.hpp>
 #endif
 
 #include <vector>
@@ -171,7 +169,7 @@ namespace RTT
                 assert( carity == collectArity() + 1 ); // check for arity functions. (this is actually a compile time assert).
                 if ( args.size() != carity ) throw wrong_number_of_args_exception(carity, args.size() );
                 // we need to ask FusedMCollectDataSource what the arg types are, based on the collect signature.
-                return new FusedMCollectDataSource<Signature>( create_sequence<typename FusedMCollectDataSource<Signature>::handle_and_arg_types >::sources(args.begin()), blocking );
+                return new FusedMCollectDataSource<Signature>( create_sequence<typename FusedMCollectDataSource<Signature>::handle_and_arg_types >::assignable(args.begin()), blocking );
             }
 
 #ifdef ORO_SIGNALLING_OPERATIONS
@@ -216,32 +214,34 @@ namespace RTT
                 if ( args.size() != OperationInterfacePartFused<Signature>::arity() ) throw wrong_number_of_args_exception(OperationInterfacePartFused<Signature>::arity(), args.size() );
                 // note: in boost 1.41.0+ the function make_unfused() is available.
 #if BOOST_VERSION >= 104100
-#ifdef USE_CPP11
-                return this->op->signals( boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
-                                                                                                                    boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
-                                                                            _1
-                                                                            )
-                                                                )
-                                   );
-#else
-                return this->op->signals( boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
-                                                                                                                    boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
-                                                                            boost::lambda::_1
-                                                                            )
-                                                                )
-                                   );
-#endif
-#else
-                return this->op->signals( boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,
-                                                                                                                            boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()),subscriber),
-                                                                            boost::lambda::_1
-                                                                            )
-                                                                )
-                                   );
-#endif
+#if !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+                auto invoke_fused = boost::bind(&FusedMSignal<Signature>::invoke,
+                                        boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
+                                        boost::arg<1>()
+                                    );
+                typedef typename boost::fusion::result_of::make_unfused< decltype(invoke_fused) >::type unfused_type;
+                return this->op->signals(boost::forward_adapter<unfused_type>(boost::fusion::make_unfused(invoke_fused)));
+#else // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+                return this->op->signals(
+                            boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
+                                                                    boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
+                                                                    boost::arg<1>()
+                                                                    )
+                                                        ))
+                            );
+#endif // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#else // BOOST_VERSION >= 104100
+                return this->op->signals(
+                            boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,
+                                                                    boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
+                                                                    boost::arg<1>()
+                                                                    )
+                                                        )
+                            );
+#endif // BOOST_VERSION >= 104100
             }
         };
-#endif
+#endif // ORO_SIGNALLING_OPERATIONS
 
         /**
          * OperationInterfacePart implementation that only provides synchronous
@@ -421,7 +421,7 @@ namespace RTT
                     assert( carity == collectArity() + 1 ); // check for arity functions. (this is actually a compile time assert).
                     if ( args.size() != carity ) throw wrong_number_of_args_exception(carity, args.size() );
                     // we need to ask FusedMCollectDataSource what the arg types are, based on the collect signature.
-                    return new FusedMCollectDataSource<Signature>( create_sequence<typename FusedMCollectDataSource<Signature>::handle_and_arg_types >::sources(args.begin()), blocking );
+                    return new FusedMCollectDataSource<Signature>( create_sequence<typename FusedMCollectDataSource<Signature>::handle_and_arg_types >::assignable(args.begin()), blocking );
                 }
 #ifdef ORO_SIGNALLING_OPERATIONS
                 virtual Handle produceSignal( base::ActionInterface* func, const std::vector<base::DataSourceBase::shared_ptr>& args, ExecutionEngine* subscriber) const {
@@ -435,23 +435,35 @@ namespace RTT
                     a2.push_back(mwp);
                     a2.insert(a2.end(), args.begin(), args.end());
                     // note: in boost 1.41.0+ the function make_unfused() is available.
-    #if BOOST_VERSION >= 104100
-                    return this->op->signals( boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
-                                                                                boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()),subscriber),
-                                                                                _1
-                                                                                )
-                                                                    )
-                                       );
-    #else
-                    return this->op->signals( boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,
-                                                                                        boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()),subscriber),
-                                                                                _1
-                                                                                )
-                                                                    )
-                                       );
-    #endif
+#if BOOST_VERSION >= 104100
+#if !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+                    auto invoke_fused = boost::bind(&FusedMSignal<Signature>::invoke,
+                                            boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
+                                            boost::arg<1>()
+                                        );
+                    typedef typename boost::fusion::result_of::make_unfused< decltype(invoke_fused) >::type unfused_type;
+                    return this->op->signals(boost::forward_adapter<unfused_type>(boost::fusion::make_unfused(invoke_fused)));
+#else // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+                    return this->op->signals(
+                                boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
+                                                                        boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
+                                                                        boost::arg<1>()
+                                                                        )
+                                                            ))
+//                                );
+#endif // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#else // BOOST_VERSION >= 104100
+                    return this->op->signals(
+                                boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,
+                                                                        boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
+                                                                        boost::arg<1>()
+                                                                        )
+                                                            )
+                                );
+#endif // BOOST_VERSION >= 104100
                 }
-#endif
+#endif // ORO_SIGNALLING_OPERATIONS
+
                 boost::shared_ptr<base::DisposableInterface> getLocalOperation() const {
                     return this->op->getImplementation();
                 }


### PR DESCRIPTION
The [Boost unfused adapter](http://www.boost.org/doc/libs/1_58_0/libs/fusion/doc/html/fusion/functional/adapters/unfused.html) accepts only LValue arguments, while in general operations can also have RValues as arguments (const references or temporaries). Without C++11 or for older Boost versions this was apparently not an issue and the necessary conversion have been done implicitly (?).

The solution applies the [forward_adapter template](http://www.boost.org/doc/libs/1_63_0/libs/functional/forward/doc/html/index.html) to overcome this limitation as suggested in the Boost Fusion documentation.

This patch also reverts the `USE_CPP11` macro usage for this file, as it did not use `std::bind` or any other C++11 feature anyway and the only effect was the namespace of placeholders (see https://github.com/orocos-toolchain/rtt/commit/35cd426b4fd93c14a597b6ae590cc45c2dd2d105). Maybe it was unintentionally that `boost::bind` was not replaced by `std::bind` in the `USE_CPP11` section of OperationInterfacePartFused.hpp like in other files of that patch (#103).
`boost::arg<i>` is a simpler solution than introducing the macro and use C++11 that also prevent namespace clashes without having to use boost::lambda.

Tested on Ubuntu Xenial with gcc 5.4, Boost 1.58 and `-std=c++11` compile flag.
[This](https://gist.github.com/meyerj/ff68336793243d58eb821696af60342c) is the build error I got without this patch.