### PR TITLE
Fix collectIfDone() for more than three arguments

### DIFF
--- a/rtt/internal/Collect.hpp
+++ b/rtt/internal/Collect.hpp
@@ -214,6 +214,40 @@ namespace RTT
         };
 
         template<class Ft, class BaseImpl>
+        struct CollectImpl<5,Ft,BaseImpl>
+        : public BaseImpl
+        {
+            typedef typename boost::function<Ft>::arg1_type arg1_type;
+            typedef typename boost::function<Ft>::arg2_type arg2_type;
+            typedef typename boost::function<Ft>::arg3_type arg3_type;
+            typedef typename boost::function<Ft>::arg4_type arg4_type;
+            typedef typename boost::function<Ft>::arg5_type arg5_type;
+            virtual ~CollectImpl() {}
+
+            /**
+             * Collect F without returning the results.
+             * @return
+             */
+            virtual SendStatus collect()
+            {
+                return BaseImpl::collect_impl();
+            }
+            /**
+             * Collect a void(arg1_type) F or
+             * arg1_type(void) F
+             * @return
+             */
+            virtual SendStatus collect(arg1_type a1, arg2_type a2, arg3_type a3, arg4_type a4, arg5_type a5)
+            {
+                return BaseImpl::collect_impl(a1,a2,a3,a4,a5);
+            }
+            virtual SendStatus collectIfDone(arg1_type a1, arg2_type a2, arg3_type a3, arg4_type a4, arg5_type a5)
+            {
+                return BaseImpl::collectIfDone_impl(a1,a2,a3,a4,a5);
+            }
+        };
+
+        template<class Ft, class BaseImpl>
         struct CollectImpl<6,Ft,BaseImpl>
         : public BaseImpl
         {
@@ -245,40 +279,6 @@ namespace RTT
             virtual SendStatus collectIfDone(arg1_type a1, arg2_type a2, arg3_type a3, arg4_type a4, arg5_type a5, arg6_type a6)
             {
                 return BaseImpl::collectIfDone_impl(a1,a2,a3,a4,a5,a6);
-            }
-        };
-
-        template<class Ft, class BaseImpl>
-        struct CollectImpl<5,Ft,BaseImpl>
-        : public BaseImpl
-        {
-            typedef typename boost::function<Ft>::arg1_type arg1_type;
-            typedef typename boost::function<Ft>::arg2_type arg2_type;
-            typedef typename boost::function<Ft>::arg3_type arg3_type;
-            typedef typename boost::function<Ft>::arg4_type arg4_type;
-            typedef typename boost::function<Ft>::arg5_type arg5_type;
-            virtual ~CollectImpl() {}
-
-            /**
-             * Collect F without returning the results.
-             * @return
-             */
-            virtual SendStatus collect()
-            {
-                return BaseImpl::collect_impl();
-            }
-            /**
-             * Collect a void(arg1_type) F or
-             * arg1_type(void) F
-             * @return
-             */
-            virtual SendStatus collect(arg1_type a1, arg2_type a2, arg3_type a3, arg4_type a4, arg5_type a5)
-            {
-                return BaseImpl::collect_impl(a1,a2,a3,a4,a5);
-            }
-            virtual SendStatus collectIfDone(arg1_type a1, arg2_type a2, arg3_type a3, arg4_type a4, arg5_type a5)
-            {
-                return BaseImpl::collectIfDone_impl(a1,a2,a3,a4,a5);
             }
         };
 

--- a/rtt/internal/CollectSignature.hpp
+++ b/rtt/internal/CollectSignature.hpp
@@ -257,7 +257,7 @@ namespace RTT
             SendStatus collectIfDone(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4)
             {
                 if (cimpl)
-                    return cimpl->collect(t1, t2, t3, t4);
+                    return cimpl->collectIfDone(t1, t2, t3, t4);
                 return SendFailure;
             }
         protected:
@@ -290,7 +290,7 @@ namespace RTT
             SendStatus collectIfDone(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5)
             {
                 if (cimpl)
-                    return cimpl->collect(t1, t2, t3, t4, t5);
+                    return cimpl->collectIfDone(t1, t2, t3, t4, t5);
                 return SendFailure;
             }
         protected:
@@ -324,7 +324,7 @@ namespace RTT
             SendStatus collectIfDone(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5, arg6_type t6)
             {
                 if (cimpl)
-                    return cimpl->collect(t1, t2, t3, t4, t5, t6);
+                    return cimpl->collectIfDone(t1, t2, t3, t4, t5, t6);
                 return SendFailure;
             }
         protected:


### PR DESCRIPTION
`collectIfDone(...)` was calling `cimpl->collect(...)` for the specializations with more than three arguments.
Also reordered template specializations in `Collect.hpp`.

This is a nasty one.