### PR TITLE
Fix/add TypeInfo retrieval by alias name

### DIFF
--- a/rtt/types/TypeInfoRepository.cpp
+++ b/rtt/types/TypeInfoRepository.cpp
@@ -82,17 +82,32 @@ namespace RTT
     {
         MutexLock lock(type_lock);
         map_t::const_iterator i = data.find( name );
-        if ( i == data.end() ) {
-            // try alternate name replace / with dots:
-            string tkname = "/" + boost::replace_all_copy(boost::replace_all_copy(name, string("."), "/"), "<","</");
-            i = data.find( tkname );
-            if ( i == data.end())
-            {
-                return 0;
+        if ( i != data.end() ) {
+            // found
+            return i->second;
+        }
+
+        // try alternate name replace / with dots:
+        string tkname = "/" + boost::replace_all_copy(boost::replace_all_copy(name, string("."), "/"), "<","</");
+        i = data.find( tkname );
+        if ( i != data.end() ) {
+            // found
+            return i->second;
+        }
+
+        // try alias name
+        for (i = data.begin(); i != data.end(); ++i) {
+            std::vector< std::string > names = i->second->getTypeNames();
+            vector<std::string>::iterator j = names.begin();
+            for (; j != names.end(); ++j) {
+                if(((*j) == name) || ((*j) == tkname)) {
+                    return i->second;
+                }
             }
         }
-        // found
-        return i->second;
+
+        // not found
+        return 0;
     }
 
     TypeInfo* TypeInfoRepository::type( const std::string& name ) const

--- a/tests/types_test.cpp
+++ b/tests/types_test.cpp
@@ -137,6 +137,7 @@ BOOST_AUTO_TEST_CASE( testStringCapacity )
     BOOST_CHECK_EQUAL( copy.get(), str.get() );
 
 }
+
 BOOST_AUTO_TEST_CASE( testTypes )
 {
     Types()->addType( new StructTypeInfo<AType,false>("astruct"));
@@ -269,8 +270,24 @@ BOOST_AUTO_TEST_CASE( testTypes )
     // execute
     executePrograms(prog);
     executeStates(state);
+}
 
+BOOST_AUTO_TEST_CASE( testAliases )
+{
+    Types()->addType( new StructTypeInfo<AType,false>("astruct"));
+    Types()->addType( new StructTypeInfo<AType,false>("aalias1"));
+    Types()->type("astruct")->addAlias("aalias2");
 
+    BOOST_CHECK( Types()->type("astruct") != 0 );
+    BOOST_CHECK( Types()->type("aalias1") != 0 );
+    BOOST_CHECK( Types()->type("aalias2") != 0 );
+
+    BOOST_CHECK_EQUAL( Types()->type("astruct"), Types()->type("aalias1") );
+    BOOST_CHECK_EQUAL( Types()->type("astruct"), Types()->type("aalias2") );
+
+    BOOST_CHECK_EQUAL( "astruct", Types()->type("astruct")->getTypeNames()[0] );
+    BOOST_CHECK_EQUAL( "aalias1", Types()->type("astruct")->getTypeNames()[1] );
+    BOOST_CHECK_EQUAL( "aalias2", Types()->type("astruct")->getTypeNames()[2] );
 }
 
 BOOST_AUTO_TEST_CASE( testCharType )


### PR DESCRIPTION
The type name aliases registered in the TypeInfo are currently unused within RTT and OCL. This commit allows to lookup TypeInfo pointers via an alias, e.g. in Orocos scripting. Not sure what they have been used for before.

Cherry-picked, slightly modified and reopened from https://github.com/meyerj/rtt/pull/5.