### PR TITLE
Fix some compiler warnings in the CORBA plugin

### DIFF
--- a/rtt/transports/corba/RTTCorbaConversion.hpp
+++ b/rtt/transports/corba/RTTCorbaConversion.hpp
@@ -247,14 +247,12 @@ namespace RTT {
 
       /**
       * Use for the conversion from a stl container to a sequence<string>
+      *
+      * Note: T needs to have reference semantics, but we cannot explicitly use a reference argument
+      * because it would break TAO. See https://github.com/orocos-toolchain/rtt/commit/7cd62561b72467a9dd79757ae22714931d0fa1c9.
       */
-      template<class dummy>
-      static bool toCorbaType(dummy dest, const StdType& src) {
-        dest = src.c_str();
-        return true;
-      }
-
-      static bool toCorbaType(CorbaType dest, const StdType& src) {
+      template<class T>
+      static bool toCorbaType(T dest, const StdType& src) {
         dest = src.c_str();
         return true;
       }

--- a/rtt/transports/corba/ServiceRequesterI.cpp
+++ b/rtt/transports/corba/ServiceRequesterI.cpp
@@ -162,7 +162,9 @@ char * RTT_corba_CServiceRequester_i::getRequestName (
         log(Error) << "No such OperationCaller: " << oname << " in "<< mservice->getRequestName()<<endlog();
         return false;
     }
-    if ( svc->getArity(oname.c_str()) == -1) {
+    try {
+        (void) svc->getArity(oname.c_str());
+    } catch( ::RTT::corba::CNoSuchNameException& ) {
         CORBA::String_var svcname = svc->getName();
         log(Error) << "No such Operation: " << oname << " in "<< svcname.in() << endlog();
         return false;


### PR DESCRIPTION
1. Compiler warning and uncaught exception in `CServiceRequester::connectCallerTo()`:
   `COperationInterface::getArity(name)` always returns an unsigned value and throws an exception if the operation with the given name does not exist.
   ```cpp
   ServiceRequesterI.cpp:164:39: warning: comparison is always false due to limited range of data type [-Wtype-limits]
   ```

2. unused-but-set-parameter warning in `AnyConversion<std::string>::toCorbaType()`
   This non-templated overload of the method is not different from the template method, so can be removed. Note that type `T` in the templated variant always needs to have reference semantics, which is the case when called from `AnyConversion<std::vector<std::string>>::toCorbaType()` in [CorbaConversion.hpp:237](https://github.com/meyerj/rtt/blob/efef0ad33e81ed220eaf2c52c39e8396e65fbb4f/rtt/transports/corba/CorbaConversion.hpp#L237).

   Fixed compiler warning:
   ```cpp
   RTTCorbaConversion.hpp:267:41: warning: parameter ‘dest’ set but not used [-Wunused-but-set-parameter]
   ```