### PR TITLE
Another fix for blocking function calls in non-periodic components

### DIFF
--- a/rtt/scripting/CallFunction.hpp
+++ b/rtt/scripting/CallFunction.hpp
@@ -102,6 +102,9 @@ namespace RTT
                 if ( _foo->needsStart() ) // _foo might be auto-started in runFunction()
                     _foo->start();
                 if ( maccept ) {
+                    // Trigger the update step of mrunner. If the activity is periodic, this is a no-op.
+                    mrunner->getActivity()->timeout();
+
                     // block for the result: foo stopped or in error
                     //mcaller->waitForFunctions(boost::bind(&CallFunction::fooDone,this) );
                     mrunner->waitForFunctions(boost::bind(&CallFunction::fooDone,this) );

--- a/tests/scripting_test.cpp
+++ b/tests/scripting_test.cpp
@@ -45,11 +45,6 @@ BOOST_AUTO_TEST_CASE(TestGetProvider)
 
     PluginLoader::Instance()->loadService("scripting",tc);
 
-    // We use a sequential activity in order to force execution on trigger().
-    tc->stop();
-    BOOST_CHECK( tc->setActivity( new SequentialActivity() ) );
-    tc->start();
-
     boost::shared_ptr<Scripting> sc = tc->getProvider<Scripting>("scripting");
     BOOST_REQUIRE( sc );
     BOOST_CHECK ( sc->ready() );
@@ -61,7 +56,10 @@ BOOST_AUTO_TEST_CASE(TestGetProvider)
     BOOST_CHECK( sc->isProgramRunning("Foo") );
 
     // executes our script in the EE:
-    tc->getActivity()->trigger();
+    while(sc->isProgramRunning("Foo")) {
+        tc->trigger();
+        usleep(100);
+    }
 
     // test results:
     BOOST_CHECK( sc->isProgramRunning("Foo") == false );
@@ -73,11 +71,6 @@ BOOST_AUTO_TEST_CASE(TestGetProvider)
 BOOST_AUTO_TEST_CASE(TestScriptingParser)
 {
     PluginLoader::Instance()->loadService("scripting",tc);
-
-    // We use a sequential activity in order to force execution on trigger().
-    tc->stop();
-    BOOST_CHECK( tc->setActivity( new SequentialActivity() ) );
-    tc->start();
 
     boost::shared_ptr<Scripting> sc = tc->getProvider<Scripting>("scripting");
     BOOST_REQUIRE( sc );
@@ -159,11 +152,6 @@ BOOST_AUTO_TEST_CASE(TestScriptingFunction)
 {
     PluginLoader::Instance()->loadService("scripting",tc);
 
-    // We use a sequential activity in order to force execution on trigger().
-    tc->stop();
-    BOOST_CHECK( tc->setActivity( new SequentialActivity() ) );
-    tc->start();
-
     boost::shared_ptr<Scripting> sc = tc->getProvider<Scripting>("scripting");
     BOOST_REQUIRE( sc );
     BOOST_CHECK ( sc->ready() );
@@ -200,6 +188,34 @@ BOOST_AUTO_TEST_CASE(TestScriptingFunction)
     BOOST_CHECK_EQUAL( i, 0);
     BOOST_CHECK( GlobalService::Instance()->provides()->hasMember("gfunc1"));
 
+    // nested function call:
+    statements="void func2(void) { func1(); }\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 0);
+    BOOST_CHECK( tc->provides("scripting")->hasMember("func2"));
+
+    // nested exported function call:
+    statements="void efunc2(void) { efunc1(); }\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 0);
+    BOOST_CHECK( tc->provides("scripting")->hasMember("efunc2"));
+
+    // nested global function call:
+    statements="void gfunc2(void) { gfunc1(); }\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 0);
+    BOOST_CHECK( tc->provides("scripting")->hasMember("gfunc2"));
+
+    // nested local function call:
+    statements="void lfunc2(void) { lfunc1(); }\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 0);
+    BOOST_CHECK( tc->provides("scripting")->hasMember("lfunc2"));
+
     // invoke a function:
     statements="func1()\n";
     r = sc->eval(statements);
@@ -224,55 +240,120 @@ BOOST_AUTO_TEST_CASE(TestScriptingFunction)
     BOOST_CHECK( r );
     BOOST_CHECK_EQUAL( i, 4);
 
+    // invoke a function with a nested function call:
+    statements="func2()\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 5);
+
+    // invoke a function with a nested exported function call:
+    statements="efunc2()\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 6);
+
+    // invoke a function with a nested global function call:
+    statements="gfunc2()\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 7);
+
+    // invoke a function with a nested local function call:
+    statements="lfunc2()\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 8);
+
     // call a function:
     statements="call func1()\n";
     r = sc->eval(statements);
     BOOST_CHECK( !r );
-    BOOST_CHECK_EQUAL( i, 4);
+    BOOST_CHECK_EQUAL( i, 8);
 
     // call an exported function:
     statements="call efunc1()\n";
     r = sc->eval(statements);
     BOOST_CHECK( !r );
-    BOOST_CHECK_EQUAL( i, 4);
+    BOOST_CHECK_EQUAL( i, 8);
 
     // RE-define a function (added to scripting interface):
     statements="void func1(void) { test.increase(); test.increase(); }\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
-    BOOST_CHECK_EQUAL( i, 4);
+    BOOST_CHECK_EQUAL( i, 8);
     BOOST_CHECK( tc->provides("scripting")->hasMember("func1"));
 
     statements="func1()\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
-    BOOST_CHECK_EQUAL( i, 6);
+    BOOST_CHECK_EQUAL( i, 10);
 
     // RE-export a function:
     statements="export void efunc1(void) { test.increase(); test.increase();}\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
-    BOOST_CHECK_EQUAL( i, 6);
+    BOOST_CHECK_EQUAL( i, 10);
     BOOST_CHECK( tc->provides()->hasMember("efunc1"));
 
     statements="efunc1()\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
-    BOOST_CHECK_EQUAL( i, 8);
+    BOOST_CHECK_EQUAL( i, 12);
 
     // RE-global a function:
     statements="global void gfunc1(void) { test.increase(); test.increase();}\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
-    BOOST_CHECK_EQUAL( i, 8);
+    BOOST_CHECK_EQUAL( i, 12);
     BOOST_CHECK( GlobalService::Instance()->provides()->hasMember("gfunc1"));
 
     statements="gfunc1()\n";
     r = sc->eval(statements);
     BOOST_CHECK( r );
-    BOOST_CHECK_EQUAL( i, 10);
+    BOOST_CHECK_EQUAL( i, 14);
+}
 
+BOOST_AUTO_TEST_CASE(TestScriptingFunctionWithYield)
+{
+    PluginLoader::Instance()->loadService("scripting",tc);
 
+    // We need a periodic activity for this test case so that yielded functions
+    // will be executed again while we are waiting.
+    tc->setPeriod(0.1);
+
+    boost::shared_ptr<Scripting> sc = tc->getProvider<Scripting>("scripting");
+    BOOST_REQUIRE( sc );
+    BOOST_CHECK ( sc->ready() );
+    bool r;
+
+    // set test counter to zero:
+    i = 0;
+
+    // define a function that yields:
+    string statements="void func1(void) { test.printNumber(\"[ENTER func1()] CycleCounter = \", CycleCounter); test.increase(); yield; test.increase(); test.printNumber(\"[EXIT func1()] CycleCounter = \", CycleCounter); }\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 0);
+    BOOST_CHECK( tc->provides("scripting")->hasMember("func1"));
+
+    // define a function that calls func1, yields and calls func1 again:
+    statements = "void func2(void) { test.printNumber(\"[ENTER func2()] CycleCounter = \", CycleCounter); func1(); yield; func1(); test.printNumber(\"[EXIT func2()] CycleCounter = \", CycleCounter); }\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 0);
+    BOOST_CHECK( tc->provides("scripting")->hasMember("func2"));
+
+    // invoke func1()
+    statements = "func1()\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 2);
+
+    // invoke func2()
+    statements="func2()\n";
+    r = sc->eval(statements);
+    BOOST_CHECK( r );
+    BOOST_CHECK_EQUAL( i, 6);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This would be another, much simpler solution for the blocking function call issue reported in https://github.com/orocos-toolchain/rtt/issues/150.

Previous proposals have been:
1. ~~https://github.com/psoetens/rtt/pull/7~~ (was invalid)
2. a. https://github.com/orocos-toolchain/rtt/pull/156: run called functions asynchronously, like an operation, but breaks yielding in functions being called
   b. https://github.com/meyerj/rtt/pull/6: extension of the previous, which additionally supports yields by falling back to function semantics in that case
3. The new proposal here is as follows:

Whenever a scripting function is called, we also trigger a full update cycle, as if `TaskContext::trigger()` had been called. This is a no-op for periodic activities, but otherwise makes sure that the function gets executed soon without an explicit trigger. The caveat is that it also triggers an update hook, which I think is acceptable for non-periodic components. The "best" option would be to only enqueue the function being called, but that's already close to the solution in https://github.com/orocos-toolchain/rtt/pull/156 and https://github.com/meyerj/rtt/pull/6.

Additionally, if the caller and the runner's thread are the same, functions will be processed in a loop now in `waitAndProcessFunctions()` because there is nothing else we can do anyway to resolve the situation and otherwise the engine would have to rely on another external trigger to continue and finish the current cycle. This change also effectively disables yields, but only if one function calls another within the same component. The current implementation, which blocks on the `msg_cond` condition variable, does not guarantee that functions execute at most once in an update cycle either, because a callback type trigger was sufficient to initiate another `processFunctions()` cycle.

This patch also contains a small optimization for `waitAndProcessMessages()`, which checked the predicate twice within each cycle.

The updated `scripting_test` has been copied from https://github.com/meyerj/rtt/pull/6 and even checks some more complex cases of nested function calls which yield.