### PR TITLE
Fixed OperationInterfacePartFused for -std=c++11 builds with Boost 1.58 (toolchain-2.9)

### DIFF
--- a/rtt/internal/BindStorage.hpp
+++ b/rtt/internal/BindStorage.hpp
@@ -289,7 +289,7 @@ namespace RTT
             typename Signal<ToBind>::shared_ptr msig;
 #endif
 
-            BindStorageImpl() :  vStore(boost::ref(retv)) {}
+            BindStorageImpl() :  vStore(retv) {}
             BindStorageImpl(const BindStorageImpl& orig) : mmeth(orig.mmeth), vStore(retv)
 #ifdef ORO_SIGNALLING_OPERATIONS
                                                          , msig(orig.msig)
@@ -337,10 +337,10 @@ namespace RTT
             void store(arg1_type t1) { a1(t1); }
             void exec() {
 #ifdef ORO_SIGNALLING_OPERATIONS
-                if (msig) (*msig)(a1.get());
+                if (msig) (*msig)(a1);
 #endif
                 if (mmeth)
-                    retv.exec( boost::bind(mmeth, boost::ref(a1.get()) ) );
+                    retv.exec( boost::bind(mmeth, a1 ) );
                 else
                     retv.executed = true;
             }
@@ -377,10 +377,10 @@ namespace RTT
             void store(arg1_type t1, arg2_type t2) { a1(t1); a2(t2); }
             void exec() {
 #ifdef ORO_SIGNALLING_OPERATIONS
-                if (msig) (*msig)(a1.get(), a2.get());
+                if (msig) (*msig)(a1, a2);
 #endif
                 if (mmeth)
-                    retv.exec( boost::bind(mmeth, boost::ref(a1.get()), boost::ref(a2.get()) ) );
+                    retv.exec( boost::bind(mmeth, a1, a2 ) );
                 else
                     retv.executed = true;
             }
@@ -419,10 +419,10 @@ namespace RTT
             void store(arg1_type t1, arg2_type t2, arg3_type t3) { a1(t1); a2(t2); a3(t3); }
             void exec() {
 #ifdef ORO_SIGNALLING_OPERATIONS
-                if (msig) (*msig)(a1.get(), a2.get(), a3.get());
+                if (msig) (*msig)(a1, a2, a3);
 #endif
                 if (mmeth)
-                    retv.exec( boost::bind(mmeth, boost::ref(a1.get()), boost::ref(a2.get()), boost::ref(a3.get()) ) );
+                    retv.exec( boost::bind(mmeth, a1, a2, a3 ) );
                 else
                     retv.executed = true;
             }
@@ -462,10 +462,10 @@ namespace RTT
             void store(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4) { a1(t1); a2(t2); a3(t3); a4(t4); }
             void exec() {
 #ifdef ORO_SIGNALLING_OPERATIONS
-                if (msig) (*msig)(a1.get(), a2.get(), a3.get(), a4.get());
+                if (msig) (*msig)(a1, a2, a3, a4);
 #endif
                 if (mmeth)
-                    retv.exec( boost::bind( mmeth, boost::ref(a1.get()), boost::ref(a2.get()), boost::ref(a3.get()), boost::ref(a4.get()) ) );
+                    retv.exec( boost::bind( mmeth, a1, a2, a3, a4 ) );
                 else
                     retv.executed = true;
             }
@@ -507,10 +507,10 @@ namespace RTT
             void store(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5) { a1(t1); a2(t2); a3(t3); a4(t4); a5(t5);}
             void exec() {
 #ifdef ORO_SIGNALLING_OPERATIONS
-                if (msig) (*msig)(a1.get(), a2.get(), a3.get(), a4.get(), a5.get());
+                if (msig) (*msig)(a1, a2, a3, a4, a5);
 #endif
                 if (mmeth)
-                    retv.exec( boost::bind( mmeth, boost::ref(a1.get()), boost::ref(a2.get()), boost::ref(a3.get()), boost::ref(a4.get()), boost::ref(a5.get()) ) );
+                    retv.exec( boost::bind( mmeth, a1, a2, a3, a4, a5 ) );
                 else
                     retv.executed = true;
             }
@@ -554,10 +554,10 @@ namespace RTT
             void store(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5, arg6_type t6) { a1(t1); a2(t2); a3(t3); a4(t4); a5(t5); a6(t6);}
             void exec() {
 #ifdef ORO_SIGNALLING_OPERATIONS
-                if (msig) (*msig)(a1.get(), a2.get(), a3.get(), a4.get(), a5.get(), a6.get());
+                if (msig) (*msig)(a1, a2, a3, a4, a5, a6);
 #endif
                 if (mmeth)
-                    retv.exec( boost::bind( mmeth, boost::ref(a1.get()), boost::ref(a2.get()), boost::ref(a3.get()), boost::ref(a4.get()), boost::ref(a5.get()), boost::ref(a6.get()) ) );
+                    retv.exec( boost::bind( mmeth, a1, a2, a3, a4, a5, a6 ) );
                 else
                     retv.executed = true;
             }
@@ -603,10 +603,10 @@ namespace RTT
             void store(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5, arg6_type t6, arg7_type t7) { a1(t1); a2(t2); a3(t3); a4(t4); a5(t5); a6(t6); a7(t7);}
             void exec() {
 #ifdef ORO_SIGNALLING_OPERATIONS
-                if (msig) (*msig)(a1.get(), a2.get(), a3.get(), a4.get(), a5.get(), a6.get(), a7.get());
+                if (msig) (*msig)(a1, a2, a3, a4, a5, a6, a7);
 #endif
                 if (mmeth)
-                    retv.exec( boost::bind( mmeth, boost::ref(a1.get()), boost::ref(a2.get()), boost::ref(a3.get()), boost::ref(a4.get()), boost::ref(a5.get()), boost::ref(a6.get()), boost::ref(a7.get()) ) );
+                    retv.exec( boost::bind( mmeth, a1, a2, a3, a4, a5, a6, a7 ) );
                 else
                     retv.executed = true;
             }

--- a/rtt/internal/BindStorage.hpp
+++ b/rtt/internal/BindStorage.hpp
@@ -71,7 +71,7 @@ namespace RTT
 
             T& get() { return arg; }
             void operator()(T a) { arg = a; }
-            operator T() { return arg;}
+            operator T&() { return arg; }
         };
 
         template<class T>
@@ -84,7 +84,7 @@ namespace RTT
 
             T& get() { return *arg; }
             void operator()(T& a) { arg = &a; }
-            operator T&() { return *arg;}
+            operator T&() { return *arg; }
         };
 
         template<class T>

--- a/rtt/internal/BindStorage.hpp
+++ b/rtt/internal/BindStorage.hpp
@@ -64,6 +64,7 @@ namespace RTT
         template<class T>
         struct AStore
         {
+            typedef T arg_type;
             T arg;
             AStore() : arg() {}
             AStore(T t) : arg(t) {}
@@ -77,6 +78,7 @@ namespace RTT
         template<class T>
         struct AStore<T&>
         {
+            typedef T& arg_type;
             T* arg;
             AStore() : arg( &NA<T&>::na() ) {}
             AStore(T& t) : arg(&t) {}

--- a/rtt/internal/CreateSequence.hpp
+++ b/rtt/internal/CreateSequence.hpp
@@ -81,8 +81,10 @@ namespace RTT
             DataStore(DataStore const& o) : arg(o.arg) {}
 
             T& get() { return arg; }
+            T const& get() const { return arg; }
             void operator()(T a) { arg = a; }
             operator T() { return arg;}
+            operator T const&() const { return arg;}
         };
 
         template<class T>
@@ -95,8 +97,10 @@ namespace RTT
             DataStore(DataStore const& o) : arg(o.arg) {}
 
             T& get() { return *arg; }
+            T const& get() const { return *arg; }
             void operator()(T& a) { arg = &a; }
             operator T&() { return *arg;}
+            operator T const&() const { return *arg;}
         };
 
         /**
@@ -154,7 +158,10 @@ namespace RTT
                 typedef typename ds_type::element_type element_type;
 
                 ds_type a =
-                    boost::dynamic_pointer_cast< element_type >( DataSourceTypeInfo<ds_arg_type>::getTypeInfo()->convert(*front) );
+                    boost::dynamic_pointer_cast< element_type >( *front );
+                if ( ! a ) {
+                    a = boost::dynamic_pointer_cast< element_type >( DataSourceTypeInfo<ds_arg_type>::getTypeInfo()->convert(*front) );
+                }
                 if ( ! a ) {
                     //cout << typeid(DataSource<ds_arg_type>).name() << endl;
                     ORO_THROW_OR_RETURN(wrong_types_of_args_exception( argnbr, tname, (*front)->getType() ), ds_type());
@@ -166,8 +173,10 @@ namespace RTT
             template<class ds_arg_type, class ads_type>
             static ads_type assignable(std::vector<base::DataSourceBase::shared_ptr>::const_iterator front, int argnbr, std::string const& tname )
             {
+                typedef typename ads_type::element_type element_type;
+
                 ads_type a =
-                    boost::dynamic_pointer_cast< AssignableDataSource<ds_arg_type> >( *front ); // note: no conversion done, must be same type.
+                    boost::dynamic_pointer_cast< element_type >( *front ); // note: no conversion done, must be same type.
                 if ( ! a ) {
                     ORO_THROW_OR_RETURN(wrong_types_of_args_exception( argnbr, tname, (*front)->getType() ), ads_type());
                 }

--- a/rtt/internal/CreateSequence.hpp
+++ b/rtt/internal/CreateSequence.hpp
@@ -51,6 +51,7 @@
 #include <boost/fusion/mpl.hpp>
 #include <boost/utility/enable_if.hpp>
 
+#include "BindStorage.hpp"
 #include "DataSource.hpp"
 #include "Exceptions.hpp"
 #include "../FactoryExceptions.hpp"
@@ -64,40 +65,6 @@ namespace RTT
     {
         namespace bf = boost::fusion;
         namespace mpl = boost::mpl;
-
-        /**
-         * Store a bound argument which may be a reference, const reference or
-         * any other type.
-         * This class was required to store (const) references, after the reference object storage
-         * was created. Copy of RTT::internal::AStore in BindStorage.hpp.
-         */
-        template<class T>
-        struct DataStore
-        {
-            typedef T arg_type;
-            T arg;
-            DataStore() : arg() {}
-            DataStore(T t) : arg(t) {}
-            DataStore(DataStore const& o) : arg(o.arg) {}
-
-            T& get() { return arg; }
-            void operator()(T a) { arg = a; }
-            operator T&() { return arg; }
-        };
-
-        template<class T>
-        struct DataStore<T&>
-        {
-            typedef T& arg_type;
-            T* arg;
-            DataStore() : arg( &NA<T&>::na() ) {}
-            DataStore(T& t) : arg(&t) {}
-            DataStore(DataStore const& o) : arg(o.arg) {}
-
-            T& get() { return *arg; }
-            void operator()(T& a) { arg = &a; }
-            operator T&() { return *arg; }
-        };
 
         /**
          * Helper class for extracting the bare pointer from a shared_ptr
@@ -233,7 +200,7 @@ namespace RTT
             /**
              * The argument storage type
              */
-            typedef DataStore<arg_type> arg_store_type;
+            typedef AStore<arg_type> arg_store_type;
 
             /**
              * The data source value type of an assignable data source is non-const, non-reference.
@@ -348,7 +315,7 @@ namespace RTT
              * We must return the resulting sequence by value, since boost fusion
              * returns temporaries, which we can't take a reference to.
              * @param in The values to store
-             * @return The receiving DataStore sequence.
+             * @return The receiving AStore sequence.
              */
             static data_store_type store(const data_type& in ) {
                 return data_store_type(bf::front(in), tail::store(bf::pop_front(in)));
@@ -419,7 +386,7 @@ namespace RTT
             typedef typename remove_cr<arg_type>::type ds_arg_type;
             typedef bf::cons<arg_type> data_type;
 
-            typedef DataStore<arg_type> arg_store_type;
+            typedef AStore<arg_type> arg_store_type;
             typedef bf::cons<arg_store_type > data_store_type;
 
             /**

--- a/rtt/internal/CreateSequence.hpp
+++ b/rtt/internal/CreateSequence.hpp
@@ -81,10 +81,8 @@ namespace RTT
             DataStore(DataStore const& o) : arg(o.arg) {}
 
             T& get() { return arg; }
-            T const& get() const { return arg; }
             void operator()(T a) { arg = a; }
-            operator T() { return arg;}
-            operator T const&() const { return arg;}
+            operator T&() { return arg; }
         };
 
         template<class T>
@@ -97,10 +95,8 @@ namespace RTT
             DataStore(DataStore const& o) : arg(o.arg) {}
 
             T& get() { return *arg; }
-            T const& get() const { return *arg; }
             void operator()(T& a) { arg = &a; }
-            operator T&() { return *arg;}
-            operator T const&() const { return *arg;}
+            operator T&() { return *arg; }
         };
 
         /**

--- a/rtt/internal/FusedFunctorDataSource.hpp
+++ b/rtt/internal/FusedFunctorDataSource.hpp
@@ -555,7 +555,7 @@ namespace RTT
              * puts them into the assignable data sources and
              * executes the associated action.
              */
-            result_type invoke(typename SequenceFactory::data_type seq) {
+            result_type invoke(const typename SequenceFactory::data_type& seq) const {
                 if ( subscriber ) {
                     // asynchronous
                     shared_ptr sg = this->cloneRT();

--- a/rtt/internal/OperationInterfacePartFused.hpp
+++ b/rtt/internal/OperationInterfacePartFused.hpp
@@ -40,6 +40,7 @@
 #define ORO_OPERATION_INTERFACE_PART_FUSED_HPP
 
 
+#include <boost/config.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/function_types/result_type.hpp>
 #include <boost/function_types/parameter_types.hpp>
@@ -50,6 +51,7 @@
 #ifndef BOOST_FUSION_UNFUSED_MAX_ARITY
 #define BOOST_FUSION_UNFUSED_MAX_ARITY 7
 #endif
+#include <boost/functional/forward_adapter.hpp>
 #include <boost/fusion/functional/generation/make_unfused.hpp>
 #else
 // our code goes up to 7 FUSION_MAX_VECTOR_SIZE defaults to 10
@@ -57,10 +59,6 @@
 #define BOOST_FUSION_UNFUSED_GENERIC_MAX_ARITY 7
 #endif
 #include <boost/fusion/include/make_unfused_generic.hpp>
-#endif
-
-#ifndef USE_CPP11
-#include <boost/lambda/lambda.hpp>
 #endif
 
 #include <vector>
@@ -216,32 +214,34 @@ namespace RTT
                 if ( args.size() != OperationInterfacePartFused<Signature>::arity() ) throw wrong_number_of_args_exception(OperationInterfacePartFused<Signature>::arity(), args.size() );
                 // note: in boost 1.41.0+ the function make_unfused() is available.
 #if BOOST_VERSION >= 104100
-#ifdef USE_CPP11
-                return this->op->signals( boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
-                                                                                                                    boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
-                                                                            _1
-                                                                            )
-                                                                )
-                                   );
-#else
-                return this->op->signals( boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
-                                                                                                                    boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
-                                                                            boost::lambda::_1
-                                                                            )
-                                                                )
-                                   );
-#endif
-#else
-                return this->op->signals( boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,
-                                                                                                                            boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()),subscriber),
-                                                                            boost::lambda::_1
-                                                                            )
-                                                                )
-                                   );
-#endif
+#if !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+                auto invoke_fused = boost::bind(&FusedMSignal<Signature>::invoke,
+                                        boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
+                                        boost::arg<1>()
+                                    );
+                typedef typename boost::fusion::result_of::make_unfused< decltype(invoke_fused) >::type unfused_type;
+                return this->op->signals(boost::forward_adapter<unfused_type>(boost::fusion::make_unfused(invoke_fused)));
+#else // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+                return this->op->signals(
+                            boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
+                                                                    boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
+                                                                    boost::arg<1>()
+                                                                    )
+                                                        ))
+                            );
+#endif // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#else // BOOST_VERSION >= 104100
+                return this->op->signals(
+                            boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,
+                                                                    boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
+                                                                    boost::arg<1>()
+                                                                    )
+                                                        )
+                            );
+#endif // BOOST_VERSION >= 104100
             }
         };
-#endif
+#endif // ORO_SIGNALLING_OPERATIONS
 
         /**
          * OperationInterfacePart implementation that only provides synchronous
@@ -421,7 +421,7 @@ namespace RTT
                     assert( carity == collectArity() + 1 ); // check for arity functions. (this is actually a compile time assert).
                     if ( args.size() != carity ) throw wrong_number_of_args_exception(carity, args.size() );
                     // we need to ask FusedMCollectDataSource what the arg types are, based on the collect signature.
-                    return new FusedMCollectDataSource<Signature>( create_sequence<typename FusedMCollectDataSource<Signature>::handle_and_arg_types >::sources(args.begin()), blocking );
+                    return new FusedMCollectDataSource<Signature>( create_sequence<typename FusedMCollectDataSource<Signature>::handle_and_arg_types >::assignable(args.begin()), blocking );
                 }
 #ifdef ORO_SIGNALLING_OPERATIONS
                 virtual Handle produceSignal( base::ActionInterface* func, const std::vector<base::DataSourceBase::shared_ptr>& args, ExecutionEngine* subscriber) const {
@@ -435,23 +435,35 @@ namespace RTT
                     a2.push_back(mwp);
                     a2.insert(a2.end(), args.begin(), args.end());
                     // note: in boost 1.41.0+ the function make_unfused() is available.
-    #if BOOST_VERSION >= 104100
-                    return this->op->signals( boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
-                                                                                boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()),subscriber),
-                                                                                _1
-                                                                                )
-                                                                    )
-                                       );
-    #else
-                    return this->op->signals( boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,
-                                                                                        boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()),subscriber),
-                                                                                _1
-                                                                                )
-                                                                    )
-                                       );
-    #endif
+#if BOOST_VERSION >= 104100
+#if !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+                    auto invoke_fused = boost::bind(&FusedMSignal<Signature>::invoke,
+                                            boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
+                                            boost::arg<1>()
+                                        );
+                    typedef typename boost::fusion::result_of::make_unfused< decltype(invoke_fused) >::type unfused_type;
+                    return this->op->signals(boost::forward_adapter<unfused_type>(boost::fusion::make_unfused(invoke_fused)));
+#else // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+                    return this->op->signals(
+                                boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
+                                                                        boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
+                                                                        boost::arg<1>()
+                                                                        )
+                                                            ))
+//                                );
+#endif // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#else // BOOST_VERSION >= 104100
+                    return this->op->signals(
+                                boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,
+                                                                        boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
+                                                                        boost::arg<1>()
+                                                                        )
+                                                            )
+                                );
+#endif // BOOST_VERSION >= 104100
                 }
-#endif
+#endif // ORO_SIGNALLING_OPERATIONS
+
                 boost::shared_ptr<base::DisposableInterface> getLocalOperation() const {
                     return this->op->getImplementation();
                 }

--- a/rtt/internal/OperationInterfacePartFused.hpp
+++ b/rtt/internal/OperationInterfacePartFused.hpp
@@ -40,7 +40,6 @@
 #define ORO_OPERATION_INTERFACE_PART_FUSED_HPP
 
 
-#include <boost/config.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/function_types/result_type.hpp>
 #include <boost/function_types/parameter_types.hpp>
@@ -214,22 +213,22 @@ namespace RTT
                 if ( args.size() != OperationInterfacePartFused<Signature>::arity() ) throw wrong_number_of_args_exception(OperationInterfacePartFused<Signature>::arity(), args.size() );
                 // note: in boost 1.41.0+ the function make_unfused() is available.
 #if BOOST_VERSION >= 104100
-#if !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#if __cplusplus > 199711L
                 auto invoke_fused = boost::bind(&FusedMSignal<Signature>::invoke,
                                         boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
                                         boost::arg<1>()
                                     );
                 typedef typename boost::fusion::result_of::make_unfused< decltype(invoke_fused) >::type unfused_type;
                 return this->op->signals(boost::forward_adapter<unfused_type>(boost::fusion::make_unfused(invoke_fused)));
-#else // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#else // __cplusplus > 199711L
                 return this->op->signals(
                             boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
                                                                     boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
                                                                     boost::arg<1>()
                                                                     )
-                                                        ))
+                                                        )
                             );
-#endif // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#endif // __cplusplus > 199711L
 #else // BOOST_VERSION >= 104100
                 return this->op->signals(
                             boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,
@@ -436,22 +435,22 @@ namespace RTT
                     a2.insert(a2.end(), args.begin(), args.end());
                     // note: in boost 1.41.0+ the function make_unfused() is available.
 #if BOOST_VERSION >= 104100
-#if !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#if __cplusplus > 199711L
                     auto invoke_fused = boost::bind(&FusedMSignal<Signature>::invoke,
                                             boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
                                             boost::arg<1>()
                                         );
                     typedef typename boost::fusion::result_of::make_unfused< decltype(invoke_fused) >::type unfused_type;
                     return this->op->signals(boost::forward_adapter<unfused_type>(boost::fusion::make_unfused(invoke_fused)));
-#else // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+#else // __cplusplus > 199711L
                     return this->op->signals(
                                 boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
                                                                         boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
                                                                         boost::arg<1>()
                                                                         )
-                                                            ))
-//                                );
-#endif // !defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_CXX11_DECLTYPE)
+                                                            )
+                                );
+#endif // __cplusplus > 199711L
 #else // BOOST_VERSION >= 104100
                     return this->op->signals(
                                 boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,


### PR DESCRIPTION
Like #196, but targets toolchain-2.9 and includes some other related patches that only apply to toolchain-2.9.