### PR TITLE
TLSF upgrade and debugging

### DIFF
--- a/rtt/CMakeLists.txt
+++ b/rtt/CMakeLists.txt
@@ -110,7 +110,7 @@ OPTION(ENABLE_MQ "Enable real-time posix message queues for data-flow." ON)
 CMAKE_DEPENDENT_OPTION(OS_RT_MALLOC "Enable RT memory management" ON "OS_HAS_TLSF" OFF)
 
 IF ( OS_RT_MALLOC )
-    SET(TLSF_FLAGS "")
+    SET(TLSF_FLAGS "-Wextra -Wall -Wwrite-strings -Wstrict-prototypes -Wmissing-prototypes -Wno-long-long -Wstrict-aliasing=2")
     OPTION( OS_RT_MALLOC_SBRK "Enable RT memory management with sbrk support" ON)
     OPTION( OS_RT_MALLOC_MMAP "Enable RT memory management with mmap support" ON)
     OPTION( OS_RT_MALLOC_STATS "Enable RT memory management with statistics" ON)

--- a/rtt/os/gnulinux/fosi.h
+++ b/rtt/os/gnulinux/fosi.h
@@ -127,7 +127,7 @@ extern "C"
      * This function should return ticks,
      * but we use ticks == nsecs in userspace
      */
-    static inline NANO_TIME rtos_get_time_ticks()
+    static inline NANO_TIME rtos_get_time_ticks(void)
     {
         return rtos_get_time_ns();
     }
@@ -288,11 +288,11 @@ extern "C"
         return pthread_mutex_unlock(m);
     }
 
-    static inline void rtos_enable_rt_warning()
+    static inline void rtos_enable_rt_warning(void)
     {
     }
 
-    static inline void rtos_disable_rt_warning()
+    static inline void rtos_disable_rt_warning(void)
     {
     }
 

--- a/rtt/os/tlsf/Changelog
+++ b/rtt/os/tlsf/Changelog
@@ -1,0 +1,132 @@
+  Version History
+  ---------------
+
+
+  -v2.4.6 (September 10 2009)
+	* Fixed a bug in the realloc func (discovered by the rockbox
+  	  project: www.rockbox.org).
+
+
+  -v2.4.5 (November 24 2008)
+	* Working on OSX/FreeBSD (may be for OpenBSD/NetBSD too).
+	  Reported by Younès HAFRI.
+          printf (and stdio.h include) is now optional.
+	  Reported by Masaki Muranaka
+
+  -v2.4.4 (October 13 2008)
+	* Corrected minor syntactic bug on statistic gathering code.
+ 	  Reported by Tim Cussins and P. Mantegazza.
+
+  -v2.4.3 (July 30 2008)
+	* Minor fixes to compile with the greenhills compiler.
+	  Reported by "Kaya, Sinan SEA" <sinan.kaya@siemens.com>
+	* Small change in the license in order to include TLSF in the RTEMS
+	  project.
+
+  -v2.4.2 (May 16 2008) (Herman ten Brugge)
+	* Memory usage statistics added again, with cleaner and more compacted
+	  code.
+
+  -v2.4.1 (April 30 2008)
+	* Fixed a bug in the tlsf_realloc function: init the pool automatically
+	  on the first call.
+	  Reported by: Alejandro Mery <amery@geeks.cl>
+
+  -v2.4  (Feb 19 2008)
+	* "rtl_*" functions renamed to "tlsf_*".
+	* Added the add_new_area function to insert new memory areas to an
+  	  existing memory pool.
+	* A single TLSF pool can manage non-contiguous memory areas.
+	* Support for mmap and sbrk added.
+	* The init_memory_pool is not longer needed when used on a system
+	  with mmap or sbrk.
+	* Removed the get_used_size counting.The same functionality can be
+	implemented outside the TLSF code.
+	
+  -v2.3.2 (Sep 27 2007) 
+  	* Minor cosmetic code improvements.
+
+  -v2.3.1 (Jul 30 2007)
+        * Fixed some minor bugs in the version 2.3. Herman ten Brugge
+	     <hermantenbrugge@home.nl>
+	
+  -v2.3 (Jul 28 2007) Released a new version with all the contributions 
+        received from Herman ten Brugge <hermantenbrugge@home.nl> 
+        (This is his summary of changes in the TLSF's code):
+        * Add 64 bit support. It now runs on x86_64 and solaris64.
+        * I also tested this on vxworks/32 and solaris/32 and i386/32 
+          processors.
+        * Remove assembly code. I could not measure any performance difference
+          on my core2 processor. This also makes the code more portable.
+        * Moved defines/typedefs from tlsf.h to tlsf.c
+        * Changed MIN_BLOCK_SIZE to sizeof (free_ptr_t) and BHDR_OVERHEAD to
+         (sizeof (bhdr_t) - MIN_BLOCK_SIZE). This does not change the fact
+         that the minumum size is still sizeof (bhdr_t).
+        * Changed all C++ comment style to C style. (// -> /* ... *./)
+        * Used ls_bit instead of ffs and ms_bit instead of fls. I did this to
+          avoid confusion with the standard ffs function which returns
+          different values.
+        * Created set_bit/clear_bit fuctions because they are not present
+          on x86_64.
+        * Added locking support + extra file target.h to show how to use it.
+        * Added get_used_size function
+        * Added rtl_realloc and rtl_calloc function
+        * Implemented realloc clever support.
+        * Added some test code in the example directory.
+
+	-- Thank you very much for your help Herman!
+
+  -v2.2.1 (Oct 23 2006)
+        * Support for ARMv5 implemented by Adam Scislowicz
+	  <proteuskor@gmail.com>. Thank you for your contribution.
+
+  - v2.2.0 (Jun 30 2006) Miguel Masmano & Ismael Ripoll.
+
+	* Blocks smaller than 128 bytes are stored on a single
+	  segregated list. The already existing bits maps and data
+	  structures are used.
+	* Minor code speed-up improvements.
+	* Worst case response time both on malloc and free improved.
+	* External fragmantation also improved!.
+	* Segragared lists are AGAIN sorted by LIFO order. Version
+	  2.1b was proven to be no better than 2.1.
+
+  - v2.1b: Allocation policy has been always a LIFO Good-Fit, that
+	   is, between several free blocks in the same range, TLSF will
+	   always allocate the most recently released. In this version of
+	   TLSF, we have implemented a FIFO Good-Fit. However,
+	   fragmentation doesn't seems to be altered so is it worth it?.
+	
+  - v2.1:  Realloc and calloc included again in TLSF 2.0.
+
+  - v2.0:  In this version,  TLSF has been programmed  from scratch.
+	   Now the allocator is provided as an unique file. Realloc and
+           calloc are not longer implemented.
+
+
+  - v1.4:  Created  the   section  "Version  History".   Studied  real
+           behaviour of actual applications (regular applications tend
+           to require small memory blocks (less than 16 bytes) whereas
+           TLSF is  optimised to  be used with  blocks larger  than 16
+           bytes: Added special lists to deal with blocks smaller than
+           16 bytes.
+
+
+  - v1.3: Change  of concept, now  the main TLSF structure  is created
+          inside of  the beginning  of the block  instead of  being an
+          static  structure, allowing  multiple TLSFs  working  at the
+          same time.  Now, TLSF uses specific processor instructions to
+          deal with bitmaps.  TLSF sanity functions added to find TLSF
+          overflows.  The  TLSF code will not  be RTLinux-oriented any
+          more.
+
+  - v1.1 ...  v1.2: Many little  bugs fixed, code cleaned and splitted
+                    in several files because of cosmetic requirements.
+                    Starting     from    TLSF    v1.1,     MaRTE    OS
+                    (http://marte.unican.es)  uses the  TLSF allocator
+		    as its default memory allocator.
+
+  - v0.1 ... v1.0: First  implementations were created for testing and
+		   research purposes.  Basically TLSF is implemented to
+                   be used by  RTLinux-GPL  (www.rtlinux-gpl.org),  so
+                   it  is RTLinux-oriented.

--- a/rtt/os/tlsf/README
+++ b/rtt/os/tlsf/README
@@ -1,0 +1,163 @@
+
+TLSF Memory Storage allocator implementation.
+Version 2.4.6 Sept 2009
+
+Authors: Miguel Masmano, Ismael Ripoll & Alfons Crespo.
+Copyright UPVLC, OCERA Consortium.
+
+TLSF is released in the GPL/LGPL licence. The exact terms of the licence
+are described in the COPYING file.
+
+This component provides basic memory allocation functions:
+malloc and free, as defined in the standard "C" library.
+
+This allocator was designed to provide real-time performance, that is:
+1.- Bounded time malloc and free.
+2.- Fast response time.
+3.- Efficient memory management, that is low fragmentation.
+
+
+The worst response time for both malloc and free is O(1).
+
+
+
+How to use it:
+
+This code  is prepared to  be used as  a stand-alone code that  can be
+linked with a regular application or  it can be compiled to be a Linux
+module  (which  required the  BigPhysicalArea  patch).  Initially  the
+module was  designed to  work jointly with  RTLinux-GPL, but it  can be
+used as a stand alone Linux module.
+
+When compiled as a regular linux process the API is:
+
+Initialisation and destruction functions
+----------------------------------------
+
+init_memory_pool may be called before any request or release call:
+
+- size_t init_memory_pool(size_t, void *);
+- void destroy_memory_pool(void *);
+
+Request and release functions
+-----------------------------
+
+As can be seen, there are two functions for each traditional memory
+allocation function (malloc, free, realloc, and calloc). One with the
+prefix "tlsf_" and the other with the suffix "_ex". 
+
+The versions with the prefix "tlsf_" provides the expected behaviour,
+that is, allocating/releasing memory from the default memory pool. The
+default memory pool is the last pool initialised by the
+init_memory_pool function.
+
+On the other hand, the functions with the prefix "_ex" enable the use of several memory pools.
+
+- void *tlsf_malloc(size_t);
+- void *malloc_ex(size_t, void *);
+
+- void tlsf_free(void *ptr);
+- void free_ex(void *, void *);
+
+- void *tlsf_realloc(void *ptr, size_t size);
+- void *realloc_ex(void *, size_t, void *);
+
+- void *tlsf_calloc(size_t nelem, size_t elem_size);
+- void *calloc_ex(size_t, size_t, void *);
+
+EXAMPLE OF USE:
+
+char memory_pool[1024*1024];
+
+{
+	...
+
+	init_memory_pool(1024*1024, memory_pool);
+
+	...
+	
+	ptr1=malloc_ex(100, memory_pool);
+	ptr2=tlsf_malloc(100); // This function will use memory_pool
+	
+        ...
+
+        tlsf_free(ptr2);
+	free_ex(ptr1, memory_pool);
+}
+
+Growing the memory pool
+-----------------------
+
+Starting from the version 2.4, the function add_new_area adds an
+memory area to an existing memory pool.
+
+- size_t add_new_area(void *, size_t, void *);
+
+This feature is pretty useful when an existing memory pool is running
+low and we want to add more free memory to it.
+EXAMPLE OF USE:
+
+char memory_pool[1024*1024];
+char memory_pool2[1024*1024];
+
+{
+	...
+
+	init_memory_pool(1024*1024, memory_pool);
+
+	...
+	
+	ptr[0]=malloc_ex(1024*256 memory_pool); 
+	ptr[1]=malloc_ex(1024*512, memory_pool); 
+	add_new_area(memory_pool2, 1024*1024, memory_pool);
+	// Now we have an extra free memory area of 1Mb
+	// The next malloc may not fail
+	ptr[2]=malloc_ex(1024*512, memory_pool); 
+	
+        ...
+
+}
+
+
+SBRK and MMAP support
+---------------------
+
+The version 2.4 can use the functions SBRK and MMAP to _automatically_
+growing the memory pool, before running out of memory.
+
+So, when this feature is enabled, unless the operating system were out
+of memory, a malloc operation would not fail due to an "out-of-memory"
+error.
+
+To enable this support, compile tlsf.c with the FLAGS -DUSE_MMAP=1 or
+-DUSE_SBRK=1 depending on whether you want to use "mmap" or "sbrk" or both.
+
+** By default (default Makefile) this feature is enabled.
+
+EXAMPLE OF USE:
+
+gcc -o tlsf.o -O2 -Wall -DUSE_MMAP=1 -DUSE_SBRK=1
+
+---
+
+If the sbrk/mmap support is enabled and we are _only_ going to use one
+memory pool, it is not necessary to call init_memory_pool
+
+EXAMPLE OF USE (with MMAP/SBRK support enabled):
+
+{
+	...
+	
+	ptr2=tlsf_malloc(100); // This function will use memory_pool
+	
+        ...
+
+        tlsf_free(ptr2);
+}
+
+
+
+
+This work has been supported by the followin projects:
+EUROPEAN: IST-2001-35102(OCERA) http://www.ocera.org.
+SPANISH: TIN2005-08665-C3-03 

--- a/rtt/os/tlsf/TODO
+++ b/rtt/os/tlsf/TODO
@@ -1,0 +1,9 @@
+To do list
+==========
+
+* Add mmap/sbrk support (DONE - V2.4).
+
+* TLSF rounds-up request size to the head of a free list.
+	It has been shown to be a good policy for small blocks (<2048).
+	But for larger blocks this policy may cause excesive fragmentation.
+	A deeper analisys should be done.

--- a/rtt/os/tlsf/tlsf.c
+++ b/rtt/os/tlsf/tlsf.c
@@ -994,8 +994,10 @@ void *calloc_ex(size_t nelem, size_t elem_size, void *mem_pool)
 
 extern void dump_memory_region(unsigned char *mem_ptr, unsigned int size);
 extern void print_block(bhdr_t * b);
+//extern void print_tlsf_mp(); in tlsf.h
 extern void print_tlsf(tlsf_t * tlsf);
-void print_all_blocks(tlsf_t * tlsf);
+//extern void print_all_blocks_mp(); in tlsf.h
+extern void print_all_blocks(tlsf_t * tlsf);
 
 void dump_memory_region(unsigned char *mem_ptr, unsigned int size)
 {
@@ -1055,6 +1057,15 @@ void print_block(bhdr_t * b)
         PRINT_MSG("prev used)\n");
 }
 
+// use default memory pool
+void print_tlsf_mp()
+{
+    if (0 == mp) return;
+    TLSF_ACQUIRE_LOCK(&((tlsf_t *)mp)->lock);
+    print_tlsf((tlsf_t *)mp);
+    TLSF_RELEASE_LOCK(&((tlsf_t *)mp)->lock);
+}
+
 void print_tlsf(tlsf_t * tlsf)
 {
     bhdr_t *next;
@@ -1077,6 +1088,15 @@ void print_tlsf(tlsf_t * tlsf)
             }
         }
     }
+}
+
+// use default memory pool
+void print_all_blocks_mp()
+{
+    if (0 == mp) return;
+    TLSF_ACQUIRE_LOCK(&((tlsf_t *)mp)->lock);
+    print_all_blocks((tlsf_t *)mp);
+    TLSF_RELEASE_LOCK(&((tlsf_t *)mp)->lock);
 }
 
 void print_all_blocks(tlsf_t * tlsf)

--- a/rtt/os/tlsf/tlsf.c
+++ b/rtt/os/tlsf/tlsf.c
@@ -1165,8 +1165,15 @@ void print_all_blocks(FILE* ff, tlsf_t * tlsf)
     area_info_t *ai;
     bhdr_t *next;
     FPRINT_MSG(ff, "\nTLSF at %p\nALL BLOCKS\n", tlsf);
-    FPRINT_MSG(ff, "Sizes pool=%u overhead=%u used=%u max-used=%u\n\n",
-               tlsf->pool_size, tlsf->overhead_size, tlsf->used_size, tlsf->max_size);
+    FPRINT_MSG(ff, "Sizes (bytes)\n");
+    FPRINT_MSG(ff, "  pool=%lu initial overhead=%lu max-possible-available=%lu\n",
+               tlsf->pool_size, tlsf->overhead_size, (tlsf->pool_size - tlsf->overhead_size));
+    FPRINT_MSG(ff, "  used=%lu max-used=%lu (both including initial overhead)\n",
+               tlsf->used_size, tlsf->max_size);
+    FPRINT_MSG(ff, "  used=%lu max-used=%lu (both without initial overhead)\n",
+               (tlsf->used_size - tlsf->overhead_size), (tlsf->max_size - tlsf->overhead_size));
+    FPRINT_MSG(ff, "  sizeof items bhdr_t=%lu area_info_t=%lu tlsf_t=%lu\n\n" ,
+               sizeof(bhdr_t), sizeof(area_info_t), sizeof(tlsf_t));
     ai = tlsf->area_head;
     while (ai) {
         next = (bhdr_t *) ((char *) ai - BHDR_OVERHEAD);

--- a/rtt/os/tlsf/tlsf.c
+++ b/rtt/os/tlsf/tlsf.c
@@ -191,6 +191,7 @@
 #ifdef USE_PRINTF
 #include <stdio.h>
 #define PRINT_MSG(fmt, args...) printf(fmt, ## args)
+#define FPRINT_MSG(ff, fmt, args...) fprintf(ff, fmt, ## args)
 #define ERROR_MSG(fmt, args...) printf(fmt, ## args)
 #else
 # if !defined(PRINT_MSG)
@@ -993,11 +994,11 @@ void *calloc_ex(size_t nelem, size_t elem_size, void *mem_pool)
 /* haven't too much worth.  To enable them, _DEBUG_TLSF_ must be set.  */
 
 extern void dump_memory_region(unsigned char *mem_ptr, unsigned int size);
-extern void print_block(bhdr_t * b);
+extern void print_block(FILE* ff, bhdr_t * b);
 //extern void print_tlsf_mp(); in tlsf.h
-extern void print_tlsf(tlsf_t * tlsf);
+extern void print_tlsf(FILE* ff, tlsf_t * tlsf);
 //extern void print_all_blocks_mp(); in tlsf.h
-extern void print_all_blocks(tlsf_t * tlsf);
+extern void print_all_blocks(FILE* ff, tlsf_t * tlsf);
 
 void dump_memory_region(unsigned char *mem_ptr, unsigned int size)
 {
@@ -1038,52 +1039,57 @@ void dump_memory_region(unsigned char *mem_ptr, unsigned int size)
     PRINT_MSG("\n\n");
 }
 
-void print_block(bhdr_t * b)
+void print_block(FILE* ff, bhdr_t * b)
 {
     if (!b)
         return;
-    PRINT_MSG(">> [%p] (", b);
+    FPRINT_MSG(ff, ">> [%p] (", b);
     if ((b->size & BLOCK_SIZE))
-        PRINT_MSG("%lu bytes, ", (unsigned long) ((intptr_t)b->size & BLOCK_SIZE));
+        FPRINT_MSG(ff, "%lu bytes, ", (unsigned long) ((intptr_t)b->size & BLOCK_SIZE));
     else
-        PRINT_MSG("sentinel, ");
+        FPRINT_MSG(ff, "sentinel, ");
     if ((b->size & BLOCK_STATE) == FREE_BLOCK)
-        PRINT_MSG("free [%p, %p], ", b->ptr.free_ptr.prev, b->ptr.free_ptr.next);
+        FPRINT_MSG(ff, "free [%p, %p], ", b->ptr.free_ptr.prev, b->ptr.free_ptr.next);
     else
-        PRINT_MSG("used, ");
+        FPRINT_MSG(ff, "used, ");
     if ((b->size & PREV_STATE) == PREV_FREE)
-        PRINT_MSG("prev. free [%p])\n", (void*)((intptr_t)b->prev_hdr & BLOCK_SIZE));
+        FPRINT_MSG(ff, "prev. free [%p])\n", (void*)((intptr_t)b->prev_hdr & BLOCK_SIZE));
     else
-        PRINT_MSG("prev used)\n");
+        FPRINT_MSG(ff, "prev used)\n");
 }
 
 // use default memory pool
-void print_tlsf_mp()
+void print_tlsf_mp(FILE* ff)
 {
+    if (0 == ff) return;
     if (0 == mp) return;
+
     TLSF_ACQUIRE_LOCK(&((tlsf_t *)mp)->lock);
-    print_tlsf((tlsf_t *)mp);
+    print_tlsf(ff, (tlsf_t *)mp);
     TLSF_RELEASE_LOCK(&((tlsf_t *)mp)->lock);
 }
 
-void print_tlsf(tlsf_t * tlsf)
+void print_tlsf(FILE* ff, tlsf_t * tlsf)
 {
+    if (0 == ff) return;
+    if (0 == tlsf) return;
+
     bhdr_t *next;
     int i, j;
 
-    PRINT_MSG("\nTLSF at %p\n", tlsf);
+    FPRINT_MSG(ff, "\nTLSF at %p\n", tlsf);
 
-    PRINT_MSG("FL bitmap: 0x%x\n\n", (unsigned) tlsf->fl_bitmap);
+    FPRINT_MSG(ff, "FL bitmap: 0x%x\n\n", (unsigned) tlsf->fl_bitmap);
 
     for (i = 0; i < REAL_FLI; i++) {
         if (tlsf->sl_bitmap[i])
-            PRINT_MSG("SL bitmap 0x%x\n", (unsigned) tlsf->sl_bitmap[i]);
+            FPRINT_MSG(ff, "SL bitmap 0x%x\n", (unsigned) tlsf->sl_bitmap[i]);
         for (j = 0; j < MAX_SLI; j++) {
             next = tlsf->matrix[i][j];
             if (next)
-                PRINT_MSG("-> [%d][%d]\n", i, j);
+                FPRINT_MSG(ff, "-> [%d][%d]\n", i, j);
             while (next) {
-                print_block(next);
+                print_block(ff, next);
                 next = next->ptr.free_ptr.next;
             }
         }
@@ -1091,24 +1097,29 @@ void print_tlsf(tlsf_t * tlsf)
 }
 
 // use default memory pool
-void print_all_blocks_mp()
+void print_all_blocks_mp(FILE* ff)
 {
+    if (0 == ff) return;
     if (0 == mp) return;
+
     TLSF_ACQUIRE_LOCK(&((tlsf_t *)mp)->lock);
-    print_all_blocks((tlsf_t *)mp);
+    print_all_blocks(ff, (tlsf_t *)mp);
     TLSF_RELEASE_LOCK(&((tlsf_t *)mp)->lock);
 }
 
-void print_all_blocks(tlsf_t * tlsf)
+void print_all_blocks(FILE* ff, tlsf_t * tlsf)
 {
+    if (0 == ff) return;
+    if (0 == tlsf) return;
+
     area_info_t *ai;
     bhdr_t *next;
-    PRINT_MSG("\nTLSF at %p\nALL BLOCKS\n\n", tlsf);
+    FPRINT_MSG(ff, "\nTLSF at %p\nALL BLOCKS\n\n", tlsf);
     ai = tlsf->area_head;
     while (ai) {
         next = (bhdr_t *) ((char *) ai - BHDR_OVERHEAD);
         while (next) {
-            print_block(next);
+            print_block(ff, next);
             if ((next->size & BLOCK_SIZE))
                 next = GET_NEXT_BLOCK(next->ptr.buffer, next->size & BLOCK_SIZE);
             else

--- a/rtt/os/tlsf/tlsf.h
+++ b/rtt/os/tlsf/tlsf.h
@@ -53,6 +53,11 @@ extern void tlsf_free(void *ptr);
 extern void *tlsf_realloc(void *ptr, size_t size);
 extern void *tlsf_calloc(size_t nelem, size_t elem_size);
 
+#if _DEBUG_TLSF_
+extern void print_tlsf_mp();
+extern void print_all_blocks_mp();
+#endif
+
 #ifdef	__cplusplus
 }
 #endif

--- a/rtt/os/tlsf/tlsf.h
+++ b/rtt/os/tlsf/tlsf.h
@@ -54,8 +54,10 @@ extern void *tlsf_realloc(void *ptr, size_t size);
 extern void *tlsf_calloc(size_t nelem, size_t elem_size);
 
 #if _DEBUG_TLSF_
-extern void print_tlsf_mp();
-extern void print_all_blocks_mp();
+// dump default memory pool to file ff
+extern void print_tlsf_mp(FILE* ff);
+// dump all blocks of default memory pool to file ff
+extern void print_all_blocks_mp(FILE* ff);
 #endif
 
 #ifdef	__cplusplus

--- a/rtt/os/tlsf/tlsf.h
+++ b/rtt/os/tlsf/tlsf.h
@@ -36,8 +36,16 @@ extern "C" {
 
 #ifdef ORO_MEMORY_POOL
 extern size_t init_memory_pool(size_t, void *);
+// get size of TLSF pool
+extern size_t get_pool_size(void *);
+extern size_t get_pool_size_mp();
+// get size of TLSF overhead
+extern size_t get_overhead_size(void *);
+extern size_t get_overhead_size_mp();
+// get currently used size (includes overhead)
 extern size_t get_used_size(void *);
 extern size_t get_used_size_mp(void);
+// get max used size (includes overhead)
 extern size_t get_max_size(void *);
 extern size_t get_max_size_mp(void);
 extern void destroy_memory_pool(void *);

--- a/rtt/os/tlsf/tlsf.h
+++ b/rtt/os/tlsf/tlsf.h
@@ -1,6 +1,6 @@
 /*
  * Two Levels Segregate Fit memory allocator (TLSF)
- * Version 2.4.4
+ * Version 2.4.6
  *
  * Written by Miguel Masmano Tello <mimastel@doctor.upv.es>
  *
@@ -19,6 +19,8 @@
 #ifndef _TLSF_H_
 #define _TLSF_H_
 
+#include <sys/types.h>
+
 /* We avoid name clashes with other projects and
  * only make the required function available
  */
@@ -35,9 +37,9 @@ extern "C" {
 #ifdef ORO_MEMORY_POOL
 extern size_t init_memory_pool(size_t, void *);
 extern size_t get_used_size(void *);
-extern size_t get_used_size_mp();
+extern size_t get_used_size_mp(void);
 extern size_t get_max_size(void *);
-extern size_t get_max_size_mp();
+extern size_t get_max_size_mp(void);
 extern void destroy_memory_pool(void *);
 extern size_t add_new_area(void *, size_t, void *);
 extern void *malloc_ex(size_t, void *);


### PR DESCRIPTION
Port of some patches from https://github.com/snrkiwi/rtt/tree/rdt-next to fix compile errors after https://github.com/orocos-toolchain/ocl/pull/57 has been merged.

The patches are mainly required for debugging TLSF memory issues.