### PR TITLE
Fix/create properly OrbRunner activity

### DIFF
--- a/rtt/transports/corba/TaskContextServer.cpp
+++ b/rtt/transports/corba/TaskContextServer.cpp
@@ -339,7 +339,7 @@ namespace RTT
     {
     public:
         OrbRunner(int scheduler, int priority, unsigned cpu_affinity)
-            : Activity(scheduler, priority, cpu_affinity)
+            : Activity(scheduler, priority, 0.0, cpu_affinity, 0, "OrbRunner")
         {}
         void loop()
         {

--- a/rtt/transports/corba/TaskContextServer.cpp
+++ b/rtt/transports/corba/TaskContextServer.cpp
@@ -339,7 +339,7 @@ namespace RTT
     {
     public:
         OrbRunner(int scheduler, int priority, unsigned cpu_affinity)
-            : Activity(scheduler, priority, 0.0, cpu_affinity, 0, "OrbRunner")
+            : Activity(scheduler, priority, 0.0, cpu_affinity, 0, "RTT::OrbRunner")
         {}
         void loop()
         {


### PR DESCRIPTION
In [TaskContextServer.cpp#L342](https://github.com/orocos-toolchain/rtt/blob/toolchain-2.9/rtt/transports/corba/TaskContextServer.cpp#L342) the `cpu_affinity` is passed as third argument and this way the compiler chooses to use the constructor in [Activity.hpp#L141](https://github.com/orocos-toolchain/rtt/blob/toolchain-2.9/rtt/Activity.hpp#L141) where the third argument is the period (double).

This PR proposes also a naming convention for the Threads created by RTT itself.
For the moment the new naming convention is used only for the OrbRunner Thread.

@meyerj PTAL

PS
If preferred I could rebase the PR on master.