### PR TITLE
Replaced all occurences of deprecated auto_ptr by unique_ptr

### DIFF
--- a/rtt/types/PropertyDecomposition.cpp
+++ b/rtt/types/PropertyDecomposition.cpp
@@ -48,6 +48,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <boost/config.hpp>
 #include <boost/lexical_cast.hpp>
 #include "../Logger.hpp"
 #include "TypeInfo.hpp"
@@ -103,7 +104,12 @@ bool typeDecomposition( base::DataSourceBase::shared_ptr dsb, PropertyBag& targe
     targetbag.setType( dsb->getTypeName() );
 
     // needed for recursion.
-    auto_ptr< Property<PropertyBag> > recurse_bag( new Property<PropertyBag>("recurse_bag","Part") );
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    unique_ptr< Property<PropertyBag> >
+#else
+    auto_ptr< Property<PropertyBag> >
+#endif
+            recurse_bag( new Property<PropertyBag>("recurse_bag","Part") );
     // First at the explicitly listed parts:
     for(vector<string>::iterator it = parts.begin(); it != parts.end(); ++it ) {
         DataSourceBase::shared_ptr part = dsb->getMember( *it );

--- a/rtt/types/PropertyDecomposition.cpp
+++ b/rtt/types/PropertyDecomposition.cpp
@@ -48,7 +48,6 @@
 #include <vector>
 #include <string>
 #include <memory>
-#include <boost/config.hpp>
 #include <boost/lexical_cast.hpp>
 #include "../Logger.hpp"
 #include "TypeInfo.hpp"
@@ -104,7 +103,7 @@ bool typeDecomposition( base::DataSourceBase::shared_ptr dsb, PropertyBag& targe
     targetbag.setType( dsb->getTypeName() );
 
     // needed for recursion.
-#ifndef BOOST_NO_CXX11_SMART_PTR
+#if __cplusplus > 199711L
     unique_ptr< Property<PropertyBag> >
 #else
     auto_ptr< Property<PropertyBag> >

--- a/tests/corba_ipc_test.cpp
+++ b/tests/corba_ipc_test.cpp
@@ -39,8 +39,6 @@
 #include <string>
 #include <stdlib.h>
 
-#include <boost/config.hpp>
-
 using namespace RTT;
 using namespace RTT::detail;
 
@@ -551,7 +549,7 @@ BOOST_AUTO_TEST_CASE( testPortProxying )
     BOOST_CHECK(!write_port->connected());
 
     // Test cloning
-#ifndef BOOST_NO_CXX11_SMART_PTR
+#if __cplusplus > 199711L
     unique_ptr<base::InputPortInterface>
 #else
     auto_ptr<base::InputPortInterface>

--- a/tests/corba_ipc_test.cpp
+++ b/tests/corba_ipc_test.cpp
@@ -19,6 +19,7 @@
 #include "unit.hpp"
 
 #include <iostream>
+#include <memory>
 
 #include <rtt/OperationCaller.hpp>
 #include <rtt/Service.hpp>
@@ -37,6 +38,8 @@
 
 #include <string>
 #include <stdlib.h>
+
+#include <boost/config.hpp>
 
 using namespace RTT;
 using namespace RTT::detail;
@@ -548,7 +551,12 @@ BOOST_AUTO_TEST_CASE( testPortProxying )
     BOOST_CHECK(!write_port->connected());
 
     // Test cloning
-    auto_ptr<base::InputPortInterface> read_clone(dynamic_cast<base::InputPortInterface*>(read_port->clone()));
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    unique_ptr<base::InputPortInterface>
+#else
+    auto_ptr<base::InputPortInterface>
+#endif
+            read_clone(dynamic_cast<base::InputPortInterface*>(read_port->clone()));
     BOOST_CHECK(mo->createConnection(*read_clone));
     BOOST_CHECK(read_clone->connected());
     BOOST_CHECK(!read_port->connected());

--- a/tests/corba_test.cpp
+++ b/tests/corba_test.cpp
@@ -37,7 +37,6 @@
 
 #include "operations_fixture.hpp"
 
-#include <boost/config.hpp>
 #include <memory>
 
 using namespace std;
@@ -610,7 +609,7 @@ BOOST_AUTO_TEST_CASE( testSharedConnections )
     // This test installs shared connections between mo1 and mo2 as writers and mi2 and mi3 as readers
 
 //    // Add a second input port mo3 to tc
-//#ifndef BOOST_NO_CXX11_SMART_PTR
+//#if __cplusplus > 199711L
 //    unique_ptr<RTT::OutputPort<double> >
 //#else
 //    auto_ptr<RTT::OutputPort<double> >
@@ -620,7 +619,7 @@ BOOST_AUTO_TEST_CASE( testSharedConnections )
 //    tc->addPort("mo3", *mo3);
 
     // Add a second input port mi3 to t2
-#ifndef BOOST_NO_CXX11_SMART_PTR
+#if __cplusplus > 199711L
     unique_ptr<RTT::InputPort<double> >
 #else
     auto_ptr<RTT::InputPort<double> >
@@ -785,7 +784,7 @@ BOOST_AUTO_TEST_CASE( testPortProxying )
     BOOST_CHECK(!write_port->connected());
 
     // Test cloning
-#ifndef BOOST_NO_CXX11_SMART_PTR
+#if __cplusplus > 199711L
     unique_ptr<base::InputPortInterface>
 #else
     auto_ptr<base::InputPortInterface>

--- a/tests/corba_test.cpp
+++ b/tests/corba_test.cpp
@@ -35,9 +35,10 @@
 #include <transports/corba/CorbaConnPolicy.hpp>
 #include <transports/corba/RTTCorbaConversion.hpp>
 
-#include <boost/scoped_ptr.hpp>
-
 #include "operations_fixture.hpp"
+
+#include <boost/config.hpp>
+#include <memory>
 
 using namespace std;
 using corba::TaskContextProxy;
@@ -609,11 +610,22 @@ BOOST_AUTO_TEST_CASE( testSharedConnections )
     // This test installs shared connections between mo1 and mo2 as writers and mi2 and mi3 as readers
 
 //    // Add a second input port mo3 to tc
-//    boost::scoped_ptr<RTT::OutputPort<double> > mo3(new RTT::OutputPort<double>());
+//#ifndef BOOST_NO_CXX11_SMART_PTR
+//    unique_ptr<RTT::OutputPort<double> >
+//#else
+//    auto_ptr<RTT::OutputPort<double> >
+//#endif
+//            mo3(new RTT::OutputPort<double>());
+
 //    tc->addPort("mo3", *mo3);
 
     // Add a second input port mi3 to t2
-    boost::scoped_ptr<RTT::InputPort<double> > mi3(new RTT::InputPort<double>());
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    unique_ptr<RTT::InputPort<double> >
+#else
+    auto_ptr<RTT::InputPort<double> >
+#endif
+            mi3(new RTT::InputPort<double>());
     t2->addPort("mi3", *mi3);
 
     // This test tests shared connections port-to-port connections.
@@ -773,7 +785,12 @@ BOOST_AUTO_TEST_CASE( testPortProxying )
     BOOST_CHECK(!write_port->connected());
 
     // Test cloning
-    auto_ptr<base::InputPortInterface> read_clone(dynamic_cast<base::InputPortInterface*>(read_port->clone()));
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    unique_ptr<base::InputPortInterface>
+#else
+    auto_ptr<base::InputPortInterface>
+#endif
+            read_clone(dynamic_cast<base::InputPortInterface*>(read_port->clone()));
     BOOST_CHECK(mo2->createConnection(*read_clone));
     BOOST_CHECK(read_clone->connected());
     BOOST_CHECK(!read_port->connected());

--- a/tests/ports_test.cpp
+++ b/tests/ports_test.cpp
@@ -26,7 +26,6 @@
 #include <extras/SimulationActivity.hpp>
 #include <extras/SimulationThread.hpp>
 
-#include <boost/config.hpp>
 #include <boost/function_types/function_type.hpp>
 #include <OperationCaller.hpp>
 
@@ -132,7 +131,7 @@ BOOST_AUTO_TEST_CASE( testPortTaskInterface )
     // We're adding the above ports to another TC as well.
     // This is not supported behavior, as it will 'overtake' ownership,
      {
-#ifndef BOOST_NO_CXX11_SMART_PTR
+#if __cplusplus > 199711L
         unique_ptr<TaskContext> tc1(new TaskContext( "tc", TaskContext::Stopped ));
         unique_ptr<TaskContext> tc2(new TaskContext( "tc2", TaskContext::Stopped ));
 #else
@@ -1045,7 +1044,7 @@ BOOST_AUTO_TEST_CASE(testPlainPortNotSignalling)
 BOOST_AUTO_TEST_CASE(testPortDataSource)
 {
     OutputPort<int> wp1("Write");
-#ifndef BOOST_NO_CXX11_SMART_PTR
+#if __cplusplus > 199711L
     unique_ptr<InputPortInterface>
 #else
     auto_ptr<InputPortInterface>

--- a/tests/ports_test.cpp
+++ b/tests/ports_test.cpp
@@ -26,10 +26,13 @@
 #include <extras/SimulationActivity.hpp>
 #include <extras/SimulationThread.hpp>
 
+#include <boost/config.hpp>
 #include <boost/function_types/function_type.hpp>
 #include <OperationCaller.hpp>
 
 #include <rtt-config.h>
+
+#include <memory>
 
 using namespace std;
 using namespace RTT;
@@ -129,8 +132,13 @@ BOOST_AUTO_TEST_CASE( testPortTaskInterface )
     // We're adding the above ports to another TC as well.
     // This is not supported behavior, as it will 'overtake' ownership,
      {
+#ifndef BOOST_NO_CXX11_SMART_PTR
+        unique_ptr<TaskContext> tc1(new TaskContext( "tc", TaskContext::Stopped ));
+        unique_ptr<TaskContext> tc2(new TaskContext( "tc2", TaskContext::Stopped ));
+#else
         auto_ptr<TaskContext> tc1(new TaskContext( "tc", TaskContext::Stopped ));
         auto_ptr<TaskContext> tc2(new TaskContext( "tc2", TaskContext::Stopped ));
+#endif
 
         tc1->ports()->addPort( rp1 );
         tc1->ports()->addPort( wp2 );
@@ -1037,7 +1045,12 @@ BOOST_AUTO_TEST_CASE(testPlainPortNotSignalling)
 BOOST_AUTO_TEST_CASE(testPortDataSource)
 {
     OutputPort<int> wp1("Write");
-    auto_ptr<InputPortInterface> reader(dynamic_cast<InputPortInterface*>(wp1.antiClone()));
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    unique_ptr<InputPortInterface>
+#else
+    auto_ptr<InputPortInterface>
+#endif
+            reader(dynamic_cast<InputPortInterface*>(wp1.antiClone()));
     BOOST_CHECK(wp1.connectTo(&*reader, ConnPolicy::buffer(2)));
 
     DataSource<int>::shared_ptr source = static_cast< DataSource<int>* >(reader->getDataSource());

--- a/tests/specialized_activities.cpp
+++ b/tests/specialized_activities.cpp
@@ -11,6 +11,9 @@
 #include "specialized_activities.hpp"
 #include <extras/FileDescriptorActivity.hpp>
 #include <iostream>
+#include <memory>
+#include <boost/config.hpp>
+
 #include <rtt-detail-fwd.hpp>
 using namespace RTT::detail;
 
@@ -54,7 +57,12 @@ BOOST_FIXTURE_TEST_SUITE(SecializedActivitiesSuite,SpecializedActivities)
 
 BOOST_AUTO_TEST_CASE( testFileDescriptorActivity )
 {
-    auto_ptr<TestFDActivity> activity(new TestFDActivity);
+#ifndef BOOST_NO_CXX11_SMART_PTR
+    unique_ptr<TestFDActivity>
+#else
+    auto_ptr<TestFDActivity>
+#endif
+            activity(new TestFDActivity);
     static const int USLEEP = 250000;
 
     int pipe_fds[2];

--- a/tests/specialized_activities.cpp
+++ b/tests/specialized_activities.cpp
@@ -12,7 +12,6 @@
 #include <extras/FileDescriptorActivity.hpp>
 #include <iostream>
 #include <memory>
-#include <boost/config.hpp>
 
 #include <rtt-detail-fwd.hpp>
 using namespace RTT::detail;
@@ -57,7 +56,7 @@ BOOST_FIXTURE_TEST_SUITE(SecializedActivitiesSuite,SpecializedActivities)
 
 BOOST_AUTO_TEST_CASE( testFileDescriptorActivity )
 {
-#ifndef BOOST_NO_CXX11_SMART_PTR
+#if __cplusplus > 199711L
     unique_ptr<TestFDActivity>
 #else
     auto_ptr<TestFDActivity>


### PR DESCRIPTION
auto_ptr was deprecated in C++11. Removes compiler warnings when compiling with `-std=c++11`.
See http://en.cppreference.com/w/cpp/memory/auto_ptr.