### PR TITLE
rtt Logger: clear any fail and eof flags

### DIFF
--- a/rtt/Logger.cpp
+++ b/rtt/Logger.cpp
@@ -510,7 +510,11 @@ namespace RTT
             os::MutexLock lock( d->inpguard );
             getline( d->remotestream, line );
             if ( !d->remotestream )
+            {
+                d->remotestream.str("");
                 d->remotestream.clear();
+                d->messagecnt = 0;
+            }
         }
         if ( !line.empty() )
             --d->messagecnt;


### PR DESCRIPTION
just call clear() will not reset the stringstream. And the log will not append to the stringsteam before reset the flag.
reflink: http://stackoverflow.com/questions/2848087/how-to-clear-stringstream