### PR TITLE
rtt: fix null ptr exception in RTT::TaskContext::setActivity

### DIFF
--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -344,22 +344,25 @@ namespace RTT
     {
         if (this->isRunning())
             return false;
-        if ( new_act == 0) {
+        if (!new_act) {
 #if defined(ORO_ACT_DEFAULT_SEQUENTIAL)
             new_act = new SequentialActivity();
 #elif defined(ORO_ACT_DEFAULT_ACTIVITY)
             new_act = new Activity();
-#else
-            return false;
 #endif
+        } else {
+            new_act->stop();
         }
-        new_act->stop();
-        if(our_act){
+        if (our_act) {
             our_act->stop();
         }
-        new_act->run( this->engine() );
-        our_act = ActivityInterface::shared_ptr( new_act );
-        our_act->start();
+        if (new_act) {
+            new_act->run( this->engine() );
+            our_act = ActivityInterface::shared_ptr( new_act );
+            our_act->start();
+        } else {
+            our_act.reset();
+        }
         return true;
     }
 

--- a/rtt/TaskContext.cpp
+++ b/rtt/TaskContext.cpp
@@ -349,6 +349,8 @@ namespace RTT
             new_act = new SequentialActivity();
 #elif defined(ORO_ACT_DEFAULT_ACTIVITY)
             new_act = new Activity();
+#else
+            return false;
 #endif
         }
         new_act->stop();
@@ -460,4 +462,3 @@ namespace RTT
         }
     }
 }
-


### PR DESCRIPTION
Fix null pointer exception that was generated only if the following conditions were met:
- `ORO_ACT_DEFAULT_SEQUENTIAL` not defined
- `ORO_ACT_DEFAULT_ACTIVITY` not defined
- `new_act == 0`

@meyerj PTAL