### PR TITLE
tests: fixed dev_test for gcc 5

### DIFF
--- a/tests/dev_test.cpp
+++ b/tests/dev_test.cpp
@@ -47,7 +47,8 @@ BOOST_FIXTURE_TEST_SUITE( DevTestSuite, DevTest )
 
 BOOST_AUTO_TEST_CASE( testClasses)
 {
-    DigitalInput din(true, false); // init, invert
+    bool din_state = true;
+    DigitalInput din(din_state, false); // init, invert
     DigitalOutput dout(false); // init.
     AnalogInput ain(0,0);
     AnalogOutput aout(0,0);


### PR DESCRIPTION
`DigitalInput` expects a `const bool &` in its constructor and stores it in a member variable. The dev_test passed a boolean literal, but C++ creates a temporary in this case which is only valid during the call.

At least with gcc 5 the dev_test consistenly failed:
```
/home/travis/build/orocos-toolchain/rtt/tests/dev_test.cpp(56): error in "testClasses": check din.isOn() failed
```

See https://travis-ci.org/orocos-toolchain/rtt/jobs/192398795.