### PR TITLE
Introduce a mutex owned by each port that protects its connections

### DIFF
--- a/rtt/base/ChannelInterface.cpp
+++ b/rtt/base/ChannelInterface.cpp
@@ -294,7 +294,7 @@ bool MultipleInputsChannelElementBase::disconnect(ChannelElementBase::shared_ptr
 
         // If the removed input was the last channel and forward is true, disconnect output side, too.
         if (was_last && forward) {
-            disconnect(true);
+            return disconnect(0, true);
         }
 
         return true;
@@ -396,7 +396,7 @@ bool MultipleOutputsChannelElementBase::disconnect(ChannelElementBase::shared_pt
 
         // If the removed output was the last channel, disconnect input side, too.
         if (was_last && !forward) {
-            disconnect(false);
+            return disconnect(0, false);
         }
 
         return true;

--- a/rtt/base/InputPortInterface.cpp
+++ b/rtt/base/InputPortInterface.cpp
@@ -118,7 +118,9 @@ FlowStatus InputPortInterface::read(DataSourceBase::shared_ptr source, bool copy
 { throw std::runtime_error("calling default InputPortInterface::read(datasource) implementation"); }
 /** Returns true if this port is connected */
 bool InputPortInterface::connected() const
-{ return cmanager.connected(); }
+{
+    return getEndpoint()->connected();
+}
 
 void InputPortInterface::disconnect()
 {
@@ -132,7 +134,7 @@ bool InputPortInterface::disconnect(PortInterface* port)
 
 bool InputPortInterface::createConnection( internal::SharedConnectionBase::shared_ptr shared_connection, ConnPolicy const& policy )
 {
-    return internal::ConnFactory::createAndCheckSharedConnection(0, this, shared_connection, policy);
+    return internal::ConnFactory::createSharedConnection(0, this, shared_connection, policy);
 }
 
 base::ChannelElementBase::shared_ptr InputPortInterface::buildRemoteChannelOutput(

--- a/rtt/base/OutputPortInterface.cpp
+++ b/rtt/base/OutputPortInterface.cpp
@@ -58,7 +58,9 @@ OutputPortInterface::~OutputPortInterface()
 
 /** Returns true if this port is connected */
 bool OutputPortInterface::connected() const
-{ return cmanager.connected(); }
+{
+    return getEndpoint()->connected();
+}
 
 bool OutputPortInterface::disconnect(PortInterface* port)
 {
@@ -92,7 +94,7 @@ bool OutputPortInterface::createConnection( InputPortInterface& input )
 
 bool OutputPortInterface::createConnection( internal::SharedConnectionBase::shared_ptr shared_connection, ConnPolicy const& policy )
 {
-    return internal::ConnFactory::createAndCheckSharedConnection(this, 0, shared_connection, policy);
+    return internal::ConnFactory::createSharedConnection(this, 0, shared_connection, policy);
 }
 
 bool OutputPortInterface::connectTo(PortInterface* other, ConnPolicy const& policy)

--- a/rtt/base/PortInterface.hpp
+++ b/rtt/base/PortInterface.hpp
@@ -46,6 +46,7 @@
 #include "../internal/ConnID.hpp"
 #include "ChannelElementBase.hpp"
 #include "../types/rtt-types-fwd.hpp"
+#include "../os/Mutex.hpp"
 #include "../rtt-fwd.hpp"
 
 namespace RTT
@@ -62,6 +63,8 @@ namespace RTT
     protected:
         DataFlowInterface* iface;
         internal::ConnectionManager cmanager;
+        os::MutexRecursive connection_lock;
+        friend class internal::PortConnectionLock;
 
         PortInterface(const std::string& name);
 

--- a/rtt/internal/ConnFactory.cpp
+++ b/rtt/internal/ConnFactory.cpp
@@ -211,6 +211,13 @@ base::ChannelElementBase::shared_ptr ConnFactory::createAndCheckStream(base::Inp
     return chan;
 }
 
+bool ConnFactory::createSharedConnection(base::OutputPortInterface* output_port, base::InputPortInterface* input_port, SharedConnectionBase::shared_ptr shared_connection, ConnPolicy const& policy)
+{
+    PortConnectionLock lock_output_port(output_port);
+    PortConnectionLock lock_input_port(input_port);
+    return createAndCheckSharedConnection(output_port, input_port, shared_connection, policy);
+}
+
 bool ConnFactory::createAndCheckSharedConnection(base::OutputPortInterface* output_port, base::InputPortInterface* input_port, SharedConnectionBase::shared_ptr shared_connection, ConnPolicy const& policy)
 {
     if (!shared_connection) return false;

--- a/rtt/internal/ConnFactory.hpp
+++ b/rtt/internal/ConnFactory.hpp
@@ -43,6 +43,7 @@
 #include "Channels.hpp"
 #include "ConnInputEndPoint.hpp"
 #include "ConnOutputEndPoint.hpp"
+#include "PortConnectionLock.hpp"
 #include "SharedConnection.hpp"
 #include "../base/PortInterface.hpp"
 #include "../base/InputPortInterface.hpp"
@@ -219,31 +220,30 @@ namespace RTT
         static base::ChannelElementBase::shared_ptr buildChannelInput(OutputPort<T>& port, ConnPolicy const& policy, bool force_unbuffered = false)
         {
             typename internal::ConnInputEndpoint<T>::shared_ptr endpoint = port.getEndpoint();
-            typename base::ChannelElement<T>::shared_ptr buffer = port.getSharedBuffer();
 
             // Note: PerInputPort implies PUSH and PerOutputPort implies PULL
             bool pull = policy.pull;
             if (policy.buffer_policy == PerInputPort) pull = ConnPolicy::PUSH;
             if (policy.buffer_policy == PerOutputPort) pull = ConnPolicy::PULL;
 
-            if (pull == ConnPolicy::PULL && !force_unbuffered) {
+            // Special case: PerOutputPort
+            typename base::ChannelElement<T>::shared_ptr buffer = port.getSharedBuffer();
+            if (policy.buffer_policy == PerOutputPort) {
                 if (!buffer) {
-                    buffer = buildDataStorage<T>(policy, port.getLastWrittenValue());
-                    if (!buffer) return typename internal::ConnOutputEndpoint<T>::shared_ptr();
-
-                    if (policy.buffer_policy == PerOutputPort) {
-                        // For PerOutputPort connections, the buffer is installed BEFORE the input endpoint!
-                        if (endpoint->connected()) {
-                            log(Error) << "You tried to create a shared output buffer connection for output port " << port.getName() << ", "
-                                       << "but the port already has at least one incompatible outgoing connection." << endlog();
-                            return typename internal::ConnOutputEndpoint<T>::shared_ptr();
-                        }
-                        return buffer->connectTo(endpoint) ? endpoint : typename internal::ConnInputEndpoint<T>::shared_ptr();
-                    } else {
-                        return endpoint->connectTo(buffer, policy.mandatory) ? buffer : typename internal::ConnInputEndpoint<T>::shared_ptr();
+                    if (endpoint->connected()) {
+                        log(Error) << "You tried to create a shared output buffer connection for output port " << port.getName() << ", "
+                                   << "but the port already has at least one incompatible outgoing connection." << endlog();
+                        return base::ChannelElementBase::shared_ptr();
                     }
 
-                } else if (policy.buffer_policy == PerOutputPort) {
+                    buffer = buildDataStorage<T>(policy, port.getLastWrittenValue());
+                    if (!buffer) return base::ChannelElementBase::shared_ptr();
+
+                    // For PerOutputPort connections, the buffer is installed BEFORE the output endpoint!
+                    if (!buffer->connectTo(endpoint)) {
+                        return base::ChannelElementBase::shared_ptr();
+                    }
+                } else {
                     // check that the existing buffer type is compatible to the new ConnPolicy
                     assert(buffer->getConnPolicy());
                     ConnPolicy buffer_policy = *(buffer->getConnPolicy());
@@ -257,14 +257,12 @@ namespace RTT
                         log(Error) << "You mixed incompatible connection policies for the shared output buffer of port " << port.getName() << ": "
                                    << "The new connection requests a " << policy << " connection, "
                                    << "but the port already has a " << buffer_policy << " buffer." << endlog();
-                        return typename internal::ConnOutputEndpoint<T>::shared_ptr();
+                        return base::ChannelElementBase::shared_ptr();
                     }
-
-                    return endpoint;
                 }
-            }
 
-            if (buffer) {
+            // Check that no shared buffer exists for all other cases...
+            } else if (buffer) {
                 // The new connection requires an unbuffered channel input or a per-connection buffer, but this port already has a shared output buffer!
                 assert(buffer->getConnPolicy());
                 ConnPolicy buffer_policy = *(buffer->getConnPolicy());
@@ -272,7 +270,14 @@ namespace RTT
                 log(Error) << "You mixed incompatible connection policies for output port " << port.getName() << ": "
                            << "The new connection requests a " << policy << " connection, "
                            << "but the port already has a " << buffer_policy << " buffer." << endlog();
-                return typename internal::ConnOutputEndpoint<T>::shared_ptr();
+                return base::ChannelElementBase::shared_ptr();
+            }
+
+            // Create buffer for PerConnection PULL connections
+            if (policy.buffer_policy == PerConnection && pull == ConnPolicy::PULL && !force_unbuffered) {
+                buffer = buildDataStorage<T>(policy, port.getLastWrittenValue());
+                if (!buffer) return base::ChannelElementBase::shared_ptr();
+                return endpoint->connectTo(buffer, policy.mandatory) ? buffer : base::ChannelElementBase::shared_ptr();
             }
 
             return endpoint;
@@ -297,35 +302,33 @@ namespace RTT
         static base::ChannelElementBase::shared_ptr buildChannelOutput(InputPort<T>& port, ConnPolicy const& policy, T const& initial_value = T() )
         {
             typename internal::ConnOutputEndpoint<T>::shared_ptr endpoint = port.getEndpoint();
-            typename base::ChannelElement<T>::shared_ptr buffer = port.getSharedBuffer();
 
             // Note: PerInputPort implies PUSH and PerOutputPort implies PULL
             bool pull = policy.pull;
             if (policy.buffer_policy == PerInputPort) pull = ConnPolicy::PUSH;
             if (policy.buffer_policy == PerOutputPort) pull = ConnPolicy::PULL;
 
-            if (pull == ConnPolicy::PUSH) {
+            // Special case: PerInputPort
+            typename base::ChannelElement<T>::shared_ptr buffer = endpoint->getSharedBuffer();
+            if (policy.buffer_policy == PerInputPort) {
                 if (!buffer) {
-                    buffer = buildDataStorage<T>(policy, initial_value);
-                    if (!buffer) return typename internal::ConnOutputEndpoint<T>::shared_ptr();
-
-                    if (policy.buffer_policy == PerInputPort) {
-                        // For PerInputPort connections, the buffer is installed AFTER the output endpoint!
-                        if (endpoint->connected()) {
-                            log(Error) << "You tried to create a shared input buffer connection for input port " << port.getName() << ", "
-                                       << "but the port already has at least one incompatible incoming connection." << endlog();
-                            return typename internal::ConnOutputEndpoint<T>::shared_ptr();
-                        }
-                        return endpoint->connectTo(buffer) ? endpoint : typename internal::ConnOutputEndpoint<T>::shared_ptr();
-                    } else {
-                        return buffer->connectTo(endpoint) ? buffer : typename internal::ConnOutputEndpoint<T>::shared_ptr();
+                    if (endpoint->connected()) {
+                        log(Error) << "You tried to create a shared input buffer connection for input port " << port.getName() << ", "
+                                   << "but the port already has at least one incompatible incoming connection." << endlog();
+                        return base::ChannelElementBase::shared_ptr();
                     }
 
-                } else if (policy.buffer_policy == PerInputPort) {
-                    // check that the existing buffer type is compatible to the new ConnPolicy
+                    buffer = buildDataStorage<T>(policy, initial_value);
+                    if (!buffer) return base::ChannelElementBase::shared_ptr();
+
+                    // For PerInputPort connections, the buffer is installed AFTER the output endpoint!
+                    if (!endpoint->connectTo(buffer)) {
+                        return base::ChannelElementBase::shared_ptr();
+                    }
+                } else {
+                    // check that the buffer type is compatible to the new ConnPolicy
                     assert(buffer->getConnPolicy());
                     ConnPolicy buffer_policy = *(buffer->getConnPolicy());
-
                     if (
                         (buffer_policy.type != policy.type) ||
                         (buffer_policy.size != policy.size) ||
@@ -335,14 +338,12 @@ namespace RTT
                         log(Error) << "You mixed incompatible connection policies for the shared input buffer of port " << port.getName() << ": "
                                    << "The new connection requests a " << policy << " connection, "
                                    << "but the port already has a " << buffer_policy << " buffer." << endlog();
-                        return typename internal::ConnOutputEndpoint<T>::shared_ptr();
+                        return base::ChannelElementBase::shared_ptr();
                     }
-
-                    return endpoint;
                 }
-            }
 
-            if (buffer) {
+            // Check that no shared buffer exists for all other cases...
+            } else if (buffer) {
                 // The new connection requires an unbuffered channel output or a per-connection buffer, but this port already has a shared input buffer!
                 assert(buffer->getConnPolicy());
                 ConnPolicy buffer_policy = *(buffer->getConnPolicy());
@@ -350,7 +351,14 @@ namespace RTT
                 log(Error) << "You mixed incompatible connection policies for input port " << port.getName() << ": "
                            << "The new connection requests a " << policy << " connection, "
                            << "but the port already has a " << buffer_policy << " buffer." << endlog();
-                return typename internal::ConnOutputEndpoint<T>::shared_ptr();
+                return base::ChannelElementBase::shared_ptr();
+            }
+
+            // Create buffer for PerConnection PUSH connections
+            if (policy.buffer_policy == PerConnection && pull == ConnPolicy::PUSH) {
+                buffer = buildDataStorage<T>(policy, initial_value);
+                if (!buffer) return base::ChannelElementBase::shared_ptr();
+                return buffer->connectTo(endpoint) ? buffer : base::ChannelElementBase::shared_ptr();
             }
 
             return endpoint;
@@ -449,6 +457,9 @@ namespace RTT
         template<typename T>
         static bool createConnection(OutputPort<T>& output_port, base::InputPortInterface& input_port, ConnPolicy const& policy)
         {
+            PortConnectionLock lock_output_port(&output_port);
+            PortConnectionLock lock_input_port(&input_port);
+
             if ( !output_port.isLocal() ) {
                 log(Error) << "Need a local OutputPort to create connections." <<endlog();
                 return false;
@@ -523,11 +534,17 @@ namespace RTT
         template<class T>
         static bool createStream(OutputPort<T>& output_port, ConnPolicy const& policy)
         {
+            PortConnectionLock lock_output_port(&output_port);
+
             StreamConnID *sid = new StreamConnID(policy.name_id);
             // Stream channel inputs are always unbuffered (push). It's the transport that has to add a buffer element if required.
             RTT::base::ChannelElementBase::shared_ptr chan = buildChannelInput( output_port, policy, /* force_unbuffered = */ true );
             if (!chan) return false;
-            return bool(createAndCheckStream(output_port, policy, chan, sid));
+            if (!bool(createAndCheckStream(output_port, policy, chan, sid))) {
+                chan->disconnect(false);
+                return false;
+            }
+            return true;
         }
 
         /**
@@ -540,16 +557,24 @@ namespace RTT
         template<class T>
         static bool createStream(InputPort<T>& input_port, ConnPolicy const& policy)
         {
+            PortConnectionLock lock_input_port(&input_port);
+
             StreamConnID *sid = new StreamConnID(policy.name_id);
             RTT::base::ChannelElementBase::shared_ptr outhalf = buildChannelOutput( input_port, policy );
             if (!outhalf) return false;
-            return bool(createAndCheckStream(input_port, policy, outhalf, sid));
+            if (!bool(createAndCheckStream(input_port, policy, outhalf, sid))) {
+                outhalf->disconnect(true);
+                return false;
+            }
+            return true;
         }
 
-        static bool createAndCheckSharedConnection(base::OutputPortInterface* output_port, base::InputPortInterface* input_port, SharedConnectionBase::shared_ptr shared_connection, ConnPolicy const& policy);
+        static bool createSharedConnection(base::OutputPortInterface* output_port, base::InputPortInterface* input_port, SharedConnectionBase::shared_ptr shared_connection, ConnPolicy const& policy);
 
     protected:
         static bool createAndCheckConnection(base::OutputPortInterface& output_port, base::InputPortInterface& input_port, base::ChannelElementBase::shared_ptr channel_input, base::ChannelElementBase::shared_ptr channel_output, ConnPolicy const& policy);
+
+        static bool createAndCheckSharedConnection(base::OutputPortInterface* output_port, base::InputPortInterface* input_port, SharedConnectionBase::shared_ptr shared_connection, ConnPolicy const& policy);
 
         static base::ChannelElementBase::shared_ptr createAndCheckStream(base::OutputPortInterface& output_port, ConnPolicy const& policy, base::ChannelElementBase::shared_ptr channel_input, StreamConnID* conn_id);
 

--- a/rtt/internal/ConnInputEndPoint.hpp
+++ b/rtt/internal/ConnInputEndPoint.hpp
@@ -40,6 +40,7 @@
 #define ORO_CONN_INPUT_ENDPOINT_HPP
 
 #include "Channels.hpp"
+#include "PortConnectionLock.hpp"
 
 namespace RTT
 { namespace internal {
@@ -72,6 +73,11 @@ namespace RTT
         virtual bool disconnect(const base::ChannelElementBase::shared_ptr& channel, bool forward)
         {
             OutputPort<T>* port = this->port;
+            PortConnectionLock lock(port);
+
+//            // Lock port connections if the request is coming from the remote end (forward == false)
+//            PortConnectionLock lock(!forward ? port : 0);
+
             if (port && channel && !forward)
             {
                 port->getManager()->removeConnection(channel.get(), /* disconnect = */ false);
@@ -85,7 +91,7 @@ namespace RTT
             // If this was the last connection, remove the buffer, too.
             // For forward == false this was already done by the base class.
             if (!this->connected() && forward) {
-                this->disconnect(false);
+                Base::disconnect(0, false);
             }
 
             return true;

--- a/rtt/internal/ConnOutputEndPoint.hpp
+++ b/rtt/internal/ConnOutputEndPoint.hpp
@@ -41,6 +41,7 @@
 
 #include "Channels.hpp"
 #include "ConnID.hpp"
+#include "PortConnectionLock.hpp"
 
 namespace RTT
 { namespace internal {
@@ -126,9 +127,14 @@ namespace RTT
 
         using Base::disconnect;
 
-        virtual bool disconnect(const base::ChannelElementBase::shared_ptr& channel, bool forward = true)
+        virtual bool disconnect(const base::ChannelElementBase::shared_ptr& channel, bool forward)
         {
             InputPort<T>* port = this->port;
+            PortConnectionLock lock(port);
+
+//            // Lock port connections if the request is coming from the remote end (forward == true)
+//            PortConnectionLock lock(forward ? port : 0);
+
             if (port && channel && forward)
             {
                 port->getManager()->removeConnection(channel.get(), /* disconnect = */ false);
@@ -142,7 +148,7 @@ namespace RTT
             // If this was the last connection, remove the buffer, too.
             // For forward == true this was already done by the base class.
             if (!this->connected() && !forward) {
-                this->disconnect(true);
+                Base::disconnect(0, true);
             }
 
             return true;

--- a/rtt/internal/ConnectionManager.hpp
+++ b/rtt/internal/ConnectionManager.hpp
@@ -144,19 +144,20 @@ namespace RTT
                 return shared_connection;
             }
 
-            /**
-             * Locks the mutex protecting the channel element list.
-             * */
-            void lock() const {
-                connection_lock.lock();
-            };
+//            /**
+//             * Locks the mutex protecting the channel element list.
+//             * */
+//            void lock() const {
+//                connection_lock.lock();
+//            };
 
-            /**
-             * Unlocks the mutex protecting the channel element list.
-             * */
-            void unlock() const {
-                connection_lock.unlock();
-            }
+//            /**
+//             * Unlocks the mutex protecting the channel element list.
+//             * */
+//            void unlock() const {
+//                connection_lock.unlock();
+//            }
+
         protected:
 
             /** Helper method for disconnect()
@@ -180,12 +181,6 @@ namespace RTT
              * A pointer to the shared connection this port may be connected to.
              */
             internal::SharedConnectionBase::shared_ptr shared_connection;
-
-            /**
-             * Lock that should be taken before the list of connections is
-             * accessed or modified
-             */
-            mutable RTT::os::Mutex connection_lock;
         };
 
     }

--- a/rtt/internal/PortConnectionLock.hpp
+++ b/rtt/internal/PortConnectionLock.hpp
@@ -1,0 +1,64 @@
+/***************************************************************************
+  tag: Peter Soetens  Thu July 19 23:09:08 CEST 2018  PortConnectionLock.hpp
+
+                        PortConnectionLock.hpp -  description
+                           -------------------
+    begin                : Thu July 19 2018
+    copyright            : (C) 2018 Johannes Meyer
+    email                : johannes@intermodalics.eu
+
+ ***************************************************************************
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU General Public                   *
+ *   License as published by the Free Software Foundation;                 *
+ *   version 2 of the License.                                             *
+ *                                                                         *
+ *   As a special exception, you may use this file as part of a free       *
+ *   software library without restriction.  Specifically, if other files   *
+ *   instantiate templates or use macros or inline functions from this     *
+ *   file, or you compile this file and link it with other files to        *
+ *   produce an executable, this file does not by itself cause the         *
+ *   resulting executable to be covered by the GNU General Public          *
+ *   License.  This exception does not however invalidate any other        *
+ *   reasons why the executable file might be covered by the GNU General   *
+ *   Public License.                                                       *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public             *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 59 Temple Place,                                    *
+ *   Suite 330, Boston, MA  02111-1307  USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef ORO_PORT_CONNECTION_LOCK_HPP
+#define ORO_PORT_CONNECTION_LOCK_HPP
+
+#include "../base/PortInterface.hpp"
+
+namespace RTT
+{ namespace internal {
+
+    class RTT_API PortConnectionLock
+    {
+        base::PortInterface *mport;
+
+    public:
+        PortConnectionLock(base::PortInterface *port)
+            : mport(port) {
+            if (mport) mport->connection_lock.lock();
+        }
+
+        ~PortConnectionLock()
+        {
+            if (mport) mport->connection_lock.unlock();
+        }
+    };
+
+}}
+
+#endif // ORO_PORT_CONNECTION_LOCK_HPP

--- a/rtt/internal/rtt-internal-fwd.hpp
+++ b/rtt/internal/rtt-internal-fwd.hpp
@@ -15,6 +15,7 @@ namespace RTT {
         class SendHandleC;
         class SignalBase;
         class SimpleConnID;
+        class PortConnectionLock;
         struct GenerateDataSource;
         struct IntrusiveStorage;
         struct LocalConnID;


### PR DESCRIPTION
The `connection_mutex` owned by the port's `ConnectionManager` was only protecting its internal list of connections, but not the whole process of creating new connections, data objects or buffers. At least connections that involve shared buffers (#114) were subject to race conditions if multiple threads establish and disconnect connections concurrently.

The new port connection mutex is locked early inside the `ConnFactory` and inside `ConnInputEndPoint` and `ConnInputEndPoint` for the case port connection is disconnected from the remote end.

`InputPortInterface::connected()` and `OutputPortInterface::connected()` are forwarding to their respective ChannelElement endpoints, where the test can be done in lock-free way.

The `ports_test` has been updated to also cover errors during concurrent connection management.

Note that writing to and reading from ports with only lock-free connections (the default) is still expected to be a lock-free operation. Only adding or removing port connections involves locks (as it has been before for the mutex owned by the `ConnectionManager`).