### PR TITLE
rtt-config.h: introduce RTT_UNUSED macro and use it consistently

### DIFF
--- a/rtt/deployment/ComponentLoader.cpp
+++ b/rtt/deployment/ComponentLoader.cpp
@@ -94,15 +94,6 @@ static const std::string delimiters(":;");
 static const char default_delimiter(':');
 # endif
 
-// define RTT_UNUSED macro
-#ifndef RTT_UNUSED
-  #ifdef __GNUC__
-    #define RTT_UNUSED __attribute__((unused))
-  #else
-    #define RTT_UNUSED
-  #endif
-#endif
-
 /** Determine whether a file extension is actually part of a library version
 
     @return true if \a ext satisfies "^\.[:digit:]+$"

--- a/rtt/os/xenomai/fosi_internal.cpp
+++ b/rtt/os/xenomai/fosi_internal.cpp
@@ -49,7 +49,7 @@
 #include <execinfo.h>
 
 extern "C"
-void warn_upon_switch(int sig __attribute__((unused)))
+void warn_upon_switch(int /*sig*/)
 {
     void *bt[32];
     int nentries;

--- a/rtt/plugin/PluginLoader.cpp
+++ b/rtt/plugin/PluginLoader.cpp
@@ -94,15 +94,6 @@ static const std::string delimiters(":;");
 static const std::string default_delimiter(":");
 # endif
 
-// define RTT_UNUSED macro
-#ifndef RTT_UNUSED
-  #ifdef __GNUC__
-    #define RTT_UNUSED __attribute__((unused))
-  #else
-    #define RTT_UNUSED
-  #endif
-#endif
-
 /** Determine whether a file extension is actually part of a library version
 
     @return true if \a ext satisfies "^\.[:digit:]+$"

--- a/rtt/rtt-config.h.in
+++ b/rtt/rtt-config.h.in
@@ -140,16 +140,27 @@
 #endif
 
 //
-// Deprecation Macro
+// Deprecation Macro RTT_DEPRECATED
 // (copied from http://stackoverflow.com/questions/295120/c-mark-as-deprecated/21265197#21265197)
 //
 #ifdef __GNUC__
-#define RTT_DEPRECATED __attribute__((deprecated))
+#define RTT_DEPRECATED __attribute__((__deprecated__))
 #elif defined(_MSC_VER)
 #define RTT_DEPRECATED __declspec(deprecated)
 #else
-#pragma message("WARNING: You need to implement RTT_DEPRECATED for this compiler")
+// #pragma message("WARNING: You need to implement RTT_DEPRECATED for this compiler")
 #define RTT_DEPRECATED
+#endif
+
+//
+// Macro RTT_UNUSED to mark unused functions or arguments and suppress
+// compiler warnings (GNUC only)
+//
+#ifdef __GNUC__
+#define RTT_UNUSED __attribute__((__unused__))
+#else
+// #pragma message("WARNING: You need to implement RTT_UNUSED for this compiler")
+#define RTT_UNUSED
 #endif
 
 #endif

--- a/tests/dataflow_performance_test.cpp
+++ b/tests/dataflow_performance_test.cpp
@@ -343,7 +343,7 @@ template <typename T, PortTypes> struct Adaptor;
             return tc->update();
         }
 
-        static bool setCpuAffinity(ThreadInterface *thread, const std::bitset<16> &cpu_affinity) {
+        RTT_UNUSED static bool setCpuAffinity(ThreadInterface *thread, const std::bitset<16> &cpu_affinity) {
             RTT::os::Thread *t = dynamic_cast<RTT::os::Thread *>(thread);
             if (!t) return false;
             return t->setCpuAffinity(cpu_affinity.to_ulong());
@@ -354,7 +354,6 @@ template <typename T, PortTypes> struct Adaptor;
             if (!t) return ~std::bitset<16>();
             return std::bitset<16>(t->getCpuAffinity());
         }
-
     }
 
     template <typename T, PortTypes>


### PR DESCRIPTION
...to suppress compiler warnings on unused code elements.

This patch has already been in `toolchain-2.9` for quite a while (https://github.com/orocos-toolchain/rtt/commit/6a4a469100d42526cdfc9c96a924aedeb6f2824e).