### PR TITLE
fixed wrong initialization of oro_atomic_t members in DataObjectLockFree<T>::DataBuf constructor

### DIFF
--- a/rtt/base/DataObjectLockFree.hpp
+++ b/rtt/base/DataObjectLockFree.hpp
@@ -107,7 +107,7 @@ namespace RTT
          */
         struct DataBuf {
             DataBuf()
-                : data(), status(NoData), read_counter(), write_lock(), next()
+                : data(), status(NoData), next()
             {
                 oro_atomic_set(&read_counter, 0);
                 oro_atomic_set(&write_lock, -1);


### PR DESCRIPTION
`oro_atomic_t` is a plain old data struct with a volatile int member. It is initialized by `oro_atomic_set()` and does not need an initializer.

This fixes an `anachronistic old-style base class initializer [-fpermissive]` compiler error with gcc-4.9 in Debian Jessie for the xenomai target.