### PR TITLE
cmake: unset found and missing components list after each invocation of the RTT cmake config

### DIFF
--- a/orocos-rtt-config.cmake
+++ b/orocos-rtt-config.cmake
@@ -53,8 +53,8 @@
 # variables is recommended.
 #
 # Example usage:
-#  find_package(OROCOS-RTT 2.0.5 EXACT REQUIRED rtt-scripting foo) # Defines OROCOS-RTT_RTT-SCRIPTING_*
-#  find_package(OROCOS-RTT QUIET COMPONENTS rtt-transport-mqueue foo) # Defines OROCOS-RTT_RTT-TRANSPORT-MQUEUE_*
+#  find_package(OROCOS-RTT 2.0.5 EXACT REQUIRED rtt-scripting) # Defines OROCOS-RTT_RTT-SCRIPTING_*
+#  find_package(OROCOS-RTT QUIET COMPONENTS rtt-transport-mqueue) # Defines OROCOS-RTT_RTT-TRANSPORT-MQUEUE_*
 #
 ########################################################################################################################
 
@@ -159,19 +159,6 @@ set(OROCOS-RTT_DEFINITIONS "-DOROCOS_TARGET=${OROCOS_TARGET}")
 set(OROCOS-RTT_USE_FILE_PATH ${SELF_DIR})
 set(OROCOS-RTT_USE_FILE ${SELF_DIR}/UseOROCOS-RTT.cmake)
 
-# Confirm found, not cached !
-message(STATUS "Orocos-RTT found in ${OROCOS-RTT_IMPORT_FILE}")
-set(OROCOS-RTT_FOUND TRUE)
-
-endif()
-
-
-########################################################################################################################
-#
-# Components: This is called each time a find_package is done:
-#
-########################################################################################################################
-
 # Default component search path
 list(APPEND OROCOS-RTT_PLUGIN_PATH "${OROCOS-RTT_PLUGINS_PATH}"
                                       "${OROCOS-RTT_TYPES_PATH}")
@@ -186,6 +173,19 @@ endforeach()
 foreach(CUSTOM_COMPONENT_PATH ${ENV_RTT_COMPONENT_PATH})
   list(APPEND OROCOS-RTT_COMPONENT_PATH "${CUSTOM_COMPONENT_PATH}")
 endforeach()
+
+# Confirm found, not cached !
+message(STATUS "Orocos-RTT found in ${OROCOS-RTT_IMPORT_FILE}")
+set(OROCOS-RTT_FOUND TRUE)
+
+endif()
+
+
+########################################################################################################################
+#
+# Components: This is called each time a find_package is done:
+#
+########################################################################################################################
 
 # Find components
 foreach(COMPONENT ${OROCOS-RTT_FIND_COMPONENTS} ${Orocos-RTT_FIND_COMPONENTS})
@@ -240,3 +240,9 @@ if(NOT OROCOS-RTT_FIND_QUIETLY AND NOT Orocos-RTT_FIND_QUIETLY)
     message(STATUS "- Could NOT find requested orocos-rtt components:${MISSING_COMPONENTS}")
   endif()
 endif()
+
+# Reset temporary variables to not mess up with later invocations
+unset(FOUND_TRANSPORTS)
+unset(AVAILABLE_TRANSPORTS)
+unset(FOUND_COMPONENTS)
+unset(MISSING_COMPONENTS)


### PR DESCRIPTION
If the RTT cmake module is used more than once with different components and the `REQUIRED` argument was not given during the first invocation, a second invocation with `REQUIRED` might trigger false errors because of items added to `MISSING_COMPONENTS` earlier.

Example:
```cmake
find_package(Orocos-RTT COMPONENTS non-existent-plugin)      # not available
if(OROCOS-RTT_NON-EXISTENT-PLUGIN_FOUND)
  # ...
endif()

# ...
find_package(Orocos-RTT REQUIRED COMPONENTS rtt-scripting)   # I really need scripting!
```
prints
```cmake
-- - Detected OROCOS_TARGET environment variable. Using: gnulinux
-- Orocos-RTT found in /opt/orocos/kinetic/install_debug/lib/cmake/orocos-rtt/orocos-rtt-gnulinux-libraries.cmake
-- Found orocos-rtt  for the gnulinux target. Available transports: corba mqueue
-- - Detected OROCOS_TARGET environment variable. Using: gnulinux
-- Found orocos-rtt  for the gnulinux target. Available transports: corba mqueue
-- - Could NOT find requested orocos-rtt components: non-existent-plugin
-- - Detected OROCOS_TARGET environment variable. Using: gnulinux
CMake Error at /opt/orocos/kinetic/install_debug/lib/cmake/orocos-rtt/orocos-rtt-config.cmake:215 (message):
  Could not find the following required OROCOS-RTT plugins:
  non-existent-plugin.  You may want to append the plugins folder location to
  the RTT_COMPONENT_PATH environment variable.  E.g., if the plugin is
  located at /path/to/plugins/libfoo-plugin.so, add /path/to to
  RTT_COMPONENT_PATH
Call Stack (most recent call first):
  CMakeLists.txt:7 (find_package)


-- Configuring incomplete, errors occurred!
See also "/opt/orocos/kinetic/src/orocos_toolchain/rtt_cmake_test/CMakeFiles/CMakeOutput.log".
```
while with this patch the result is
```cmake
-- - Detected OROCOS_TARGET environment variable. Using: gnulinux
-- Orocos-RTT found in /opt/orocos/kinetic/install_debug/lib/cmake/orocos-rtt/orocos-rtt-gnulinux-libraries.cmake
-- Found orocos-rtt  for the gnulinux target. Available transports: corba mqueue
-- - Could NOT find requested orocos-rtt components: non-existent-plugin
-- - Detected OROCOS_TARGET environment variable. Using: gnulinux
-- Found orocos-rtt  for the gnulinux target. 
-- - Found requested orocos-rtt components: rtt-scripting
-- Configuring done
-- Generating done
-- Build files have been written to: /opt/orocos/kinetic/src/orocos_toolchain/rtt_cmake_test
```

Also moved initialization of `OROCOS-RTT_PLUGIN_PATH` to the `if(NOT OROCOS-RTT_FOUND)` section to not re-add the same directories over and over again.
