### PR TITLE
TimerThread: do not return the same instance if CPU affinity differs

### DIFF
--- a/rtt/extras/TimerThread.cpp
+++ b/rtt/extras/TimerThread.cpp
@@ -44,6 +44,7 @@
 #include "../Logger.hpp"
 #include <algorithm>
 #include "../os/MutexLock.hpp"
+#include "../os/MainThread.hpp"
 
 namespace RTT {
     using namespace extras;
@@ -60,7 +61,7 @@ namespace RTT {
 
     TimerThreadPtr TimerThread::Instance(int scheduler, int pri, double per)
     {
-      return Instance(scheduler, pri, per, ~0);
+      return Instance(scheduler, pri, per, 0);
     }
 
     TimerThreadPtr TimerThread::Instance(int scheduler, int pri, double per, unsigned cpu_affinity)
@@ -68,6 +69,7 @@ namespace RTT {
         // Since the period is stored as nsecs, we convert per to NS in order
         // to get a match.
         os::CheckPriority(scheduler, pri);
+        if (cpu_affinity == 0) cpu_affinity = os::MainThread::Instance()->getCpuAffinity();
         TimerThreadList::iterator it = TimerThreads.begin();
         while ( it != TimerThreads.end() ) {
             TimerThreadPtr tptr = it->lock();

--- a/rtt/os/MainThread.cpp
+++ b/rtt/os/MainThread.cpp
@@ -111,6 +111,11 @@ namespace RTT
     	return rtos_task_get_pid(&main_task);
     }
 
+    unsigned MainThread::getCpuAffinity() const
+    {
+        return rtos_task_get_cpu_affinity(&main_task);
+    }
+
     bool MainThread::setPeriod(Seconds period)
     {
         return false;

--- a/rtt/os/MainThread.hpp
+++ b/rtt/os/MainThread.hpp
@@ -128,6 +128,8 @@ namespace RTT
 
         virtual unsigned int getPid() const;
 
+        virtual unsigned getCpuAffinity() const;
+
         virtual void setMaxOverrun(int m);
 
         virtual int getMaxOverrun() const;

--- a/rtt/os/Thread.cpp
+++ b/rtt/os/Thread.cpp
@@ -41,6 +41,7 @@
 #include "threads.hpp"
 #include "../Logger.hpp"
 #include "MutexLock.hpp"
+#include "MainThread.hpp"
 
 #include "../rtt-config.h"
 #include "../internal/CatchConfig.hpp"

--- a/rtt/os/Thread.hpp
+++ b/rtt/os/Thread.hpp
@@ -119,6 +119,7 @@ namespace RTT
              * @param priority The priority of the thread, this is interpreted by your RTOS.
              * @param period   The period in seconds (eg 0.001) of the thread, or zero if not periodic.
              * @param cpu_affinity The cpu affinity of the thread, this is interpreted by your RTOS.
+             *                     If 0, the new thread inherits the affinity of its creator (the default).
              * @param name     The name of the Thread. May be used by your OS to identify the thread.
              *                 the thread's own virtual functions are executed.
              */
@@ -223,7 +224,7 @@ namespace RTT
 
             /**
              * Set cpu affinity for this thread
-             * @cpu_affinity The cpu affinity of the thread (@see rtos_task_set_cpu_affinity).
+             * @param cpu_affinity The cpu affinity of the thread (@see rtos_task_set_cpu_affinity).
              * @return true if the mask has been applied
              */
             virtual bool setCpuAffinity(unsigned cpu_affinity);

--- a/rtt/os/Thread.hpp
+++ b/rtt/os/Thread.hpp
@@ -220,6 +220,7 @@ namespace RTT
             virtual int getPriority() const;
 
             virtual unsigned int getPid() const;
+
             /**
              * Set cpu affinity for this thread
              * @cpu_affinity The cpu affinity of the thread (@see rtos_task_set_cpu_affinity).

--- a/rtt/os/ThreadInterface.hpp
+++ b/rtt/os/ThreadInterface.hpp
@@ -190,6 +190,11 @@ namespace RTT
              */
             virtual unsigned int getPid() const = 0;
 
+            /**
+             * @return the cpu affinity
+             */
+            virtual unsigned getCpuAffinity() const = 0;
+
             virtual void setMaxOverrun(int m) = 0;
 
             virtual int getMaxOverrun() const = 0;

--- a/rtt/os/gnulinux/fosi_internal.cpp
+++ b/rtt/os/gnulinux/fosi_internal.cpp
@@ -178,7 +178,7 @@ namespace RTT
             }
         }
 
-        if ( cpu_affinity != (unsigned)~0 ) {
+        if ( cpu_affinity != 0 ) {
             log(Debug) << "Setting CPU affinity to " << cpu_affinity << endlog();
             int result = rtos_task_set_cpu_affinity(task, cpu_affinity);
             if (result != 0) {

--- a/rtt/os/xenomai/fosi_internal.cpp
+++ b/rtt/os/xenomai/fosi_internal.cpp
@@ -424,7 +424,7 @@ namespace RTT
 
         INTERNAL_QUAL unsigned rtos_task_get_cpu_affinity(const RTOS_TASK *task)
         {
-            return 0;
+            return ~0;
         }
 
         INTERNAL_QUAL const char* rtos_task_get_name(const RTOS_TASK* mytask) {

--- a/tests/taskthread_test.cpp
+++ b/tests/taskthread_test.cpp
@@ -205,6 +205,14 @@ BOOST_AUTO_TEST_CASE(testPeriodic )
         }
     }
 
+    // Different CPU affinity
+    unsigned cpu_affinity = 1; // first CPU only
+    if ( mtask.thread()->getCpuAffinity() != cpu_affinity ) {
+        PeriodicActivity m4task(ORO_SCHED_OTHER, 15, 0.01, cpu_affinity);
+        BOOST_CHECK( mtask.thread() != m4task.thread() );
+        BOOST_CHECK_EQUAL( cpu_affinity, m4task.thread()->getCpuAffinity() );
+    }
+
     // Starting thread if thread not running
     BOOST_CHECK( mtask.thread()->stop() );
     BOOST_CHECK( mtask.thread()->isRunning() == false );


### PR DESCRIPTION
Unfortunately there is a regression bug in https://github.com/orocos-toolchain/rtt/pull/205 which has been merged into master.

The CPU affinity comparison in `RTT::TimerThread::Instance()` added in 2cfecd7 was not taking into account which CPUs are actually available and therefore created a new timer thread in almost all cases on target gnulinux. This patch makes `getCpuAffinity()` also available for `RTT::os::MainThread` and uses the main thread's CPU affinity as a default value for TimerThread instances.

If no specific CPU affinity was given in the Thread or Activity constructor, the `cpu_affinity` argument has a default value of 0. The gnulinux implementation of `rtos_task_create()` forwarded this value to `rtos_task_set_cpu_affinity()` which resets the affinity attributes to all CPUs in this case. On the other hand,  if `cpu_affinity` set by the user is `~0`, the call to rtos_task_set_cpu_affinity() was skipped and the new threads inherits the affinity of its creator, the default behavior of `pthread_create()`.

This patch basically swaps these two cases, so that new threads inherit the affinity of their parent (typically the main thread) and the affinity is only overwritten in case the user sets it explicitly. If the `cpu_affinity` argument is `~0`, the affinity will be reset to all available CPUs, disregarding the flags of the parent.

This might even be considered as a bug fix, looking at the test case in [tasks_test.cpp:376](https://github.com/meyerj/rtt/blob/f65d958ea07691525d0dd48ef6f3366bde9612a6/tests/tasks_test.cpp#L376).

@snrkiwi 