### PR TITLE
tests: fixed some newer unit tests for the xenomai target (Xenomai 2)

### DIFF
--- a/tests/taskstates_test.cpp
+++ b/tests/taskstates_test.cpp
@@ -25,6 +25,7 @@
 #include <extras/SequentialActivity.hpp>
 #include <extras/SimulationActivity.hpp>
 #include <extras/SimulationThread.hpp>
+#include <os/fosi.h>
 
 #include <boost/function_types/function_type.hpp>
 #include <OperationCaller.hpp>
@@ -644,7 +645,10 @@ public:
         : TaskContext("test") {}
     void updateHook() { error(); }
     void errorHook() {
-        while(getTargetState() != Stopped);
+        while(getTargetState() != Stopped) {
+            TIME_SPEC t = ticks2timespec(nano2ticks(100000000LL));
+            rtos_nanosleep(&t, 0);
+        }
         error();
         trigger();
     }
@@ -673,7 +677,10 @@ public:
         : TaskContext("test"), mRecovered(true) {} // true is an error
     void updateHook() { error(); }
     void errorHook() {
-        while(getTargetState() != Stopped);
+        while(getTargetState() != Stopped) {
+            TIME_SPEC t = ticks2timespec(nano2ticks(100000000LL));
+            rtos_nanosleep(&t, 0);
+        }
         mRecovered = recover();
         trigger();
     }
@@ -704,7 +711,8 @@ public:
         : TaskContext("test") {}
     void updateHook() { error(); }
     void errorHook() {
-        usleep(100);
+        TIME_SPEC t = ticks2timespec(nano2ticks(100000000LL));
+        rtos_nanosleep(&t, 0);
         lastErrorHook = TimeService::Instance()->getTicks();
         trigger();
     }

--- a/tests/taskthread_test.cpp
+++ b/tests/taskthread_test.cpp
@@ -207,7 +207,8 @@ BOOST_AUTO_TEST_CASE(testPeriodic )
 
     // Different CPU affinity
     unsigned cpu_affinity = 1; // first CPU only
-    if ( mtask.thread()->getCpuAffinity() != cpu_affinity ) {
+    if ( mtask.thread()->getCpuAffinity() != (unsigned) ~0 &&
+         mtask.thread()->getCpuAffinity() != cpu_affinity ) {
         PeriodicActivity m4task(ORO_SCHED_OTHER, 15, 0.01, cpu_affinity);
         BOOST_CHECK( mtask.thread() != m4task.thread() );
         BOOST_CHECK_EQUAL( cpu_affinity, m4task.thread()->getCpuAffinity() );
@@ -445,6 +446,7 @@ BOOST_AUTO_TEST_CASE( testScheduler )
 }
 
 #if !defined( OROCOS_TARGET_MACOSX )
+#if !defined( OROCOS_TARGET_XENOMAI )
 /**
  * Checks if the rtos_task_get_pid function works properly.
  */
@@ -458,6 +460,7 @@ BOOST_AUTO_TEST_CASE( testThreadPID )
 //	cout << "PID:" << mpid <<endl;
 //	cout << "TID:" << tid << endl;
 }
+#endif
 #endif
 
 #if !defined( OROCOS_TARGET_WIN32 )


### PR DESCRIPTION
- Calls to usleep from a SCHED_FIFO thread triggers the context switch signal handler. Use `rtos_nanosleep()` instead.

- CPU affinitiy can only be set when a thread is created with xenomai, but `getCPUAffinity()` returns `~0` unconditionally. TimerThread ignores the CPU affinity if `getCPUAffinity()` is not supported for the respective target and the test case would fail.

- `Thread::getPid()` and `rtos_task_get_pid()` are not supported in Xenomai either.