### PR TITLE
Fix service destruction

### DIFF
--- a/rtt/Service.cpp
+++ b/rtt/Service.cpp
@@ -123,26 +123,18 @@ namespace RTT {
     }
 
     Service::shared_ptr Service::provides(const std::string& service_name) {
-        if (service_name == "this")
-            return provides();
-        shared_ptr sp = services[service_name];
+        shared_ptr sp = getService(service_name);
         if (sp)
             return sp;
         sp = boost::make_shared<Service>(service_name, mowner);
-        sp->setOwner( mowner );
-        // we pass and store a shared ptr in setParent, so we hack it like this:
-        shared_ptr me;
-        try {
-            me = shared_from_this();
-        } catch ( boost::bad_weak_ptr& bw ) {
-            me.reset(this); // take ownership
-        }
-        sp->setParent( me );
-        services[service_name] = sp;
-        return sp;
+        if ( addService(sp) )
+            return sp;
+        return shared_ptr();
     }
 
     Service::shared_ptr Service::getService(const std::string& service_name) {
+        if (service_name == "this")
+            return provides();
         Services::iterator it = services.find(service_name);
         if (it != services.end() )
             return it->second;

--- a/rtt/Service.cpp
+++ b/rtt/Service.cpp
@@ -103,10 +103,11 @@ namespace RTT {
     }
 
     void Service::removeService( string const& name) {
-        // carefully written to avoid destructor to call back on us when called from removeService.
+        // carefully written to avoid destructor to call back on us when called from clear().
         if ( services.count(name) ) {
             shared_ptr sp = services.find(name)->second;
             services.erase(name);
+            sp->setParent(Service::shared_ptr());
             sp.reset(); // this possibly deletes.
         }
     }
@@ -263,19 +264,8 @@ namespace RTT {
 
         this->mowner = new_owner;
 
-        for( Services::iterator it= services.begin(); it != services.end(); ++it) {
+        for( Services::iterator it= services.begin(); it != services.end(); ++it)
             it->second->setOwner( new_owner );
-            if (new_owner) {
-                // we pass and store a shared ptr in setParent, so we hack it like this:
-                shared_ptr me;
-                try {
-                    me = shared_from_this();
-                } catch ( boost::bad_weak_ptr& bw ) {
-                    me.reset(this); // take ownership
-                }
-                it->second->setParent( me );
-            }
-        }
     }
 
     void Service::setParent( Service::shared_ptr p) {

--- a/rtt/ServiceRequester.cpp
+++ b/rtt/ServiceRequester.cpp
@@ -104,7 +104,7 @@ namespace RTT
         try {
             return shared_from_this();
         } catch( boost::bad_weak_ptr& /*bw*/ ) {
-            log(Error) <<"When using boost < 1.40.0 : You are not allowed to call provides() on a ServiceRequester that does not yet belong to a TaskContext or another ServiceRequester." << endlog();
+            log(Error) <<"When using boost < 1.40.0 : You are not allowed to call requires() on a ServiceRequester that does not yet belong to a TaskContext or another ServiceRequester." << endlog();
             log(Error) <<"Try to avoid using requires() in this case: omit it or use the service requester directly." <<endlog();
             log(Error) <<"OR: upgrade to boost 1.40.0, then this error will go away." <<endlog();
             throw std::runtime_error("Illegal use of requires()");
@@ -114,12 +114,13 @@ namespace RTT
     ServiceRequester::shared_ptr ServiceRequester::requires(const std::string& service_name) {
         if (service_name == "this")
             return requires();
-        shared_ptr sp = mrequests[service_name];
-        if (sp)
+        Requests::iterator it = mrequests.find(service_name);
+        if (it != mrequests.end() )
+            return it->second;
+        shared_ptr sp = boost::make_shared<ServiceRequester>(service_name, mrowner);
+        if ( addServiceRequester(sp) )
             return sp;
-        sp = boost::make_shared<ServiceRequester>(service_name, mrowner);
-        mrequests[service_name] = sp;
-        return sp;
+        return shared_ptr();
     }
 
     bool ServiceRequester::addServiceRequester(ServiceRequester::shared_ptr obj) {

--- a/rtt/ServiceRequester.cpp
+++ b/rtt/ServiceRequester.cpp
@@ -95,6 +95,9 @@ namespace RTT
             it->second->setCaller( new_owner ? new_owner->engine() : 0);
 
         this->mrowner = new_owner;
+
+        for(Requests::iterator it = mrequests.begin(); it != mrequests.end(); ++it)
+            it->second->setOwner( new_owner );
     }
 
     ServiceRequester::shared_ptr ServiceRequester::requires() {

--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -124,6 +124,7 @@ namespace RTT
             // here would only lead to calling invalid virtual functions.
             // [Rule no 1: Don't call virtual functions in a destructor.]
             // [Rule no 2: Don't call virtual functions in a constructor.]
+            this->clear();
 
             // these need to be freed before we cleanup the EE:
             localservs.clear();

--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -128,7 +128,9 @@ namespace RTT
 
             // these need to be freed before we cleanup the EE:
             localservs.clear();
+            tcservice->setOwner(0);
             tcservice.reset();
+            tcrequests->setOwner(0);
             tcrequests.reset();
 
             // remove from all users.


### PR DESCRIPTION
Fixes the service destruction bug as reported in https://github.com/orocos-toolchain/rtt/issues/179. We should clear() the tasks service and requester interface on TaskContext destruction to not prevent destruction of children unless they are still referenced from somewhere else.

Includes https://github.com/psoetens/rtt/pull/8, but adds a commit which recursively resets the owner pointer of all children in case there is still another reference. In this case they should at least know that their owning TaskContext went away.