### PR TITLE
tests: removed special case for high-priority real-time threads in testAffinity

### DIFF
--- a/tests/tasks_test.cpp
+++ b/tests/tasks_test.cpp
@@ -338,16 +338,6 @@ void testAffinity2(boost::scoped_ptr<TestPeriodic>& run,
     BOOST_CHECK(t->setCpuAffinity(1 << targetCPU));
     BOOST_CHECK_EQUAL((1 << targetCPU), t->getCpuAffinity());
 
-    if ( t->getScheduler() == os::HighestPriority) {
-        r = t->start();
-        BOOST_CHECK_MESSAGE( r, "Failed to start Thread");
-        r = t->stop();
-        BOOST_CHECK_MESSAGE( r, "Failed to stop Thread");
-        BOOST_CHECK_MESSAGE( run->stepped == true, "Step not executed" );
-        BOOST_CHECK_EQUAL(targetCPU, run->cpu);
-        BOOST_CHECK_LT(0, run->succ);
-        run->reset();
-    }
     BOOST_CHECK_EQUAL(0, run->cpu);
     r = t->start();
     BOOST_CHECK_MESSAGE( r, "Failed to start Thread");


### PR DESCRIPTION
The condition to execute that part was always evaluating to false because it compared a scheduler type with a priority. The actual test case is invalid because even for a real-time thread with the highest priority there is no guarantee that it executes at least once between the start and stop call.

@snrkiwi You added this test case in 2011. Is this something you would expect from RTT? Maybe the test would have worked back then, but a later update changed the behavior of  `start()` in this case and this was not detected due to the wrong comparison?