### PR TITLE
TimerThread: do not return the same instance if CPU affinity differs

### DIFF
--- a/rtt/extras/TimerThread.cpp
+++ b/rtt/extras/TimerThread.cpp
@@ -77,7 +77,10 @@ namespace RTT {
                 it = TimerThreads.begin();
                 continue;
             }
-            if ( tptr->getScheduler() == scheduler && tptr->getPriority() == pri && tptr->getPeriodNS() == Seconds_to_nsecs(per) ) {
+            if ( tptr->getScheduler() == scheduler &&
+                 tptr->getPriority() == pri &&
+                 tptr->getPeriodNS() == Seconds_to_nsecs(per) &&
+                 tptr->getCpuAffinity() == cpu_affinity ) {
                 return tptr;
             }
             ++it;


### PR DESCRIPTION
This was probably forgotten in e013a1ff that introduced CPU affinity of threads.