### PR TITLE
os: Change thread name compaction algorithm to produce more readable results

### DIFF
--- a/rtt/os/gnulinux/fosi_internal.cpp
+++ b/rtt/os/gnulinux/fosi_internal.cpp
@@ -167,12 +167,23 @@ namespace RTT
             // trim the name to fit 16 bytes restriction (including terminating
             // \0 character) of pthread_setname_np
             static const int MAX_THREAD_NAME_SIZE = 15;
+            char n[MAX_THREAD_NAME_SIZE + 1];
             const char *thread_name = task->name;
-            std::size_t thread_name_len = strlen(thread_name);
+            const std::size_t thread_name_len = strlen(thread_name);
             if (thread_name_len > MAX_THREAD_NAME_SIZE) {
-                thread_name += thread_name_len - MAX_THREAD_NAME_SIZE;
+                // result = first 7 chars + "~" + last 7 chars
+                strncpy(&n[0], thread_name, 7);
+                n[7] = '~';
+                strncpy(&n[8], &thread_name[thread_name_len - 7], 7);
+                // terminate below
             }
-            int result = pthread_setname_np(task->thread, thread_name);
+            else
+            {
+                // result = thread_name
+                strncpy(&n[0], thread_name, MAX_THREAD_NAME_SIZE);
+            }
+            n[MAX_THREAD_NAME_SIZE] = '\0'; // explicitly terminate
+            int result = pthread_setname_np(task->thread, &n[0]);
             if (result != 0) {
                 log(Warning) << "Failed to set thread name for " << task->name << ": "
                              << strerror(result) << endlog();

--- a/tests/tasks_test.cpp
+++ b/tests/tasks_test.cpp
@@ -542,13 +542,21 @@ BOOST_AUTO_TEST_CASE( testAllocation )
 BOOST_AUTO_TEST_SUITE_END()
 
 #if defined( OROCOS_TARGET_GNULINUX ) && defined( ORO_HAVE_PTHREAD_SETNAME_NP )
-BOOST_AUTO_TEST_CASE( testThreadName )
+BOOST_AUTO_TEST_CASE( testThreadName1 )
 {
-    Activity activity(0, 0, "thread_name_34567890");
+    Activity activity(0, 0, "hello-world");
     RTT::os::ThreadInterface *thread = activity.thread();
     char buffer[256];
     pthread_getname_np(thread->getTask()->thread, buffer, sizeof(buffer));
-    BOOST_CHECK_EQUAL(std::string(buffer), std::string("d_name_34567890"));
+    BOOST_CHECK_EQUAL(std::string(buffer), std::string("hello-world"));
+}
+BOOST_AUTO_TEST_CASE( testThreadName2 )
+{
+    Activity activity(0, 0, "abcdefgXXXXX1234567");
+    RTT::os::ThreadInterface *thread = activity.thread();
+    char buffer[256];
+    pthread_getname_np(thread->getTask()->thread, buffer, sizeof(buffer));
+    BOOST_CHECK_EQUAL(std::string(buffer), std::string("abcdefg~1234567"));
 }
 #endif
 


### PR DESCRIPTION
A patch contributed by @snrkiwi:

The algorithm currently takes only the last 15 characters of the activity's name. With long component/activity names this can easily result in the same name for multiple components. This is exacerbated in CORBA dispatchers which append "Corba" on the end of the activity's name, thus reducing the usable name size to 10 characters. So any component names that end in "Configuration" will all have the same thread name, "figurationCorba", rendering them unidentifiable.

A compromise solution is to take the first 7 char's of the name, and the last 7 char's of the name, and put the `"~"` char between them. Now components like `"RobotConfiguration"` and `"MyConfiguration"` become `"RobotCon~uration"` and `"MyConfiguration"` respectively, and their CORBA dispatchers become `"RobotCon~onCorba"` and `"MyConfig~onCorba"` respectively. These are more recognizable.

Added a test for <15 char names.
Made thread_name_len a constant.