### PR TITLE
Corba aliases: revert API changes and fixed ComponentLoader::unloadComponent() for aliased components

### DIFF
--- a/rtt/deployment/ComponentLoader.cpp
+++ b/rtt/deployment/ComponentLoader.cpp
@@ -596,7 +596,7 @@ bool ComponentLoader::reloadInProcess(string file, string libname)
                 for ( cit = comps.begin(); cit != comps.end(); ++cit) {
                     if( (*ctype) == cit->second.type ) {
                         // the type of an allocated component was loaded from this library. it might be unsafe to reload the library
-                        log(Info) << "can NOT reload library because of the instance " << cit->second.type  <<"::"<<cit->second.instance->getName()  <<endlog();
+                        log(Info) << "can NOT reload library because of the instance " << cit->second.type  <<"::"<<cit->first <<endlog();
                         can_unload = false;
                     }
                 }
@@ -764,17 +764,16 @@ RTT::TaskContext *ComponentLoader::loadComponent(const std::string & name, const
     return instance;
 }
 
-bool ComponentLoader::unloadComponent( RTT::TaskContext* tc, const std::string& name ) {
+bool ComponentLoader::unloadComponent( RTT::TaskContext* tc ) {
     if (!tc)
         return false;
-    CompList::iterator it;
-    if (name.empty())
-        it = comps.find( tc->getName() );
-    else
-        it = comps.find( name );
+    CompList::iterator it = comps.begin();
+    while ( it != comps.end() ) {
+        if ( it->second.instance == tc) break;
+    }
 
     if ( it != comps.end() ) {
-        delete tc;
+        delete it->second.instance;
         comps.erase(it);
         return true;
     }

--- a/rtt/deployment/ComponentLoader.hpp
+++ b/rtt/deployment/ComponentLoader.hpp
@@ -178,7 +178,7 @@ namespace RTT {
              * be used after this function returns true.
              * @return false if \a tc was not loaded by this ComponentLoader.
              */
-            bool unloadComponent( RTT::TaskContext* tc, std::string const& name="" );
+            bool unloadComponent( RTT::TaskContext* tc );
 
             /**
              * Lists all Component created by loadComponent().

--- a/rtt/transports/corba/TaskContextProxy.cpp
+++ b/rtt/transports/corba/TaskContextProxy.cpp
@@ -168,7 +168,7 @@ namespace RTT
 
         this->synchronize();
     }
-    
+
     TaskContextProxy::TaskContextProxy( ::RTT::corba::CTaskContext_ptr taskc)
         : TaskContext("CORBAProxy"), mtask( corba::CTaskContext::_duplicate(taskc) )
     {

--- a/rtt/transports/corba/TaskContextProxy.hpp
+++ b/rtt/transports/corba/TaskContextProxy.hpp
@@ -95,10 +95,10 @@ namespace RTT
         TaskContextProxy(std::string location, bool is_ior);
 
         /**
-         * A Private constructor which does nothing       
+         * A Private constructor which does nothing
          * */
         TaskContextProxy();
-        
+
         /**
          * Private constructor which creates a new connection to
          * a corba object
@@ -117,7 +117,7 @@ namespace RTT
          * initializes the class from a stringified ior or taskname in NameServer.
          * */
         void initFromURIOrTaskname(std::string location, bool is_ior);
-        
+
         void synchronize();
 
         mutable corba::CTaskContext_var mtask;


### PR DESCRIPTION
#66 introduced aliases for CORBA component servers and added an optional name argument to `ComponentLoader::unloadComponent(tc)` in bf92dcb3483f89ccb436502e1f74a04361e53c74. This change has been reverted, because it could lead to inconsistencies in the internal component map, if a TaskContext is destroyed based on the given name but with an unrelated instance pointer.

This concern has initially be brought up as a comment in https://github.com/orocos-toolchain/rtt/commit/bf92dcb3483f89ccb436502e1f74a04361e53c74.

The new approach should be safe as it does not rely on the name or alias of the instance to be unloaded at all.