### PR TITLE
[DO NOT MERGE] RFC: corba: allow selecting dispatchers per-channel

### DIFF
--- a/rtt/transports/corba/CorbaDispatcher.cpp
+++ b/rtt/transports/corba/CorbaDispatcher.cpp
@@ -37,12 +37,125 @@
 
 
 #include "CorbaDispatcher.hpp"
+#include <boost/lexical_cast.hpp>
 
-namespace RTT {
-    using namespace corba;
-    CorbaDispatcher::DispatchMap CorbaDispatcher::DispatchI;
-    RTT_CORBA_API os::Mutex* CorbaDispatcher::mlock = 0;
+using namespace RTT;
+using namespace RTT::corba;
 
-    int CorbaDispatcher::defaultScheduler = ORO_SCHED_RT;
-    int CorbaDispatcher::defaultPriority  = os::LowestPriority;
+CorbaDispatcher::DispatchMap CorbaDispatcher::DispatchI;
+RTT_CORBA_API os::Mutex* CorbaDispatcher::mlock = 0;
+
+int CorbaDispatcher::defaultScheduler = ORO_SCHED_RT;
+int CorbaDispatcher::defaultPriority  = os::LowestPriority;
+
+CorbaDispatcher::DispatchEntry& CorbaDispatcher::Get(std::string const& name, int scheduler, int priority)
+{
+    DispatchMap::iterator result = DispatchI.find(name);
+    if ( result != DispatchI.end() )
+        return result->second;
+
+    CorbaDispatcher* dispatcher = new CorbaDispatcher( name, scheduler, priority );
+    dispatcher->start();
+    return (DispatchI[name] = DispatchEntry(dispatcher));
+}
+
+CorbaDispatcher* CorbaDispatcher::Instance(DataFlowInterface* iface, int scheduler, int priority) {
+    return Instance(defaultDispatcherName(iface), scheduler, priority);
+}
+
+std::string CorbaDispatcher::defaultDispatcherName(DataFlowInterface* iface)
+{
+    std::string name;
+    if ( iface == 0 || iface->getOwner() == 0)
+        name = "Global";
+    else
+        name = iface->getOwner()->getName();
+    return name + ".CorbaDispatch." + boost::lexical_cast<std::string>(reinterpret_cast<uint64_t>(iface));
+}
+
+/**
+ * Create a new dispatcher and registers it under a certain name
+ *
+ * @param name the dispatcher registration name
+ * @return
+ */
+CorbaDispatcher* CorbaDispatcher::Instance(std::string const& name, int scheduler, int priority) {
+    if (!mlock) mlock = new os::Mutex();
+    os::MutexLock lock(*mlock);
+
+    return Get(name, scheduler, priority).dispatcher;
+}
+
+CorbaDispatcher* CorbaDispatcher::Acquire(RTT::DataFlowInterface* interface, int scheduler, int priority) {
+    return Acquire(defaultDispatcherName(interface), scheduler, priority);
+}
+
+CorbaDispatcher* CorbaDispatcher::Acquire(std::string const& name, int scheduler, int priority) {
+    if (!mlock) mlock = new os::Mutex();
+    os::MutexLock lock(*mlock);
+
+    DispatchEntry& entry = Get(name, scheduler, priority);
+    entry.refcount.inc();
+    return entry.dispatcher;
+}
+
+void CorbaDispatcher::Release(CorbaDispatcher* dispatcher) {
+    return Release(dispatcher->getName());
+}
+
+void CorbaDispatcher::Release(std::string const& name) {
+    if (!mlock) return;
+    os::MutexLock lock(*mlock);
+
+    DispatchMap::iterator result = DispatchI.find(name);
+    if ( result != DispatchI.end() ) {
+        if (result->second.refcount.dec_and_test())
+        {
+            delete result->second.dispatcher;
+            DispatchI.erase(result);
+        }
+    }
+    if ( DispatchI.empty() )
+    {
+        delete mlock;
+        mlock = 0;
+    }
+}
+
+void CorbaDispatcher::hasElement(base::ChannelElementBase::shared_ptr c0, base::ChannelElementBase::shared_ptr c1, bool& result)
+{
+    result = result || (c0 == c1);
+}
+
+void CorbaDispatcher::dispatchChannel( base::ChannelElementBase::shared_ptr chan ) {
+    bool has_element = false;
+    RClist.apply(boost::bind(&CorbaDispatcher::hasElement, _1, chan, boost::ref(has_element)));
+    if (!has_element)
+        RClist.append( chan );
+    this->trigger();
+}
+
+void CorbaDispatcher::cancelChannel( base::ChannelElementBase::shared_ptr chan ) {
+    RClist.erase( chan );
+}
+
+bool CorbaDispatcher::initialize() {
+    log(Info) <<"Started " << this->getName() << "." <<endlog();
+    do_exit = false;
+    return true;
+}
+
+void CorbaDispatcher::loop() {
+    while ( !RClist.empty() && !do_exit) {
+        base::ChannelElementBase::shared_ptr chan = RClist.front();
+        CRemoteChannelElement_i* rbase = dynamic_cast<CRemoteChannelElement_i*>(chan.get());
+        if (rbase)
+            rbase->transferSamples();
+        RClist.erase( chan );
+    }
+}
+
+bool CorbaDispatcher::breakLoop() {
+    do_exit = true;
+    return true;
 }

--- a/rtt/transports/corba/CorbaDispatcher.cpp
+++ b/rtt/transports/corba/CorbaDispatcher.cpp
@@ -115,11 +115,6 @@ void CorbaDispatcher::Release(std::string const& name) {
             DispatchI.erase(result);
         }
     }
-    if ( DispatchI.empty() )
-    {
-        delete mlock;
-        mlock = 0;
-    }
 }
 
 void CorbaDispatcher::hasElement(base::ChannelElementBase::shared_ptr c0, base::ChannelElementBase::shared_ptr c1, bool& result)

--- a/rtt/transports/corba/CorbaLib.cpp
+++ b/rtt/transports/corba/CorbaLib.cpp
@@ -115,7 +115,13 @@ namespace RTT {
 
             virtual base::ChannelElementBase* buildDataStorage(ConnPolicy const& policy) const { return 0; }
 
-            virtual CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface*, ::PortableServer::POA* poa, bool) const {
+            virtual CRemoteChannelElement_i* createOutputChannelElement_i(std::string const&, ::PortableServer::POA* poa, bool) const {
+                Logger::In in("CorbaFallBackProtocol");
+                log(Error) << "Could create Channel : data type not known to CORBA Transport." <<Logger::endl;
+                return 0;
+
+            }
+            virtual CRemoteChannelElement_i* createInputChannelElement_i(::PortableServer::POA* poa, bool) const {
                 Logger::In in("CorbaFallBackProtocol");
                 log(Error) << "Could create Channel : data type not known to CORBA Transport." <<Logger::endl;
                 return 0;

--- a/rtt/transports/corba/CorbaTemplateProtocol.hpp
+++ b/rtt/transports/corba/CorbaTemplateProtocol.hpp
@@ -69,8 +69,11 @@ namespace RTT
            */
           typedef typename Property<T>::DataSourceType PropertyType;
 
-          CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface* sender,PortableServer::POA_ptr poa, bool is_pull) const
-          { return new RemoteChannelElement<T>(*this, sender, poa, is_pull); }
+          CRemoteChannelElement_i* createOutputChannelElement_i(std::string const& dispatcherName,PortableServer::POA_ptr poa, bool is_pull) const
+          { return new RemoteChannelElement<T>(dispatcherName, *this, poa, is_pull); }
+
+          CRemoteChannelElement_i* createInputChannelElement_i(PortableServer::POA_ptr poa, bool is_pull) const
+          { return new RemoteChannelElement<T>(*this, poa, is_pull); }
 
           /**
            * Create an transportable object for a \a protocol which contains the value of \a source.

--- a/rtt/transports/corba/CorbaTypeTransporter.hpp
+++ b/rtt/transports/corba/CorbaTypeTransporter.hpp
@@ -83,7 +83,15 @@ namespace RTT {
 	     * @param poa The POA to manage the server code.
 	     * @return the created CChannelElement_i.
 	     */
-	    virtual CRemoteChannelElement_i* createChannelElement_i(DataFlowInterface* sender, ::PortableServer::POA* poa, bool is_pull) const = 0;
+	    virtual CRemoteChannelElement_i* createOutputChannelElement_i(std::string const& dispatcherName, ::PortableServer::POA* poa, bool is_pull) const = 0;
+
+	    /**
+	     * Builds a channel element for remote transport in both directions.
+	     * @param sender The data flow interface which will be sending or receiving this channel.
+	     * @param poa The POA to manage the server code.
+	     * @return the created CChannelElement_i.
+	     */
+	    virtual CRemoteChannelElement_i* createInputChannelElement_i(::PortableServer::POA* poa, bool is_pull) const = 0;
 
 	    /**
 	     * The CORBA transport does not support creating 'CORBA' streams.

--- a/rtt/transports/corba/DataFlowI.h
+++ b/rtt/transports/corba/DataFlowI.h
@@ -191,6 +191,9 @@ namespace RTT {
             	      ,::RTT::corba::CNoSuchPortException
             	    ));
 
+            static std::string dispatcherNameFromPolicy(
+                    RTT::DataFlowInterface* interface,
+                    RTT::ConnPolicy const& policy);
             CChannelElement_ptr buildChannelOutput(const char* reader_port, RTT::corba::CConnPolicy& policy) ACE_THROW_SPEC ((
             	      CORBA::SystemException
             	      ,::RTT::corba::CNoCorbaTransport

--- a/rtt/transports/corba/RemotePorts.cpp
+++ b/rtt/transports/corba/RemotePorts.cpp
@@ -142,9 +142,11 @@ RTT::base::ChannelElementBase::shared_ptr RemoteInputPort::buildRemoteChannelOut
 
     // Input side is now ok and waiting for us to complete. We build our corba channel element too
     // and connect it to the remote side and vice versa.
+
+    std::string dispatcherName = CDataFlowInterface_i::dispatcherNameFromPolicy(output_port.getInterface(), policy);
     CRemoteChannelElement_i*  local =
         static_cast<CorbaTypeTransporter*>(type->getProtocol(ORO_CORBA_PROTOCOL_ID))
-                            ->createChannelElement_i(output_port.getInterface(), mpoa, policy.pull);
+                            ->createOutputChannelElement_i(dispatcherName, mpoa, policy.pull);
 
     CRemoteChannelElement_var proxy = local->_this();
     local->setRemoteSide(remote);

--- a/tests/test-runner-corba.cpp
+++ b/tests/test-runner-corba.cpp
@@ -102,7 +102,6 @@ public:
             init_unit_test_suite(framework::master_test_suite().argc,framework::master_test_suite().argv);
 	}
 	~InitOrocos(){
-	    corba::CorbaDispatcher::ReleaseAll();
 	    corba::TaskContextServer::ShutdownOrb(true);
 	    corba::TaskContextServer::DestroyOrb();
 


### PR DESCRIPTION
This PR implements the main idea I had for a while on how to separate communication domains under the CORBA transport.

By default, the policy is the same than the one being used now: there's one dispatcher per task context. However, one can set a policy's name_id to pick a different dispatcher, possibly sharing dispatchers between tasks (how dispatchers are allocated becomes a system builder's concern).