### PR TITLE
os/gnulinux: fix return value of pthread_mutexattr_settype in rtos_mutex_rec_init()

### DIFF
--- a/rtt/os/gnulinux/fosi.h
+++ b/rtt/os/gnulinux/fosi.h
@@ -201,7 +201,7 @@ extern "C"
         if (ret != 0) return ret;
 
         // make mutex recursive
-        pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP);
+        ret = pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP);
         if (ret != 0) return ret;
 
         ret = pthread_mutex_init(m, &attr);


### PR DESCRIPTION
Minor bug in the code to initialize a recursive mutex for the `gnulinux` target, an oversight in https://github.com/orocos-toolchain/rtt/pull/258/commits/67e1a101c7cfa14068cf94cefe20fb6ecbe6ec11#diff-39403cc75fc553eb965d446766e58f07R204. Not critical because at least on common platforms it is unlikely that
```cpp
pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP)
```
ever returns with a non-zero value (`EINVAL`) ([man](https://linux.die.net/man/3/pthread_mutexattr_settype)).