### PR TITLE
tests: make taskstates_test more robust against slow execution

### DIFF
--- a/tests/taskstates_test.cpp
+++ b/tests/taskstates_test.cpp
@@ -655,7 +655,9 @@ BOOST_AUTO_TEST_CASE(calling_error_does_not_override_a_stop_transition)
     {
         calling_error_does_not_override_a_stop_transition_Task task;
         task.start();
-        usleep(100);
+        while(!task.inRunTimeError()) {
+            usleep(100);
+        }
         task.stop();
         BOOST_REQUIRE_EQUAL(RTT::TaskContext::Stopped, task.getTaskState());
         BOOST_REQUIRE_EQUAL(RTT::TaskContext::Stopped, task.getTargetState());
@@ -682,7 +684,9 @@ BOOST_AUTO_TEST_CASE(calling_recover_does_not_override_a_stop_transition)
     {
         calling_recover_does_not_override_a_stop_transition_Task task;
         task.start();
-        usleep(100);
+        while(!task.inRunTimeError()) {
+            usleep(100);
+        }
         task.stop();
         BOOST_REQUIRE_EQUAL(RTT::TaskContext::Stopped, task.getTaskState());
         BOOST_REQUIRE_EQUAL(RTT::TaskContext::Stopped, task.getTargetState());
@@ -715,7 +719,9 @@ BOOST_AUTO_TEST_CASE(testErrorHook_is_not_called_during_stop)
     {
         errorHook_is_not_called_after_an_exit_transition_Task task;
         task.start();
-        usleep(100);
+        while(!task.inRunTimeError()) {
+            usleep(100);
+        }
         task.stop();
         BOOST_REQUIRE(task.lastErrorHook < task.lastStopHook);
     }


### PR DESCRIPTION
...in order to fix build errors on Travis: https://travis-ci.org/orocos-toolchain/rtt/builds/301599579
New build was successful: https://travis-ci.org/orocos-toolchain/rtt/builds/301622937

These new test cases have been added in 5247e72d as part of https://github.com/orocos-toolchain/rtt/pull/182.