### PR TITLE
Fix setting the caller engine for RemoteOperationCaller instances

### DIFF
--- a/rtt/OperationCaller.hpp
+++ b/rtt/OperationCaller.hpp
@@ -393,7 +393,6 @@ namespace RTT
                 }
                 if (this->impl->ready()) {
                     log(Debug) << "Constructed OperationCaller from remote implementation '"<< mname<<"'."<< endlog();
-                    this->impl->setCaller(mcaller);
                 } else {
                     this->impl.reset(); // clean up.
                     log(Error) << "Tried to construct OperationCaller from incompatible operation '"<< mname<<"'."<< endlog();

--- a/rtt/Service.hpp
+++ b/rtt/Service.hpp
@@ -50,9 +50,6 @@
 
 #include "ConfigurationInterface.hpp"
 #include "Operation.hpp"
-#ifdef ORO_REMOTING
-#include "internal/RemoteOperationCaller.hpp"
-#endif
 #include <boost/shared_ptr.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/type_traits/function_traits.hpp>

--- a/rtt/base/OperationCallerInterface.hpp
+++ b/rtt/base/OperationCallerInterface.hpp
@@ -42,7 +42,7 @@ namespace RTT
              * @param ee The ExecutionEngine of the component that
              * owns this operation.
              */
-            void setOwner(ExecutionEngine* ee);
+            virtual void setOwner(ExecutionEngine* ee);
 
             /**
              * Sets the caller's engine of this operation.
@@ -51,7 +51,7 @@ namespace RTT
              * @param ee The ExecutionEngine of the component that
              * is calling this operation.
              */
-            void setCaller(ExecutionEngine* ee);
+            virtual void setCaller(ExecutionEngine* ee);
 
             /**
              * Sets the Thread execution policy of this object.

--- a/rtt/internal/DataSourceStorage.hpp
+++ b/rtt/internal/DataSourceStorage.hpp
@@ -82,15 +82,6 @@ namespace RTT
             void result() { return; }
         };
 
-        template<>
-        struct is_arg_return<DSRStore<void> > : public mpl::false_
-        {};
-
-        template<class T>
-        struct is_arg_return<DSRStore<T> > : public mpl::true_
-        {};
-
-
         //! Partial specialisations for storing a void, not a void or reference
         //! Wraps around RStore.
         template<class R>

--- a/rtt/internal/DataSourceStorage.hpp
+++ b/rtt/internal/DataSourceStorage.hpp
@@ -82,6 +82,15 @@ namespace RTT
             void result() { return; }
         };
 
+        template<>
+        struct is_arg_return<DSRStore<void> > : public mpl::false_
+        {};
+
+        template<class T>
+        struct is_arg_return<DSRStore<T> > : public mpl::true_
+        {};
+
+
         //! Partial specialisations for storing a void, not a void or reference
         //! Wraps around RStore.
         template<class R>

--- a/rtt/internal/OperationCallerC.cpp
+++ b/rtt/internal/OperationCallerC.cpp
@@ -120,12 +120,12 @@ namespace RTT {
     };
 
     OperationCallerC::OperationCallerC()
-        : d(0), m()
+        : d(0), ofp(0)
     {
     }
 
     OperationCallerC::OperationCallerC(OperationInterfacePart* mr, const std::string& name, ExecutionEngine* caller)
-        : d( mr ? new D( mr, name, caller) : 0 ), m(), ofp(mr), mname(name)
+        : d( mr ? new D( mr, name, caller) : 0 ), ofp(mr), mname(name)
     {
         if ( d && d->m ) {
             this->m = d->m;
@@ -139,8 +139,18 @@ namespace RTT {
     }
 
     OperationCallerC::OperationCallerC(const OperationCallerC& other)
-        : d( other.d ? new D(*other.d) : 0 ), m( other.m ? other.m : 0), ofp(other.ofp), mname(other.mname)
+        : d( other.d ? new D(*other.d) : 0 ), m( other.m ? other.m : 0), s( other.s ? other.s : 0), ofp(other.ofp), mname(other.mname)
     {
+    }
+
+    OperationCallerC::OperationCallerC(const OperationCallerC& other, ExecutionEngine* caller)
+        : d( other.d ? new D(*other.d) : 0 ), ofp(other.ofp), mname(other.mname)
+    {
+        if ( d ) {
+            d->caller = caller;
+        } else {
+            d = new D(other.ofp, other.mname, caller);
+        }
     }
 
     OperationCallerC& OperationCallerC::operator=(const OperationCallerC& other)
@@ -207,7 +217,6 @@ namespace RTT {
         }
         return *this;
     }
-
 
     bool OperationCallerC::call() {
         if (m)

--- a/rtt/internal/OperationCallerC.hpp
+++ b/rtt/internal/OperationCallerC.hpp
@@ -84,6 +84,11 @@ namespace RTT
         OperationCallerC(const OperationCallerC& other);
 
         /**
+         * A OperationCallerC is copyable by value, with assignment of a new caller.
+         */
+        OperationCallerC(const OperationCallerC& other, ExecutionEngine* caller);
+
+        /**
          * A OperationCallerC is assignable.
          */
         OperationCallerC& operator=(const OperationCallerC& other);

--- a/rtt/internal/RemoteOperationCaller.hpp
+++ b/rtt/internal/RemoteOperationCaller.hpp
@@ -410,10 +410,12 @@ namespace RTT
             /**
              * Create a RemoteOperationCaller object which executes a remote method
              *
+             * @param of The OperationFactory for methods.
              * @param name The name of this method.
-             * @param com The OperationFactory for methods.
+             * @param caller The caller's engine of this operation. Will be reset if this RemoteOperationCaller is
+             *               assigned to an OperationCaller.
              */
-            RemoteOperationCaller(OperationInterfacePart* of, std::string name, ExecutionEngine* caller)
+            RemoteOperationCaller(OperationInterfacePart* of, std::string name, ExecutionEngine* caller = 0)
             {
                 // create the method.
                 this->mmeth = OperationCallerC(of, name, caller);
@@ -432,6 +434,14 @@ namespace RTT
 
             virtual bool ready() const {
                 return this->mmeth.ready();
+            }
+
+            virtual void setCaller(ExecutionEngine* caller) {
+                // re-create the method.
+                this->mmeth = OperationCallerC(this->mmeth, caller);
+                // add the arguments to the method.
+                this->sendargs.initArgs( this->mmeth );
+                this->sendargs.initRet(  this->mmeth );
             }
 
             virtual base::OperationCallerBase<OperationCallerT>* cloneI(ExecutionEngine* caller) const {

--- a/rtt/internal/RemoteOperationCaller.hpp
+++ b/rtt/internal/RemoteOperationCaller.hpp
@@ -422,6 +422,7 @@ namespace RTT
                 // add the arguments to the method.
                 this->sendargs.initArgs( this->mmeth );
                 this->sendargs.initRet(  this->mmeth );
+                this->base::OperationCallerInterface::setCaller(caller);
             }
 
             RemoteOperationCaller(const SendHandleC& sh )
@@ -442,6 +443,7 @@ namespace RTT
                 // add the arguments to the method.
                 this->sendargs.initArgs( this->mmeth );
                 this->sendargs.initRet(  this->mmeth );
+                this->base::OperationCallerInterface::setCaller(caller);
             }
 
             virtual base::OperationCallerBase<OperationCallerT>* cloneI(ExecutionEngine* caller) const {

--- a/tests/operations_fixture.hpp
+++ b/tests/operations_fixture.hpp
@@ -59,6 +59,11 @@ public:
     double m6(int i, double d, bool c, std::string s, float f, char h) { if ( i == 1 && d == 2.0 && c == true && s == "hello" && f == 5.0f && h == 'a') return -7.0; else return 7.0;  }
     double m7(int i, double d, bool c, std::string s, float f, char h, unsigned int st) { if ( i == 1 && d == 2.0 && c == true && s == "hello" && f == 5.0f && h == 'a' && st == 7) return -8.0; else return 8.0;  }
 
+    void *returnAddressOf(int &i) { return &i; }
+    const void *returnAddressOfConst(const int &i) { return &i; }
+
+    int sleepAndIncrement(int seconds) { sleep(seconds); return ++i; }
+
     //exception tests:
     void m0except(void) { throw std::runtime_error("exception"); }
 

--- a/tests/operations_fixture1.cpp
+++ b/tests/operations_fixture1.cpp
@@ -46,4 +46,9 @@ void OperationsFixture::createOperationCallerFactories1(TaskContext* target)
     to->addOperation("o1cr", &OperationsFixture::m1cr, this, OwnThread).doc("M1cr");
 
     to->addOperation("o1", &OperationsFixture::m1, this, OwnThread).doc("M1").arg("a", "ad");
+
+    // Extra operations for RemoteOperationCaller tests
+    to->addOperation("returnAddressOf", &OperationsFixture::returnAddressOf, this);
+    to->addOperation("returnAddressOfConst", &OperationsFixture::returnAddressOfConst, this);
+    to->addOperation("sleepAndIncOwnThread", &OperationsFixture::sleepAndIncrement, this, RTT::OwnThread);
 }


### PR DESCRIPTION
This bugfix affects all OperationCallers where the signature does not exactly match the operation's signature. In this case `RTT::OperationCaller<Signature>` falls back to an `RemoteOperationCaller<Signature>` implementation, which is able to adapt argument or return types if the exact types or qualifiers do not match.

Without this patch it was not possible to set the caller engine of such an operation caller after the initial construction because it did not reimplement the [OperationCallerInterface::setCaller()](https://orocos-toolchain.github.io/rtt/master/api/html/structRTT_1_1base_1_1OperationCallerInterface.html#adb68aecd6596ce7e6760dd5e3da999e2) method, but stored the original caller inside the `OperationCallerC` instance stored in the `mmeth` member variable. As a consequence setting the caller after construction had no effect and could trigger the "You forgot to use setCaller()!" assertion ([LocalOperationCaller::checkCaller()](https://github.com/orocos-toolchain/rtt/blob/toolchain-2.9/rtt/internal/LocalOperationCaller.hpp#L284)) in 2.9 or break callbacks in earlier versions of RTT.

The new unit tests are not directly related, but verify that operations called via a `RemoteOperationCaller` are not called too often, which was observed in an application using toolchain-2.8, and that operations and operation callers with reference arguments preserve the address of their arguments. The latter can be dangerous in case of operations sent to another thread and I am not sure if people are aware of this potential problem or if this is documented somewhere. Maybe it would be better to adapt the signature when creating `RTT::Operation<Signature>` instances from function pointers implicitly, e.g. in [RTT::TaskContext::addOperation(const std::string name, Signature *func, ExecutionThread et)](https://orocos-toolchain.github.io/rtt/master/api/html/classRTT_1_1TaskContext.html#ab20c2fe74dd0691f7c07e72948738c8f) to not run into thread-safety problems if `Signature` contains reference arguments?