### PR TITLE
operations: add const qualifier in collect family of functions

### DIFF
--- a/rtt/SendHandle.hpp
+++ b/rtt/SendHandle.hpp
@@ -121,7 +121,7 @@ namespace RTT
         /**
          * Collect this operator if the method has no arguments.
          */
-        SendStatus collect()
+        SendStatus collect() const
         {
             if (this->impl)
                 return this->impl->collect();

--- a/rtt/internal/CollectSignature.hpp
+++ b/rtt/internal/CollectSignature.hpp
@@ -121,14 +121,14 @@ namespace RTT
             CollectSignature(ToCollect implementation) : cimpl(implementation) {}
             ~CollectSignature() {}
 
-            SendStatus collect()
+            SendStatus collect() const
             {
                 if (this->cimpl)
                     return this->cimpl->collect();
                 return SendFailure;
             }
 
-            SendStatus collectIfDone()
+            SendStatus collectIfDone() const
             {
                 if (this->cimpl)
                     return this->cimpl->collectIfDone();
@@ -154,14 +154,14 @@ namespace RTT
             /**
              * Collect this operator if the method has one argument.
              */
-            SendStatus collect(arg1_type a1)
+            SendStatus collect(arg1_type a1) const
             {
                 if (cimpl)
                     return cimpl->collect( a1 );
                 return SendFailure;
             }
 
-            SendStatus collectIfDone(arg1_type a1)
+            SendStatus collectIfDone(arg1_type a1) const
             {
                 if (cimpl)
                     return cimpl->collectIfDone( a1 );
@@ -184,14 +184,14 @@ namespace RTT
             /**
              * Collect this operator if the method has two arguments.
              */
-            SendStatus collect(arg1_type t1, arg2_type t2)
+            SendStatus collect(arg1_type t1, arg2_type t2) const
             {
                 if (cimpl)
                     return cimpl->collect(t1, t2);
                 return SendFailure;
             }
 
-            SendStatus collectIfDone(arg1_type t1, arg2_type t2)
+            SendStatus collectIfDone(arg1_type t1, arg2_type t2) const
             {
                 if (cimpl)
                     return cimpl->collectIfDone(t1, t2);
@@ -215,14 +215,14 @@ namespace RTT
             /**
              * Collect this operator if the method has three arguments.
              */
-            SendStatus collect(arg1_type t1, arg2_type t2, arg3_type t3)
+            SendStatus collect(arg1_type t1, arg2_type t2, arg3_type t3) const
             {
                 if (cimpl)
                     return cimpl->collect(t1, t2, t3);
                 return SendFailure;
             }
 
-            SendStatus collectIfDone(arg1_type t1, arg2_type t2, arg3_type t3)
+            SendStatus collectIfDone(arg1_type t1, arg2_type t2, arg3_type t3) const
             {
                 if (cimpl)
                     return cimpl->collectIfDone(t1, t2, t3);
@@ -247,14 +247,14 @@ namespace RTT
             /**
              * Collect this operator if the method has four arguments.
              */
-            SendStatus collect(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4)
+            SendStatus collect(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4) const
             {
                 if (cimpl)
                     return cimpl->collect(t1, t2, t3, t4);
                 return SendFailure;
             }
 
-            SendStatus collectIfDone(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4)
+            SendStatus collectIfDone(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4) const
             {
                 if (cimpl)
                     return cimpl->collectIfDone(t1, t2, t3, t4);
@@ -280,14 +280,14 @@ namespace RTT
             /**
              * Collect this operator if the method has four arguments.
              */
-            SendStatus collect(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5)
+            SendStatus collect(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5) const
             {
                 if (cimpl)
                     return cimpl->collect(t1, t2, t3, t4, t5);
                 return SendFailure;
             }
 
-            SendStatus collectIfDone(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5)
+            SendStatus collectIfDone(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5) const
             {
                 if (cimpl)
                     return cimpl->collectIfDone(t1, t2, t3, t4, t5);
@@ -314,14 +314,14 @@ namespace RTT
             /**
              * Collect this operator if the method has four arguments.
              */
-            SendStatus collect(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5, arg6_type t6)
+            SendStatus collect(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5, arg6_type t6) const
             {
                 if (cimpl)
                     return cimpl->collect(t1, t2, t3, t4, t5, t6);
                 return SendFailure;
             }
 
-            SendStatus collectIfDone(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5, arg6_type t6)
+            SendStatus collectIfDone(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5, arg6_type t6) const
             {
                 if (cimpl)
                     return cimpl->collectIfDone(t1, t2, t3, t4, t5, t6);

--- a/rtt/internal/LocalOperationCaller.hpp
+++ b/rtt/internal/LocalOperationCaller.hpp
@@ -201,7 +201,7 @@ namespace RTT
             }
 
 
-            SendStatus collectIfDone_impl() {
+            SendStatus collectIfDone_impl() const {
                 if ( this->retv.isExecuted()) {
                     this->retv.checkError();
                     return SendSuccess;
@@ -212,7 +212,7 @@ namespace RTT
             // collect_impl belongs in LocalOperationCallerImpl because it would need
             // to be repeated in each BindStorage spec.
             template<class T1>
-            SendStatus collectIfDone_impl( T1& a1 ) {
+            SendStatus collectIfDone_impl( T1& a1 ) const {
                 if ( this->retv.isExecuted()) {
                     this->retv.checkError();
                     bf::vector_tie(a1) = bf::filter_if< is_arg_return<boost::remove_reference<mpl::_> > >(this->vStore);
@@ -222,7 +222,7 @@ namespace RTT
             }
 
             template<class T1, class T2>
-            SendStatus collectIfDone_impl( T1& a1, T2& a2 ) {
+            SendStatus collectIfDone_impl( T1& a1, T2& a2 ) const {
                 if ( this->retv.isExecuted()) {
                     this->retv.checkError();
                     bf::vector_tie(a1,a2) = bf::filter_if< is_arg_return<boost::remove_reference<mpl::_> > >(this->vStore);
@@ -232,7 +232,7 @@ namespace RTT
             }
 
             template<class T1, class T2, class T3>
-            SendStatus collectIfDone_impl( T1& a1, T2& a2, T3& a3 ) {
+            SendStatus collectIfDone_impl( T1& a1, T2& a2, T3& a3 ) const {
                 if ( this->retv.isExecuted()) {
                     this->retv.checkError();
                     bf::vector_tie(a1,a2,a3) = bf::filter_if< is_arg_return<boost::remove_reference<mpl::_> > >(this->vStore);
@@ -242,7 +242,7 @@ namespace RTT
             }
 
             template<class T1, class T2, class T3, class T4>
-            SendStatus collectIfDone_impl( T1& a1, T2& a2, T3& a3, T4& a4 ) {
+            SendStatus collectIfDone_impl( T1& a1, T2& a2, T3& a3, T4& a4 ) const {
                 if ( this->retv.isExecuted()) {
                     this->retv.checkError();
                     bf::vector_tie(a1,a2,a3,a4) = bf::filter_if< is_arg_return<boost::remove_reference<mpl::_> > >(this->vStore);
@@ -252,7 +252,7 @@ namespace RTT
             }
 
             template<class T1, class T2, class T3, class T4, class T5>
-            SendStatus collectIfDone_impl( T1& a1, T2& a2, T3& a3, T4& a4, T5& a5 ) {
+            SendStatus collectIfDone_impl( T1& a1, T2& a2, T3& a3, T4& a4, T5& a5 ) const {
                 if ( this->retv.isExecuted()) {
                     this->retv.checkError();
                     bf::vector_tie(a1,a2,a3,a4,a5) = bf::filter_if< is_arg_return<boost::remove_reference<mpl::_> > >(this->vStore);
@@ -262,7 +262,7 @@ namespace RTT
             }
 
             template<class T1, class T2, class T3, class T4, class T5, class T6>
-            SendStatus collectIfDone_impl( T1& a1, T2& a2, T3& a3, T4& a4, T5& a5, T6& a6 ) {
+            SendStatus collectIfDone_impl( T1& a1, T2& a2, T3& a3, T4& a4, T5& a5, T6& a6 ) const {
                 if ( this->retv.isExecuted()) {
                     this->retv.checkError();
                     bf::vector_tie(a1,a2,a3,a4,a5,a6) = bf::filter_if< is_arg_return<boost::remove_reference<mpl::_> > >(this->vStore);
@@ -272,7 +272,7 @@ namespace RTT
             }
 
             template<class T1, class T2, class T3, class T4, class T5, class T6, class T7>
-            SendStatus collectIfDone_impl( T1& a1, T2& a2, T3& a3, T4& a4, T5& a5, T6& a6, T7& a7 ) {
+            SendStatus collectIfDone_impl( T1& a1, T2& a2, T3& a3, T4& a4, T5& a5, T6& a6, T7& a7 ) const {
                 if ( this->retv.isExecuted()) {
                     this->retv.checkError();
                     bf::vector_tie(a1,a2,a3,a4,a5,a6,a7) = bf::filter_if< is_arg_return<boost::remove_reference<mpl::_> > >(this->vStore);
@@ -281,7 +281,7 @@ namespace RTT
                     return SendNotReady;
             }
 
-            bool checkCaller() {
+            bool checkCaller() const {
                 if (!this->caller) {
                     log(Error) << "You're using call() an OwnThread operation or collect() on a sent operation without setting a caller in the OperationCaller. This often causes deadlocks." <<endlog();
                     log(Error) << "Use this->engine() in a component or GlobalEngine::Instance() in a non-component function. Returning a CollectFailure." <<endlog();
@@ -290,55 +290,55 @@ namespace RTT
                 return true;
             }
 
-            SendStatus collect_impl() {
+            SendStatus collect_impl() const {
                 if (!checkCaller()) return CollectFailure;
                 this->caller->waitForMessages( boost::bind(&Store::RStoreType::isExecuted,boost::ref(this->retv)) );
                 return this->collectIfDone_impl();
             }
             template<class T1>
-            SendStatus collect_impl( T1& a1 ) {
+            SendStatus collect_impl( T1& a1 ) const {
                 if (!checkCaller()) return CollectFailure;
                 this->caller->waitForMessages( boost::bind(&Store::RStoreType::isExecuted,boost::ref(this->retv)) );
                 return this->collectIfDone_impl(a1);
             }
 
             template<class T1, class T2>
-            SendStatus collect_impl( T1& a1, T2& a2 ) {
+            SendStatus collect_impl( T1& a1, T2& a2 ) const {
                 if (!checkCaller()) return CollectFailure;
                 this->caller->waitForMessages( boost::bind(&Store::RStoreType::isExecuted,boost::ref(this->retv)) );
                 return this->collectIfDone_impl(a1,a2);
             }
 
             template<class T1, class T2, class T3>
-            SendStatus collect_impl( T1& a1, T2& a2, T3& a3 ) {
+            SendStatus collect_impl( T1& a1, T2& a2, T3& a3 ) const {
                 if (!checkCaller()) return CollectFailure;
                 this->caller->waitForMessages( boost::bind(&Store::RStoreType::isExecuted,boost::ref(this->retv)) );
                 return this->collectIfDone_impl(a1,a2,a3);
             }
 
 	    template<class T1, class T2, class T3, class T4>
-            SendStatus collect_impl( T1& a1, T2& a2, T3& a3, T4& a4) {
+            SendStatus collect_impl( T1& a1, T2& a2, T3& a3, T4& a4) const {
                 if (!checkCaller()) return CollectFailure;
                 this->caller->waitForMessages( boost::bind(&Store::RStoreType::isExecuted,boost::ref(this->retv)) );
                 return this->collectIfDone_impl(a1,a2,a3,a4);
             }
 
 	    template<class T1, class T2, class T3, class T4, class T5>
-	    SendStatus collect_impl( T1& a1, T2& a2, T3& a3, T4& a4, T5& a5) {
+	    SendStatus collect_impl( T1& a1, T2& a2, T3& a3, T4& a4, T5& a5) const {
                 if (!checkCaller()) return CollectFailure;
                 this->caller->waitForMessages( boost::bind(&Store::RStoreType::isExecuted,boost::ref(this->retv)) );
                 return this->collectIfDone_impl(a1,a2,a3,a4, a5);
             }
 
 	    template<class T1, class T2, class T3, class T4, class T5, class T6>
-	    SendStatus collect_impl( T1& a1, T2& a2, T3& a3, T4& a4, T5& a5, T6& a6) {
+	    SendStatus collect_impl( T1& a1, T2& a2, T3& a3, T4& a4, T5& a5, T6& a6) const {
                 if (!checkCaller()) return CollectFailure;
                 this->caller->waitForMessages( boost::bind(&Store::RStoreType::isExecuted,boost::ref(this->retv)) );
                 return this->collectIfDone_impl(a1,a2,a3,a4,a5,a6);
             }
 
 	    template<class T1, class T2, class T3, class T4, class T5, class T6, class T7>
-	    SendStatus collect_impl( T1& a1, T2& a2, T3& a3, T4& a4, T5& a5, T6& a6, T7& a7) {
+	    SendStatus collect_impl( T1& a1, T2& a2, T3& a3, T4& a4, T5& a5, T6& a6, T7& a7) const {
                 if (!checkCaller()) return CollectFailure;
                 this->caller->waitForMessages( boost::bind(&Store::RStoreType::isExecuted,boost::ref(this->retv)) );
                 return this->collectIfDone_impl(a1,a2,a3,a4,a5,a6,a7);
@@ -527,7 +527,7 @@ namespace RTT
                 return NA<result_type>::na();
             }
 
-            result_type ret_impl()
+            result_type ret_impl() const
             {
                 this->retv.checkError();
                 return this->retv.result(); // may return void.
@@ -539,7 +539,7 @@ namespace RTT
              * all arguments.
              */
             template<class T1>
-            result_type ret_impl(T1 a1)
+            result_type ret_impl(T1 a1) const
             {
                 this->retv.checkError();
                 typedef mpl::and_<boost::is_reference<mpl::_>, mpl::not_<boost::is_const<boost::remove_reference<mpl::_> > > > pred;
@@ -550,7 +550,7 @@ namespace RTT
             }
 
             template<class T1,class T2>
-            result_type ret_impl(T1 a1, T2 a2)
+            result_type ret_impl(T1 a1, T2 a2) const
             {
                 this->retv.checkError();
                 typedef mpl::and_<boost::is_reference<mpl::_>, mpl::not_<boost::is_const<boost::remove_reference<mpl::_> > > > pred;
@@ -561,7 +561,7 @@ namespace RTT
             }
 
             template<class T1,class T2, class T3>
-            result_type ret_impl(T1 a1, T2 a2, T3 a3)
+            result_type ret_impl(T1 a1, T2 a2, T3 a3) const
             {
                 this->retv.checkError();
                 typedef mpl::and_<boost::is_reference<mpl::_>, mpl::not_<boost::is_const<boost::remove_reference<mpl::_> > > > pred;
@@ -572,7 +572,7 @@ namespace RTT
             }
 
             template<class T1,class T2, class T3, class T4>
-            result_type ret_impl(T1 a1, T2 a2, T3 a3, T4 a4)
+            result_type ret_impl(T1 a1, T2 a2, T3 a3, T4 a4) const
             {
                 this->retv.checkError();
                 typedef mpl::and_<boost::is_reference<mpl::_>, mpl::not_<boost::is_const<boost::remove_reference<mpl::_> > > > pred;
@@ -583,7 +583,7 @@ namespace RTT
             }
 
             template<class T1,class T2, class T3, class T4, class T5>
-            result_type ret_impl(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5)
+            result_type ret_impl(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5) const
             {
                 this->retv.checkError();
                 typedef mpl::and_<boost::is_reference<mpl::_>, mpl::not_<boost::is_const<boost::remove_reference<mpl::_> > > > pred;
@@ -594,7 +594,7 @@ namespace RTT
             }
 
             template<class T1,class T2, class T3, class T4, class T5, class T6>
-            result_type ret_impl(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6)
+            result_type ret_impl(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6) const
             {
                 this->retv.checkError();
                 typedef mpl::and_<boost::is_reference<mpl::_>, mpl::not_<boost::is_const<boost::remove_reference<mpl::_> > > > pred;
@@ -605,7 +605,7 @@ namespace RTT
             }
 
             template<class T1,class T2, class T3, class T4, class T5, class T6, class T7>
-            result_type ret_impl(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7)
+            result_type ret_impl(T1 a1, T2 a2, T3 a3, T4 a4, T5 a5, T6 a6, T7 a7) const
             {
                 this->retv.checkError();
                 typedef mpl::and_<boost::is_reference<mpl::_>, mpl::not_<boost::is_const<boost::remove_reference<mpl::_> > > > pred;

--- a/rtt/internal/ReturnSignature.hpp
+++ b/rtt/internal/ReturnSignature.hpp
@@ -65,7 +65,7 @@ namespace RTT
             ReturnSignature(ToInvoke implementation) : impl(implementation) {}
             ~ReturnSignature() {}
 
-            result_type ret() {
+            result_type ret() const {
                 if (impl)
                     return impl->ret();
                 return NA<result_type>::na();
@@ -85,13 +85,13 @@ namespace RTT
             ReturnSignature(ToInvoke implementation) : impl(implementation) {}
             ~ReturnSignature() {}
 
-            result_type ret(arg1_type a1) {
+            result_type ret(arg1_type a1) const {
                 if (impl)
                     return impl->ret( a1 );
                 return NA<result_type>::na();
             }
 
-            result_type ret() {
+            result_type ret() const {
                 if (impl)
                     return impl->ret();
                 return NA<result_type>::na();
@@ -112,13 +112,13 @@ namespace RTT
             ReturnSignature(ToInvoke implementation) : impl(implementation) {}
             ~ReturnSignature() {}
 
-            result_type ret(arg1_type a1, arg2_type a2) {
+            result_type ret(arg1_type a1, arg2_type a2) const {
                 if (impl)
                     return impl->ret( a1,a2 );
                 return NA<result_type>::na();
             }
 
-            result_type ret() {
+            result_type ret() const {
                 if (impl)
                     return impl->ret();
                 return NA<result_type>::na();
@@ -139,13 +139,13 @@ namespace RTT
             ReturnSignature(ToInvoke implementation) : impl(implementation) {}
             ~ReturnSignature() { }
 
-            result_type ret(arg1_type a1, arg2_type a2, arg3_type a3) {
+            result_type ret(arg1_type a1, arg2_type a2, arg3_type a3) const {
                 if (impl)
                     return impl->ret( a1,a2,a3 );
                 return NA<result_type>::na();
             }
 
-            result_type ret() {
+            result_type ret() const {
                 if (impl)
                     return impl->ret();
                 return NA<result_type>::na();
@@ -168,13 +168,13 @@ namespace RTT
             ReturnSignature(ToInvoke implementation) : impl(implementation) {}
             ~ReturnSignature() { }
 
-            result_type ret(arg1_type a1, arg2_type a2, arg3_type a3, arg4_type a4) {
+            result_type ret(arg1_type a1, arg2_type a2, arg3_type a3, arg4_type a4) const {
                 if (impl)
                     return impl->ret( a1,a2,a3,a4 );
                 return NA<result_type>::na();
             }
 
-            result_type ret() {
+            result_type ret() const {
                 if (impl)
                     return impl->ret();
                 return NA<result_type>::na();
@@ -197,13 +197,13 @@ namespace RTT
             ReturnSignature(ToInvoke implementation) : impl(implementation) {}
             ~ReturnSignature() { }
 
-            result_type ret(arg1_type a1, arg2_type a2, arg3_type a3, arg4_type a4, arg5_type a5) {
+            result_type ret(arg1_type a1, arg2_type a2, arg3_type a3, arg4_type a4, arg5_type a5) const {
                 if (impl)
                     return impl->ret( a1,a2,a3,a4,a5 );
                 return NA<result_type>::na();
             }
 
-            result_type ret() {
+            result_type ret() const {
                 if (impl)
                     return impl->ret();
                 return NA<result_type>::na();
@@ -227,13 +227,13 @@ namespace RTT
             ReturnSignature(ToInvoke implementation) : impl(implementation) {}
             ~ReturnSignature() { }
 
-            result_type ret(arg1_type a1, arg2_type a2, arg3_type a3, arg4_type a4, arg5_type a5, arg6_type a6) {
+            result_type ret(arg1_type a1, arg2_type a2, arg3_type a3, arg4_type a4, arg5_type a5, arg6_type a6) const {
                 if (impl)
                     return impl->ret( a1,a2,a3,a4,a5,a6 );
                 return NA<result_type>::na();
             }
 
-            result_type ret() {
+            result_type ret() const {
                 if (impl)
                     return impl->ret();
                 return NA<result_type>::na();
@@ -258,13 +258,13 @@ namespace RTT
             ReturnSignature(ToInvoke implementation) : impl(implementation) {}
             ~ReturnSignature() { }
 
-            result_type ret(arg1_type a1, arg2_type a2, arg3_type a3, arg4_type a4, arg5_type a5, arg6_type a6, arg7_type a7) {
+            result_type ret(arg1_type a1, arg2_type a2, arg3_type a3, arg4_type a4, arg5_type a5, arg6_type a6, arg7_type a7) const {
                 if (impl)
                     return impl->ret( a1,a2,a3,a4,a5,a6,a7 );
                 return NA<result_type>::na();
             }
 
-            result_type ret() {
+            result_type ret() const {
                 if (impl)
                     return impl->ret();
                 return NA<result_type>::na();


### PR DESCRIPTION
From https://github.com/orocos-toolchain/rtt/commit/ed8401254918465a5613f5f2574c04c1514c95e8 (by @psoetens):
> There was no need to have this non-const. non-const prevented us to use it on a `const&` to a `SendHandle`, which we do need if the `SendHandle` is presented by a `DataSource`.

This commit is part of unmerged https://github.com/orocos-toolchain/rtt/pull/84, but actually independent.