### PR TITLE
Fix namespace of some definitions and exclude unrelated namespaces from API documentation

### DIFF
--- a/rtt/RTT.hpp
+++ b/rtt/RTT.hpp
@@ -58,11 +58,13 @@ namespace RTT {}
 #include "Attribute.hpp"
 #include "Port.hpp"
 
+#ifndef DOXYGEN
 namespace BFL {
 }
 
 namespace KDL {
 }
+#endif
 
 /**
  * The project wide Orocos namespace contains all user classes

--- a/rtt/internal/OperationCallerC.cpp
+++ b/rtt/internal/OperationCallerC.cpp
@@ -44,7 +44,9 @@
 #include "Exceptions.hpp"
 #include <vector>
 
-namespace RTT {
+namespace RTT
+{ namespace internal {
+
     using namespace detail;
 
 
@@ -278,4 +280,5 @@ namespace RTT {
 
     DataSourceBase::shared_ptr OperationCallerC::getCallDataSource() { return m; }
     DataSourceBase::shared_ptr OperationCallerC::getSendDataSource() { return s; }
-}
+
+}}

--- a/rtt/internal/SendHandleC.cpp
+++ b/rtt/internal/SendHandleC.cpp
@@ -44,7 +44,9 @@
 #include "Exceptions.hpp"
 #include <vector>
 
-namespace RTT {
+namespace RTT
+{ namespace internal {
+
     using namespace detail;
 
 
@@ -280,4 +282,5 @@ namespace RTT {
     DataSourceBase::shared_ptr SendHandleC::getSendHandleDataSource() { return e->s; }
 
     OperationInterfacePart* SendHandleC::getOrp() { return e->orp; }
-}
+
+}}

--- a/rtt/marsh/TinyDemarshaller.cpp
+++ b/rtt/marsh/TinyDemarshaller.cpp
@@ -363,58 +363,58 @@ namespace RTT
             return true;
             }
         };
-    }
 
-    using namespace detail;
+        using namespace detail;
 
-    class TinyDemarshaller::D {
-    public:
-        D(const std::string& f) : doc( f.c_str() ), loadOkay(false) {}
-        TiXmlDocument doc;
-        bool loadOkay;
-    };
+        class TinyDemarshaller::D {
+        public:
+            D(const std::string& f) : doc( f.c_str() ), loadOkay(false) {}
+            TiXmlDocument doc;
+            bool loadOkay;
+        };
 
-    TinyDemarshaller::TinyDemarshaller( const std::string& filename )
-        : d( new TinyDemarshaller::D(filename) )
-    {
-        Logger::In in("TinyDemarshaller");
-        d->loadOkay = d->doc.LoadFile();
+        TinyDemarshaller::TinyDemarshaller( const std::string& filename )
+            : d( new TinyDemarshaller::D(filename) )
+        {
+            Logger::In in("TinyDemarshaller");
+            d->loadOkay = d->doc.LoadFile();
 
-        if ( !d->loadOkay ) {
-            log(Error) << "Could not load " << filename << " Error: "<< d->doc.ErrorDesc() << endlog();
-            return;
+            if ( !d->loadOkay ) {
+                log(Error) << "Could not load " << filename << " Error: "<< d->doc.ErrorDesc() << endlog();
+                return;
+            }
+
+        }
+
+        TinyDemarshaller::~TinyDemarshaller()
+        {
+            delete d;
+        }
+
+        bool TinyDemarshaller::deserialize( PropertyBag &v )
+        {
+            Logger::In in("TinyDemarshaller");
+
+            if ( !d->loadOkay )
+                return false;
+
+            TiXmlHandle docHandle( &d->doc );
+            TiXmlHandle propHandle = docHandle.FirstChildElement( "properties" );
+
+            if ( ! propHandle.Node() ) {
+                log(Error) << "No <properties> element found in document!"<< endlog();
+                return false;
+            }
+
+            detail::Tiny2CPFHandler proc( v );
+
+            if ( proc.populateBag( propHandle.Node() ) == false) {
+                deleteProperties( v );
+                return false;
+            }
+            return true;
         }
 
     }
-
-    TinyDemarshaller::~TinyDemarshaller()
-    {
-        delete d;
-    }
-
-    bool TinyDemarshaller::deserialize( PropertyBag &v )
-    {
-        Logger::In in("TinyDemarshaller");
-
-        if ( !d->loadOkay )
-            return false;
-
-		TiXmlHandle docHandle( &d->doc );
-		TiXmlHandle propHandle = docHandle.FirstChildElement( "properties" );
-
-        if ( ! propHandle.Node() ) {
-            log(Error) << "No <properties> element found in document!"<< endlog();
-            return false;
-        }
-
-        detail::Tiny2CPFHandler proc( v );
-
-        if ( proc.populateBag( propHandle.Node() ) == false) {
-            deleteProperties( v );
-            return false;
-        }
-        return true;
-    }
-
 }
 

--- a/rtt/scripting/StatementProcessor.cpp
+++ b/rtt/scripting/StatementProcessor.cpp
@@ -53,7 +53,8 @@
 using namespace boost;
 
 namespace RTT
-{
+{ namespace scripting {
+
     using namespace detail;
     struct StatementProcessor::D
     {
@@ -260,5 +261,5 @@ namespace RTT
         return -1;
     }
 
-}
+}}
 

--- a/rtt/transports/corba/corba.h
+++ b/rtt/transports/corba/corba.h
@@ -58,9 +58,11 @@
 #else
 # include <omniORB4/CORBA.h>
 # include <omniORB4/poa.h>
+# ifndef DOXYGEN
 namespace CORBA {
     typedef Any* Any_ptr;
 }
+# endif
 # undef ACE_THROW_SPEC
 # define ACE_THROW_SPEC(x)
 # undef ACE_THROW


### PR DESCRIPTION
https://github.com/orocos-toolchain/rtt/commit/b6344416a45887f61af37061b29045e5a1d3cc3d revealed that some classes are implemented in the `RTT` namespace directly while they are defined in a nested namespace, like `RTT::marsh` or `RTT::internal`.

Foreign namespaces should be excluded from API documentation, like `boost::serialization` or `CORBA`.