### PR TITLE
Fix compilation error with Boost 1.64

### DIFF
--- a/rtt/transports/mqueue/binary_data_archive.hpp
+++ b/rtt/transports/mqueue/binary_data_archive.hpp
@@ -71,6 +71,14 @@
 #include <streambuf>
 #include <cstring>
 #include <boost/version.hpp>
+#if BOOST_VERSION >= 106400
+// The class name has been changed from boost::serialization::array<T> to array_wrapper<T> in Boost 1.61,
+// but the header has only be renamed in Boost 1.64. Starting from Boost 1.65 array.hpp includes array_wrapper.hpp,
+// but with 1.64 compilation fails if array_wrapper.hpp is not included.
+# include <boost/serialization/array_wrapper.hpp>
+#else
+# include <boost/serialization/array.hpp>
+#endif
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/is_bitwise_serializable.hpp>
 #include <boost/archive/detail/iserializer.hpp>

--- a/rtt/types/carray.hpp
+++ b/rtt/types/carray.hpp
@@ -40,7 +40,14 @@
 #define ORO_CARRAY_HPP_
 
 #include <boost/version.hpp>
-#include <boost/serialization/array.hpp>
+#if BOOST_VERSION >= 106400
+// The class name has been changed from boost::serialization::array<T> to array_wrapper<T> in Boost 1.61,
+// but the header has only be renamed in Boost 1.64. Starting from Boost 1.65 array.hpp includes array_wrapper.hpp,
+// but with 1.64 compilation fails if array_wrapper.hpp is not included.
+# include <boost/serialization/array_wrapper.hpp>
+#else
+# include <boost/serialization/array.hpp>
+#endif
 #include <boost/array.hpp>
 
 namespace RTT

--- a/rtt/types/type_discovery.hpp
+++ b/rtt/types/type_discovery.hpp
@@ -63,11 +63,18 @@
 
 #include <cassert>
 #include <boost/version.hpp>
+#if BOOST_VERSION >= 106400
+// The class name has been changed from boost::serialization::array<T> to array_wrapper<T> in Boost 1.61,
+// but the header has only be renamed in Boost 1.64. Starting from Boost 1.65 array.hpp includes array_wrapper.hpp,
+// but with 1.64 compilation fails if array_wrapper.hpp is not included.
+# include <boost/serialization/array_wrapper.hpp>
+#else
+# include <boost/serialization/array.hpp>
+#endif
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/is_bitwise_serializable.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/string.hpp>
-#include <boost/serialization/array.hpp>
 #include <boost/archive/detail/iserializer.hpp>
 #include <boost/archive/detail/oserializer.hpp>
 #include <boost/archive/archive_exception.hpp>

--- a/tests/mqueue_archive_test.cpp
+++ b/tests/mqueue_archive_test.cpp
@@ -21,6 +21,14 @@
 #include <boost/version.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/iostreams/device/array.hpp>
+#if BOOST_VERSION >= 106400
+// The class name has been changed from boost::serialization::array<T> to array_wrapper<T> in Boost 1.61,
+// but the header has only be renamed in Boost 1.64. Starting from Boost 1.65 array.hpp includes array_wrapper.hpp,
+// but with 1.64 compilation fails if array_wrapper.hpp is not included.
+# include <boost/serialization/array_wrapper.hpp>
+#else
+# include <boost/serialization/array.hpp>
+#endif
 #include <boost/serialization/vector.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 


### PR DESCRIPTION
`boost::serialization::array<T>` has been renamed to `array_wrapper<T>` in Boost 1.61. Its usage in RTT has been adapted in https://github.com/orocos-toolchain/rtt/commit/87659188c71bf3013247590a386321648dd8fb67 with a follow-up in https://github.com/orocos-toolchain/rtt/commit/0d83c908a6f06934cbf6b872537a49edcaf730fd (https://github.com/orocos-toolchain/rtt/pull/192).

The respective header has also been renamed to `array_wrapper.hpp` in Boost 1.64 and starting from 1.65 [array.hpp](https://github.com/boostorg/serialization/blob/boost-1.65.0/include/boost/serialization/array.hpp#L26) includes [array_wrapper.hpp](https://github.com/boostorg/serialization/blob/boost-1.65.0/include/boost/serialization/array_wrapper.hpp) (https://github.com/boostorg/serialization/commit/1d86261581230e2dc5d617a9b16287d326f3e229). But
for 1.64 compilation failed with the following errors due to the missing/wrong include:

```cpp
rtt/internal/../types/carray.hpp:101:56: error: expected ‘)’ before ‘<’ token
             carray( boost::serialization::array_wrapper<T> const& orig)

rtt/internal/../types/carray.hpp:171:41: error: ‘array_wrapper’ is not a member of ‘boost::serialization’
             const carray<T>& operator=( boost::serialization::array_wrapper<OtherT> const& orig ) {
                                         ^
rtt/internal/../types/carray.hpp:171:83: error: expected primary-expression before ‘>’ token
             const carray<T>& operator=( boost::serialization::array_wrapper<OtherT> const& orig ) {
                                                                                   ^
rtt/internal/../types/carray.hpp:171:85: error: expected primary-expression before ‘const’
             const carray<T>& operator=( boost::serialization::array_wrapper<OtherT> const& orig ) {
                                                                                     ^
rtt/internal/../types/carray.hpp:171:97: error: declaration of ‘operator=’ as non-function
             const carray<T>& operator=( boost::serialization::array_wrapper<OtherT> const& orig ) {
                                                                                                 ^
```