### PR TITLE
Improved naming of timer threads

### DIFF
--- a/rtt/os/Timer.cpp
+++ b/rtt/os/Timer.cpp
@@ -144,6 +144,16 @@ namespace RTT {
         }
     }
 
+    Timer::Timer(TimerId max_timers, int scheduler, int priority, const std::string& name)
+        : mThread(0), mdo_quit(false)
+    {
+        mtimers.resize(max_timers);
+        if (scheduler != -1) {
+            mThread = new Activity(scheduler, priority, 0.0, this, name);
+            mThread->start();
+        }
+    }
+
     Timer::~Timer()
     {
         delete mThread;

--- a/rtt/os/Timer.cpp
+++ b/rtt/os/Timer.cpp
@@ -134,16 +134,6 @@ namespace RTT {
         return true;
     }
 
-    Timer::Timer(TimerId max_timers, int scheduler, int priority)
-        : mThread(0), mdo_quit(false)
-    {
-        mtimers.resize(max_timers);
-        if (scheduler != -1) {
-            mThread = new Activity(scheduler, priority, 0.0, this, "Timer");
-            mThread->start();
-        }
-    }
-
     Timer::Timer(TimerId max_timers, int scheduler, int priority, const std::string& name)
         : mThread(0), mdo_quit(false)
     {

--- a/rtt/os/Timer.hpp
+++ b/rtt/os/Timer.hpp
@@ -109,20 +109,6 @@ namespace RTT
 
     public:
         /**
-         * Create a timer object which can hold \a max_timers timers.
-         * A Timer must be executed in a non periodic thread (or the main thread)
-         * or it will refuse to start.
-         * If \a scheduler is set to -1 (default) no thread is created and you need
-         * to attach a thread yourself to this Timer.
-         * @param max_timers The initial amount of timers this Timer can monitor.
-         * Keep as low as possible. See also setMaxTimers().
-         * @param scheduler The Orocos scheduler type for this timer. ORO_SCHED_OTHER or ORO_SCHED_RT or
-         * -1 to attach your own thread.
-         * @param priority The priority within the \a scheduler of this timer.
-         */
-        Timer(TimerId max_timers, int scheduler = -1, int priority = 0);
-
-        /**
          * Create a named timer object which can hold \a max_timers timers.
          * \sa Timer::Timer()
          * @param max_timers The initial amount of timers this Timer can monitor.

--- a/rtt/os/Timer.hpp
+++ b/rtt/os/Timer.hpp
@@ -110,7 +110,10 @@ namespace RTT
     public:
         /**
          * Create a named timer object which can hold \a max_timers timers.
-         * \sa Timer::Timer()
+         * A Timer must be executed in a non periodic thread (or the main thread)
+         * or it will refuse to start.
+         * If \a scheduler is set to -1 (default) no thread is created and you need
+         * to attach a thread yourself to this Timer.
          * @param max_timers The initial amount of timers this Timer can monitor.
          * Keep as low as possible. See also setMaxTimers().
          * @param scheduler The Orocos scheduler type for this timer. ORO_SCHED_OTHER or ORO_SCHED_RT or

--- a/rtt/os/Timer.hpp
+++ b/rtt/os/Timer.hpp
@@ -46,6 +46,7 @@
 #include "Condition.hpp"
 #include "ThreadInterface.hpp"
 #include "../base/RunnableInterface.hpp"
+#include <string>
 #include <vector>
 #include <utility>
 
@@ -120,6 +121,18 @@ namespace RTT
          * @param priority The priority within the \a scheduler of this timer.
          */
         Timer(TimerId max_timers, int scheduler = -1, int priority = 0);
+
+        /**
+         * Create a named timer object which can hold \a max_timers timers.
+         * \sa Timer::Timer()
+         * @param max_timers The initial amount of timers this Timer can monitor.
+         * Keep as low as possible. See also setMaxTimers().
+         * @param scheduler The Orocos scheduler type for this timer. ORO_SCHED_OTHER or ORO_SCHED_RT or
+         * -1 to attach your own thread.
+         * @param priority The priority within the \a scheduler of this timer.
+         * @param name The name of the timer (ie the underlying Activity/Thread)
+         */
+        Timer(TimerId max_timers, int scheduler = -1, int priority = 0, const std::string& name = std::string("Timer"));
 
         ~Timer();
 

--- a/rtt/transports/corba/CorbaDispatcher.hpp
+++ b/rtt/transports/corba/CorbaDispatcher.hpp
@@ -110,7 +110,7 @@ namespace RTT {
                         name = "Global";
                     else
                         name = iface->getOwner()->getName();
-                    name += ".CorbaDispatch";
+                    name += "Corba";
                     DispatchI[iface] = new CorbaDispatcher( name, scheduler, priority );
                     DispatchI[iface]->start();
                     return DispatchI[iface];


### PR DESCRIPTION
Copy of https://github.com/orocos-toolchain/rtt/pull/213, but targeting `master`:


Required to fix ocl build errors after https://github.com/orocos-toolchain/ocl/pull/73 has been merged, which was a duplicate of https://github.com/orocos-toolchain/ocl/pull/59, but targeted `master`.

From https://github.com/orocos-toolchain/rtt/commit/96e1045165572afbe3a54ee1bafd55f21c4ac7e7:
> This ensures that the underlying Activity/Thread can be traced back to some other entity that created this timer, rather than ending up with multiple threads named `Timer`.