### PR TITLE
Revert USE_CPP11 patch and eliminate boost lambda outside scripting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ endif()
 
 PROJECT(orocos-rtt)
 
-
 SET( RTT_VERSION 2.8.3 )
 STRING( REGEX MATCHALL "[0-9]+" RTT_VERSIONS ${RTT_VERSION} )
 LIST( GET RTT_VERSIONS 0 RTT_VERSION_MAJOR)
@@ -42,11 +41,6 @@ if (NOT EXISTS ${PROJ_SOURCE_DIR}/orocos-rtt.cmake)
     "See orocos-rtt.default.cmake")
   INCLUDE(${PROJ_SOURCE_DIR}/orocos-rtt.default.cmake)
 endif ()
-
-OPTION(USE_CPP11 "Turn on to replace boost::bind with cpp11 bind." OFF)
-if(USE_CPP11)
-  ADD_DEFINITIONS(-DUSE_CPP11)
-endif(USE_CPP11)
 
 # On Windows, the default CMAKE_INSTALL_PREFIX is either:
 # C:\Program Files\orocos-rtt or C:\Program Files (x86)\orocos-rtt

--- a/rtt/ExecutionEngine.cpp
+++ b/rtt/ExecutionEngine.cpp
@@ -48,8 +48,6 @@
 #include "extras/SlaveActivity.hpp"
 
 #include <boost/bind.hpp>
-#include <boost/ref.hpp>
-#include <functional>
 #include <algorithm>
 
 #define ORONUM_EE_MQUEUE_SIZE 100
@@ -157,8 +155,8 @@ namespace RTT
             found = true; // always true in order to be able to quit waitForMessages.
         }
         virtual void dispose() {}
-        virtual bool isError() const { return false;}
-
+        virtual bool isError() const { return false; }
+        bool done() const { return !mf->isLoaded() || found; }
     };
 
     bool ExecutionEngine::removeFunction( ExecutableInterface* f )
@@ -178,7 +176,7 @@ namespace RTT
             // Running: create message on stack.
             RemoveMsg rmsg(f,this);
             if ( this->process(&rmsg) )
-                this->waitForMessages( ! lambda::bind(&ExecutableInterface::isLoaded, f) || lambda::bind(&RemoveMsg::found,boost::ref(rmsg)) );
+                this->waitForMessages( boost::bind(&RemoveMsg::done, &rmsg) );
             if (!rmsg.found)
                 return false;
         }

--- a/rtt/ExecutionEngine.cpp
+++ b/rtt/ExecutionEngine.cpp
@@ -49,10 +49,6 @@
 
 #include <boost/bind.hpp>
 #include <boost/ref.hpp>
-#ifndef USE_CPP11
-#include <boost/lambda/lambda.hpp>
-#include <boost/lambda/bind.hpp>
-#endif
 #include <functional>
 #include <algorithm>
 
@@ -182,11 +178,7 @@ namespace RTT
             // Running: create message on stack.
             RemoveMsg rmsg(f,this);
             if ( this->process(&rmsg) )
-#ifdef USE_CPP11
-                this->waitForMessages( ! bind(&ExecutableInterface::isLoaded, f) || bind(&RemoveMsg::found,boost::ref(rmsg)) );
-#else
                 this->waitForMessages( ! lambda::bind(&ExecutableInterface::isLoaded, f) || lambda::bind(&RemoveMsg::found,boost::ref(rmsg)) );
-#endif
             if (!rmsg.found)
                 return false;
         }

--- a/rtt/InputPort.hpp
+++ b/rtt/InputPort.hpp
@@ -152,7 +152,7 @@ namespace RTT
         {
             FlowStatus result = NoData;
             // read and iterate if necessary.
-            cmanager.select_reader_channel( boost::bind( &InputPort::do_read, this, boost::ref(sample), boost::ref(result), boost::lambda::_1, boost::lambda::_2), copy_old_data );
+            cmanager.select_reader_channel( boost::bind( &InputPort::do_read, this, boost::ref(sample), boost::ref(result), _1, _2 ), copy_old_data );
             return result;
         }
 

--- a/rtt/InputPort.hpp
+++ b/rtt/InputPort.hpp
@@ -152,11 +152,7 @@ namespace RTT
         {
             FlowStatus result = NoData;
             // read and iterate if necessary.
-#ifdef USE_CPP11
-            cmanager.select_reader_channel( bind( &InputPort::do_read, this, boost::ref(sample), boost::ref(result), _1, _2), copy_old_data );
-#else
             cmanager.select_reader_channel( boost::bind( &InputPort::do_read, this, boost::ref(sample), boost::ref(result), boost::lambda::_1, boost::lambda::_2), copy_old_data );
-#endif
             return result;
         }
 

--- a/rtt/OutputPort.hpp
+++ b/rtt/OutputPort.hpp
@@ -233,15 +233,9 @@ namespace RTT
             has_initial_sample = true;
             has_last_written_value = false;
 
-#ifdef USE_CPP11
-            cmanager.delete_if( bind(
-                        &OutputPort<T>::do_init, this, boost::ref(sample), _1)
-                    );
-#else
             cmanager.delete_if( boost::bind(
                         &OutputPort<T>::do_init, this, boost::ref(sample), _1)
                     );
-#endif
         }
 
         /**
@@ -258,15 +252,9 @@ namespace RTT
             }
             has_last_written_value = keeps_last_written_value;
 
-#ifdef USE_CPP11
-            cmanager.delete_if( bind(
-                        &OutputPort<T>::do_write, this, boost::ref(sample), _1)
-                    );
-#else
             cmanager.delete_if( boost::bind(
                         &OutputPort<T>::do_write, this, boost::ref(sample), boost::lambda::_1)
                     );
-#endif
         }
 
         void write(base::DataSourceBase::shared_ptr source)

--- a/rtt/OutputPort.hpp
+++ b/rtt/OutputPort.hpp
@@ -234,7 +234,7 @@ namespace RTT
             has_last_written_value = false;
 
             cmanager.delete_if( boost::bind(
-                        &OutputPort<T>::do_init, this, boost::ref(sample), _1)
+                        &OutputPort<T>::do_init, this, boost::ref(sample), _1 )
                     );
         }
 
@@ -253,7 +253,7 @@ namespace RTT
             has_last_written_value = keeps_last_written_value;
 
             cmanager.delete_if( boost::bind(
-                        &OutputPort<T>::do_write, this, boost::ref(sample), boost::lambda::_1)
+                        &OutputPort<T>::do_write, this, boost::ref(sample), _1 )
                     );
         }
 

--- a/rtt/Service.cpp
+++ b/rtt/Service.cpp
@@ -40,8 +40,6 @@
 #include "TaskContext.hpp"
 #include <algorithm>
 #include "internal/mystd.hpp"
-#include <boost/lambda/lambda.hpp>
-#include <boost/lambda/construct.hpp>
 #include <algorithm>
 
 namespace RTT {
@@ -223,7 +221,10 @@ namespace RTT {
             simpleoperations.erase(simpleoperations.begin() );
         }
 
-        for_each(ownedoperations.begin(),ownedoperations.end(), lambda::delete_ptr() );
+        for( OperationList::const_iterator it = ownedoperations.begin(); it != ownedoperations.end(); ++it )
+        {
+            delete *it;
+        }
         ownedoperations.clear();
 
         OperationInterface::clear();

--- a/rtt/internal/ConnectionManager.hpp
+++ b/rtt/internal/ConnectionManager.hpp
@@ -56,9 +56,7 @@
 #include <boost/tuple/tuple.hpp>
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
-#ifndef USE_CPP11
 #include <boost/lambda/lambda.hpp>
-#endif
 
 #include <rtt/os/Mutex.hpp>
 #include <rtt/os/MutexLock.hpp>

--- a/rtt/internal/ConnectionManager.hpp
+++ b/rtt/internal/ConnectionManager.hpp
@@ -56,7 +56,6 @@
 #include <boost/tuple/tuple.hpp>
 #include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/lambda/lambda.hpp>
 
 #include <rtt/os/Mutex.hpp>
 #include <rtt/os/MutexLock.hpp>

--- a/rtt/internal/ListLocked.hpp
+++ b/rtt/internal/ListLocked.hpp
@@ -254,7 +254,7 @@ namespace RTT
             {
             if(pred(cur->data))
             {
-                cur = mlist.erase_and_dispose(cur, boost::bind(&ListLocked::give_back, this, ::_1) );
+                cur = mlist.erase_and_dispose(cur, boost::bind(&ListLocked::give_back, this, _1) );
                 deleted = true;
             }
             else

--- a/rtt/internal/OperationCallerBinder.hpp
+++ b/rtt/internal/OperationCallerBinder.hpp
@@ -65,7 +65,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
-                return boost::bind( boost::mem_fn(m), o, ::_1 );
+                return boost::bind( boost::mem_fn(m), o, _1 );
             }
         };
 
@@ -74,7 +74,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
-                return boost::bind( boost::mem_fn(m), o, ::_1, ::_2 );
+                return boost::bind( boost::mem_fn(m), o, _1, _2 );
             }
         };
 
@@ -83,7 +83,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
-                return boost::bind( boost::mem_fn(m), o, ::_1, ::_2, ::_3 );
+                return boost::bind( boost::mem_fn(m), o, _1, _2, _3 );
             }
         };
 
@@ -92,7 +92,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
-                return boost::bind( boost::mem_fn(m), o, ::_1, ::_2, ::_3, ::_4 );
+                return boost::bind( boost::mem_fn(m), o, _1, _2, _3, _4 );
             }
         };
 
@@ -101,7 +101,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
-                return boost::bind( boost::mem_fn(m), o, ::_1, ::_2, ::_3, ::_4, ::_5 );
+                return boost::bind( boost::mem_fn(m), o, _1, _2, _3, _4, _5 );
             }
         };
 
@@ -110,7 +110,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
-                return boost::bind( boost::mem_fn(m), o, ::_1, ::_2, ::_3, ::_4, ::_5, ::_6 );
+                return boost::bind( boost::mem_fn(m), o, _1, _2, _3, _4, _5, _6 );
             }
         };
 
@@ -119,7 +119,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
-                return boost::bind( boost::mem_fn(m), o, ::_1, ::_2, ::_3, ::_4, ::_5, ::_6, ::_7 );
+                return boost::bind( boost::mem_fn(m), o, _1, _2, _3, _4, _5, _6, _7 );
             }
         };
 
@@ -128,7 +128,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
-                return boost::bind( boost::mem_fn(m), o, ::_1, ::_2, ::_3, ::_4, ::_5, ::_6, ::_7, ::_8 );
+                return boost::bind( boost::mem_fn(m), o, _1, _2, _3, _4, _5, _6, _7, _8 );
             }
         };
 
@@ -137,7 +137,7 @@ namespace RTT
         {
             template<class M, class O>
             boost::function<F> operator()(M m, O o) {
-                return boost::bind( boost::mem_fn(m), o, ::_1, ::_2, ::_3, ::_4, ::_5, ::_6, ::_7, ::_8, ::_9 );
+                return boost::bind( boost::mem_fn(m), o, _1, _2, _3, _4, _5, _6, _7, _8, _9 );
             }
         };
 

--- a/rtt/internal/OperationInterfacePartFused.hpp
+++ b/rtt/internal/OperationInterfacePartFused.hpp
@@ -59,8 +59,6 @@
 #include <boost/fusion/include/make_unfused_generic.hpp>
 #endif
 
-#include <boost/lambda/lambda.hpp>
-
 #include <vector>
 #include <string>
 
@@ -216,14 +214,14 @@ namespace RTT
 #if BOOST_VERSION >= 104100
                 return this->op->signals( boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
                                                                                                                     boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
-                                                                            boost::lambda::_1
+                                                                            _1
                                                                             )
                                                                 )
                                    );
 #else
                 return this->op->signals( boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,
                                                                                                                             boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()),subscriber),
-                                                                            boost::lambda::_1
+                                                                            _1
                                                                             )
                                                                 )
                                    );
@@ -424,21 +422,21 @@ namespace RTT
                     a2.push_back(mwp);
                     a2.insert(a2.end(), args.begin(), args.end());
                     // note: in boost 1.41.0+ the function make_unfused() is available.
-    #if BOOST_VERSION >= 104100
+#if BOOST_VERSION >= 104100
                     return this->op->signals( boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
                                                                                 boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()),subscriber),
                                                                                 _1
                                                                                 )
                                                                     )
                                        );
-    #else
+#else
                     return this->op->signals( boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,
                                                                                         boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()),subscriber),
                                                                                 _1
                                                                                 )
                                                                     )
                                        );
-    #endif
+#endif
                 }
 #endif
                 boost::shared_ptr<base::DisposableInterface> getLocalOperation() const {

--- a/rtt/internal/OperationInterfacePartFused.hpp
+++ b/rtt/internal/OperationInterfacePartFused.hpp
@@ -59,9 +59,7 @@
 #include <boost/fusion/include/make_unfused_generic.hpp>
 #endif
 
-#ifndef USE_CPP11
 #include <boost/lambda/lambda.hpp>
-#endif
 
 #include <vector>
 #include <string>
@@ -216,21 +214,12 @@ namespace RTT
                 if ( args.size() != OperationInterfacePartFused<Signature>::arity() ) throw wrong_number_of_args_exception(OperationInterfacePartFused<Signature>::arity(), args.size() );
                 // note: in boost 1.41.0+ the function make_unfused() is available.
 #if BOOST_VERSION >= 104100
-#ifdef USE_CPP11
-                return this->op->signals( boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
-                                                                                                                    boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
-                                                                            _1
-                                                                            )
-                                                                )
-                                   );
-#else
                 return this->op->signals( boost::fusion::make_unfused(boost::bind(&FusedMSignal<Signature>::invoke,
                                                                                                                     boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()), subscriber),
                                                                             boost::lambda::_1
                                                                             )
                                                                 )
                                    );
-#endif
 #else
                 return this->op->signals( boost::fusion::make_unfused_generic(boost::bind(&FusedMSignal<Signature>::invoke,
                                                                                                                             boost::make_shared<FusedMSignal<Signature> >(func, SequenceFactory::assignable(args.begin()),subscriber),

--- a/rtt/internal/SignalBase.cpp
+++ b/rtt/internal/SignalBase.cpp
@@ -37,7 +37,7 @@
 
 
 #include "SignalBase.hpp"
-#include <boost/lambda/bind.hpp>
+#include <boost/bind.hpp>
 
 #ifdef ORO_SIGNAL_USE_LIST_LOCK_FREE
 #else
@@ -232,15 +232,14 @@ namespace RTT {
         }
 
 #ifdef ORO_SIGNAL_USE_LIST_LOCK_FREE
-        // required for GCC 4.0.2
-        ConnectionBase* getPointer( ConnectionBase::shared_ptr c ) {
-            return c.get();
+        static void disconnectImpl( const ConnectionBase::shared_ptr& c ) {
+            c->disconnect();
         }
 #endif
 
         void SignalBase::disconnect() {
 #ifdef ORO_SIGNAL_USE_LIST_LOCK_FREE
-            mconnections.apply( boost::lambda::bind(&ConnectionBase::disconnect, boost::lambda::bind( &getPointer, boost::lambda::_1) ) ); // works for any compiler
+            mconnections.apply( boost::bind(&disconnectImpl, _1 ) );
 #else
             // avoid invalidating iterator
             os::MutexLock lock(m);

--- a/rtt/internal/signal_template.hpp
+++ b/rtt/internal/signal_template.hpp
@@ -43,11 +43,9 @@
 #include "NA.hpp"
 
 #ifdef ORO_SIGNAL_USE_LIST_LOCK_FREE
-#ifndef USE_CPP11
 #include <boost/lambda/bind.hpp>
 #include <boost/bind.hpp>
 #include <boost/lambda/casts.hpp>
-#endif
 #else
 #include "../os/MutexLock.hpp"
 #endif
@@ -140,14 +138,9 @@ namespace RTT {
             // this code did initially not work under gcc 4.0/ubuntu breezy.
             // connection_t::get() const becomes an undefined symbol.
             // works under gcc 3.4
-#ifdef USE_CPP11
-            mconnections.apply( bind(&connection_impl::emit,
-                                                    bind( &applyEmit, _1) // works for any compiler
-#else
             mconnections.apply( boost::lambda::bind(&connection_impl::emit,
                                                     boost::lambda::bind( &applyEmit, boost::lambda::_1) // works for any compiler
                                                     //not in gcc 4.0.2: boost::lambda::ll_static_cast<connection_impl*>(boost::lambda::bind(&connection_t::get, boost::lambda::_1))
-#endif
 #if OROCOS_SIGNATURE_NUM_ARGS != 0
                                                     ,OROCOS_SIGNATURE_ARGS
 #endif

--- a/rtt/internal/signal_template.hpp
+++ b/rtt/internal/signal_template.hpp
@@ -43,9 +43,7 @@
 #include "NA.hpp"
 
 #ifdef ORO_SIGNAL_USE_LIST_LOCK_FREE
-#include <boost/lambda/bind.hpp>
 #include <boost/bind.hpp>
-#include <boost/lambda/casts.hpp>
 #else
 #include "../os/MutexLock.hpp"
 #endif
@@ -103,14 +101,7 @@ namespace RTT {
         typedef arg1_type first_argument_type;
         typedef arg2_type second_argument_type;
 #endif
-    private:
-#ifdef ORO_SIGNAL_USE_LIST_LOCK_FREE
-        // required for GCC 4.0.2
-        static connection_impl* applyEmit( connection_t c ) {
-            return static_cast<connection_impl*> (c.get() );
-        }
-#endif
-    public:
+
 		OROCOS_SIGNAL_N()
 		{
 		}
@@ -130,6 +121,17 @@ namespace RTT {
             return Handle(conn);
 		}
 
+    private:
+        static void emitImpl(const connection_t& c
+#if OROCOS_SIGNATURE_NUM_ARGS != 0
+                                        , OROCOS_SIGNATURE_PARMS
+#endif
+                         )
+        {
+            static_cast<connection_impl*>(c.get())->emit(OROCOS_SIGNATURE_ARGS);
+        }
+
+    public:
 		R emit(OROCOS_SIGNATURE_PARMS)
 		{
 #ifdef ORO_SIGNAL_USE_LIST_LOCK_FREE
@@ -138,9 +140,8 @@ namespace RTT {
             // this code did initially not work under gcc 4.0/ubuntu breezy.
             // connection_t::get() const becomes an undefined symbol.
             // works under gcc 3.4
-            mconnections.apply( boost::lambda::bind(&connection_impl::emit,
-                                                    boost::lambda::bind( &applyEmit, boost::lambda::_1) // works for any compiler
-                                                    //not in gcc 4.0.2: boost::lambda::ll_static_cast<connection_impl*>(boost::lambda::bind(&connection_t::get, boost::lambda::_1))
+            mconnections.apply( boost::bind(&OROCOS_SIGNAL_N::emitImpl,
+                                                    _1
 #if OROCOS_SIGNATURE_NUM_ARGS != 0
                                                     ,OROCOS_SIGNATURE_ARGS
 #endif

--- a/tests/datasource_test.cpp
+++ b/tests/datasource_test.cpp
@@ -32,10 +32,7 @@
 #include <boost/serialization/array.hpp>
 
 #include <os/fosi.h>
-#include <boost/lambda/lambda.hpp>
 #include "datasource_fixture.hpp"
-
-using namespace boost::lambda;
 
 class DataSourceTest
 {

--- a/tests/enum_string_type_test.cpp
+++ b/tests/enum_string_type_test.cpp
@@ -21,15 +21,12 @@
 #include <rtt-fwd.hpp>
 #include <internal/DataSources.hpp>
 #include <os/fosi.h>
-#include <boost/lambda/lambda.hpp>
 
 #include "datasource_fixture.hpp"
 #include "marsh/PropertyBagIntrospector.hpp"
 #include "types/EnumTypeInfo.hpp"
 #include "marsh/PropertyLoader.hpp"
 #include "TaskContext.hpp"
-
-using namespace boost::lambda;
 
 typedef enum
 {
@@ -74,7 +71,6 @@ public:
 
 // Registers the fixture into the 'registry'
 BOOST_FIXTURE_TEST_SUITE( EnumTypeTestSuite, EnumTypeTest )
-
 // Tests enum to string conversions
 BOOST_AUTO_TEST_CASE( testEnumStringConversion )
 {

--- a/tests/enum_type_test.cpp
+++ b/tests/enum_type_test.cpp
@@ -21,15 +21,12 @@
 #include <rtt-fwd.hpp>
 #include <internal/DataSources.hpp>
 #include <os/fosi.h>
-#include <boost/lambda/lambda.hpp>
 
 #include "datasource_fixture.hpp"
 #include "marsh/PropertyBagIntrospector.hpp"
 #include "types/EnumTypeInfo.hpp"
 #include "marsh/PropertyLoader.hpp"
 #include "TaskContext.hpp"
-
-using namespace boost::lambda;
 
 typedef enum
 {

--- a/tests/type_discovery_container_test.cpp
+++ b/tests/type_discovery_container_test.cpp
@@ -26,7 +26,6 @@
 #include <internal/DataSources.hpp>
 #include <types/type_discovery.hpp>
 #include <os/fosi.h>
-#include <boost/lambda/lambda.hpp>
 
 #include "datasource_fixture.hpp"
 #include "types/StructTypeInfo.hpp"
@@ -34,7 +33,6 @@
 #include "types/SequenceTypeInfo.hpp"
 #include "types/BoostArrayTypeInfo.hpp"
 
-using namespace boost::lambda;
 using namespace boost::archive;
 using namespace boost::serialization;
 
@@ -61,9 +59,6 @@ BOOST_AUTO_TEST_CASE( testCTypeArray )
     // check the part names lookup:
     vector<string> names = atype->getMemberNames();
     BOOST_CHECK_EQUAL( atype->getMemberNames().size(), 2 ); // capacity,size
-
-//    for_each( names.begin(), names.end(), cout << lambda::_1 <<", " );
-//    cout <<endl;
 
     BOOST_REQUIRE_EQUAL( names.size(), 2);
     BOOST_REQUIRE( atype->getMember("0") );
@@ -109,9 +104,6 @@ BOOST_AUTO_TEST_CASE( testContainerType )
     // check the part names lookup:
     vector<string> names = atype->getMemberNames();
     BOOST_CHECK_EQUAL( atype->getMemberNames().size(), 2 ); // capacity,size
-
-//    for_each( names.begin(), names.end(), cout << lambda::_1 <<", " );
-//    cout <<endl;
 
     BOOST_REQUIRE_EQUAL( names.size(), 2);
     BOOST_REQUIRE( atype->getMember("0") );
@@ -167,9 +159,6 @@ BOOST_AUTO_TEST_CASE( testStringContainerType )
     // check the part names lookup:
     vector<string> names = atype->getMemberNames();
     BOOST_CHECK_EQUAL( atype->getMemberNames().size(), 2 ); // capacity,size
-
-//    for_each( names.begin(), names.end(), cout << lambda::_1 <<", " );
-//    cout <<endl;
 
     BOOST_REQUIRE_EQUAL( names.size(), 2);
     BOOST_REQUIRE( atype->getMember("0") );

--- a/tests/type_discovery_struct_test.cpp
+++ b/tests/type_discovery_struct_test.cpp
@@ -26,7 +26,6 @@
 #include <internal/DataSources.hpp>
 #include <types/type_discovery.hpp>
 #include <os/fosi.h>
-#include <boost/lambda/lambda.hpp>
 
 #include "datasource_fixture.hpp"
 #include "types/StructTypeInfo.hpp"
@@ -34,7 +33,6 @@
 #include "types/SequenceTypeInfo.hpp"
 #include "types/BoostArrayTypeInfo.hpp"
 
-using namespace boost::lambda;
 using namespace boost::archive;
 using namespace boost::serialization;
 
@@ -61,9 +59,6 @@ BOOST_AUTO_TEST_CASE( testATypeStruct )
     // check the part names lookup:
     vector<string> names = atype->getMemberNames();
     BOOST_CHECK_EQUAL( atype->getMemberNames().size(), 5 );
-
-//    for_each( names.begin(), names.end(), cout << lambda::_1 <<", " );
-//    cout <<endl;
 
     BOOST_REQUIRE_EQUAL( names.size(), 5);
     BOOST_REQUIRE( atype->getMember("a") );

--- a/tests/type_discovery_test.cpp
+++ b/tests/type_discovery_test.cpp
@@ -26,7 +26,6 @@
 #include <internal/DataSources.hpp>
 #include <types/type_discovery.hpp>
 #include <os/fosi.h>
-#include <boost/lambda/lambda.hpp>
 
 #include "datasource_fixture.hpp"
 #include "types/StructTypeInfo.hpp"
@@ -34,7 +33,6 @@
 #include "types/SequenceTypeInfo.hpp"
 #include "types/BoostArrayTypeInfo.hpp"
 
-using namespace boost::lambda;
 using namespace boost::archive;
 using namespace boost::serialization;
 
@@ -60,9 +58,6 @@ BOOST_AUTO_TEST_CASE( testATypeDiscovery )
     BOOST_CHECK_EQUAL( out.mnames.size(), 5 );
     BOOST_CHECK_EQUAL( out.mparts.size(), 5 );
     BOOST_CHECK_EQUAL( out.mparent, atype);
-
-//    for_each( out.mnames.begin(), out.mnames.end(), cout << lambda::_1 <<", " );
-//    cout <<endl;
 
     BOOST_REQUIRE_EQUAL( out.mparts.size(), 5);
 
@@ -110,9 +105,6 @@ BOOST_AUTO_TEST_CASE( testBTypeDiscovery )
     BOOST_CHECK_EQUAL( out.mnames.size(), 5 );
     BOOST_CHECK_EQUAL( out.mparts.size(), 5 );
     BOOST_CHECK_EQUAL( out.mparent, atype);
-
-//    for_each( out.mnames.begin(), out.mnames.end(), cout << lambda::_1 <<", " );
-//    cout <<endl;
 
     BOOST_REQUIRE_EQUAL( out.mparts.size(), 5);
 


### PR DESCRIPTION
This PR reverts the introduction of the `USE_CPP11` cmake option and preprocessor guard introduced in https://github.com/orocos-toolchain/rtt/pull/103, which I would consider as hotfix. Instead, it eliminates all usages of Boost Lambda outside RTT scripting and unifies the placeholder syntax for `boost::bind()`:
- `_1` <-- prefered
- `boost::lambda::_1`
- `::_1`

Tested with the following combinations of platforms, compilers and Boost:

- [x] Ubuntu Xenial, Boost 1.58, gcc 5.4, C++03
- [x] Ubuntu Xenial, Boost 1.58, gcc 5.4, C++11 (requires merge with #196)
- [x] Ubuntu Xenial, Boost 1.58, clang 3.8, C++03
- [x] Ubuntu Xenial, Boost 1.58, clang 3.8, C++11 (requires merge with #196)
- [x] Ubuntu Lucid, Boost 1.58, gcc 4.4
- [ ] Ubuntu Trusty, Boost 1.54, gcc 4.8, C++03
- [ ] Ubuntu Trusty, Boost 1.54, gcc 4.8, C++11
- [ ] Mac OS X
- ...