### PR TITLE
Add ostream operator for RTT::ConnPolicy

### DIFF
--- a/rtt/ConnPolicy.cpp
+++ b/rtt/ConnPolicy.cpp
@@ -47,6 +47,9 @@
 #include "Property.hpp"
 #include "PropertyBag.hpp"
 
+#include <boost/lexical_cast.hpp>
+#include <iostream>
+
 using namespace std;
 
 namespace RTT
@@ -171,4 +174,40 @@ namespace RTT
     }
     /** @endcond */
 
+    std::ostream &operator<<(std::ostream &os, const ConnPolicy &cp)
+    {
+        std::string type;
+        switch(cp.type) {
+            case ConnPolicy::UNBUFFERED:      type = "UNBUFFERED"; break;
+            case ConnPolicy::DATA:            type = "DATA"; break;
+            case ConnPolicy::BUFFER:          type = "BUFFER"; break;
+            case ConnPolicy::CIRCULAR_BUFFER: type = "CIRCULAR_BUFFER"; break;
+            default:                          type = "(unknown type)"; break;
+        }
+        if (cp.size > 0) {
+            type += "[" + boost::lexical_cast<std::string>(cp.size) + "]";
+        }
+
+        std::string lock_policy;
+        switch(cp.lock_policy) {
+            case ConnPolicy::UNSYNC:    lock_policy = "UNSYNC"; break;
+            case ConnPolicy::LOCKED:    lock_policy = "LOCKED"; break;
+            case ConnPolicy::LOCK_FREE: lock_policy = "LOCK_FREE"; break;
+            default:                    lock_policy = "(unknown lock policy)"; break;
+        }
+
+        std::string pull;
+        // note: cast to int to suppress clang "warning: switch condition has boolean value"
+        switch(int(cp.pull)) {
+            case int(ConnPolicy::PUSH): pull = "PUSH"; break;
+            case int(ConnPolicy::PULL): pull = "PULL"; break;
+        }
+
+        os << pull << " ";
+        os << lock_policy << " ";
+        os << type;
+        if (!cp.name_id.empty()) os << " (name_id=" << cp.name_id << ")";
+
+        return os;
+    }
 }

--- a/rtt/ConnPolicy.hpp
+++ b/rtt/ConnPolicy.hpp
@@ -40,6 +40,7 @@
 #define ORO_CONN_POLICY_HPP
 
 #include <string>
+#include <iosfwd>
 #include "rtt-fwd.hpp"
 #include "rtt-config.h"
 
@@ -55,6 +56,7 @@ namespace RTT {
      *       \a size number of elements can be stored until the reader reads
      *       them. BUFFER drops newer samples on full, CIRCULAR_BUFFER drops older samples on full.
      *       UNBUFFERED is only valid for output streaming connections.
+     *
      *  <li> the locking policy: LOCKED, LOCK_FREE or UNSYNC. This defines how locking is done in the
      *       connection. For now, only three policies are available. LOCKED uses
      *       mutexes, LOCK_FREE uses a lock free method and UNSYNC means there's no
@@ -77,10 +79,12 @@ namespace RTT {
      *       local in-process communication is used, unless one of the ports is
      *       remote. If the transport type deviates from the default remote transport
      *       of one of the ports, an out-of-band transport is setup using that type.
+     *
      *  <li> the data size. Some protocols require a hint on big the data will be,
      *       especially if the data is dynamically sized (like std::vector<double>).
      *       If you leave this empty (recommended), the protocol will try to guess it.
      *       The unit of data size is protocol dependent.
+     *
      *  <li> the name of the connection. Can be used to coordinate out of band
      *       transport such that they can find each other by name. In practice,
      *       the name contains a port number or file descriptor to be opened.
@@ -100,6 +104,9 @@ namespace RTT {
         static const int UNSYNC    = 0;
         static const int LOCKED    = 1;
         static const int LOCK_FREE = 2;
+
+        static const bool PUSH = false;
+        static const bool PULL = true;
 
         /**
          * Create a policy for a (lock-free) fifo buffer connection of a given size.
@@ -181,6 +188,8 @@ namespace RTT {
          */
         mutable std::string name_id;
     };
+
+    std::ostream &operator<<(std::ostream &os, const ConnPolicy &cp);
 }
 
 #endif

--- a/rtt/typekit/RealTimeTypekitTypes2.cpp
+++ b/rtt/typekit/RealTimeTypekitTypes2.cpp
@@ -70,7 +70,7 @@ namespace RTT
              ti->addType( new StdTypeInfo<FlowStatus>("FlowStatus"));
              ti->addType( new StdTypeInfo<SendStatus>("SendStatus"));
              ti->addType( new TemplateTypeInfo<PropertyBag, true>("PropertyBag") );
-             ti->addType( new StructTypeInfo<ConnPolicy,false>("ConnPolicy") );
+             ti->addType( new StructTypeInfo<ConnPolicy>("ConnPolicy") );
              ti->addType( new TemplateTypeInfo<EmptySendHandle>("SendHandle") ); //dummy, replaced by real stuff when seen by parser.
              ti->addType( new TemplateTypeInfo<TaskContext*>("TaskContext"));
          }


### PR DESCRIPTION
This patch is a backport of the streaming operator added in [#118](https://github.com/orocos-toolchain/rtt/pull/118/files#diff-b45975d85b48882bab76083ed4efd886R263).

It is required to fix build errors with some newer unit tests that have originally been written for `toolchain-2.9`, e.g. the unit test added in #281.