### PR TITLE
Another attempt to fix flaky unit tests at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ install:
 script:
   # Run tests
   - export BOOST_TEST_LOG_LEVEL=message
+  - export ORBtraceExceptions=1
   - make -j1 check

--- a/tests/corba_ipc_test.cpp
+++ b/tests/corba_ipc_test.cpp
@@ -559,7 +559,7 @@ BOOST_AUTO_TEST_CASE( testPortProxying )
 BOOST_AUTO_TEST_CASE( testDataHalfs )
 {
     if(std::getenv("CI") != NULL) {
-      BOOST_TEST_MESSAGE("Skipping testAffinity because it can fail on integration servers.");
+      BOOST_TEST_MESSAGE("Skipping testDataHalfs because it can fail on integration servers.");
       return;
     }
 
@@ -625,7 +625,7 @@ BOOST_AUTO_TEST_CASE( testDataHalfs )
 BOOST_AUTO_TEST_CASE( testBufferHalfs )
 {
     if(std::getenv("CI") != NULL) {
-      BOOST_TEST_MESSAGE("Skipping testAffinity because it can fail on integration servers.");
+      BOOST_TEST_MESSAGE("Skipping testBufferHalfs because it can fail on integration servers.");
       return;
     }
 

--- a/tests/taskthread_fd_test.cpp
+++ b/tests/taskthread_fd_test.cpp
@@ -245,6 +245,11 @@ BOOST_AUTO_TEST_CASE(testFileDescriptor_Write )
 
 BOOST_AUTO_TEST_CASE(testFileDescriptor_Timeout )
 {
+    if(std::getenv("CI") != NULL) {
+        BOOST_TEST_MESSAGE("Skipping testFileDescriptor_Timeout because it can fail on integration servers.");
+        return;
+    }
+
 	TestFileDescriptor		mcomp("Comp");
     mcomp.setActivity( new FileDescriptorActivity( 15 ) );
     FileDescriptorActivity* mtask = dynamic_cast<FileDescriptorActivity*>( mcomp.getActivity() );


### PR DESCRIPTION
Unit tests on [Travis CI](https://travis-ci.org/orocos-toolchain/rtt) occasionally fail for no good reason, especially for branches and pull requests based on [toolchain-2.9](https://github.com/orocos-toolchain/rtt/tree/toolchain-2.9):

- https://travis-ci.org/orocos-toolchain/rtt/builds/406025524
- https://travis-ci.org/orocos-toolchain/rtt/builds/395411220

This pull request...
- disables the `testFileDescriptor_Timeout` test case for Travis (based on the `CI` environment variable) which has timing requirements Travis cannot always satisfy.
- enables OmniORB exception tracing such that they are printed to the console (instead of a generic "unknown location/unknown type" error message). The `giopStream::CommFailure` exceptions can occur during cleanup of the `corba-ipc-test` (to be investigated...), but they don't affect the results:
   https://travis-ci.org/orocos-toolchain/rtt/builds/406047115#L2222
- fixes the `BOOST_TEST_MESSAGE` output in `corba_ipc_test.cpp`