### PR TITLE
Fix multi-signal emission in case of fused functor data source callbacks

### DIFF
--- a/rtt/internal/BindStorage.hpp
+++ b/rtt/internal/BindStorage.hpp
@@ -289,7 +289,7 @@ namespace RTT
             typename Signal<ToBind>::shared_ptr msig;
 #endif
 
-            BindStorageImpl() :  vStore(boost::ref(retv)) {}
+            BindStorageImpl() :  vStore(retv) {}
             BindStorageImpl(const BindStorageImpl& orig) : mmeth(orig.mmeth), vStore(retv)
 #ifdef ORO_SIGNALLING_OPERATIONS
                                                          , msig(orig.msig)
@@ -337,10 +337,10 @@ namespace RTT
             void store(arg1_type t1) { a1(t1); }
             void exec() {
 #ifdef ORO_SIGNALLING_OPERATIONS
-                if (msig) (*msig)(a1.get());
+                if (msig) (*msig)(a1);
 #endif
                 if (mmeth)
-                    retv.exec( boost::bind(mmeth, boost::ref(a1.get()) ) );
+                    retv.exec( boost::bind(mmeth, a1 ) );
                 else
                     retv.executed = true;
             }
@@ -377,10 +377,10 @@ namespace RTT
             void store(arg1_type t1, arg2_type t2) { a1(t1); a2(t2); }
             void exec() {
 #ifdef ORO_SIGNALLING_OPERATIONS
-                if (msig) (*msig)(a1.get(), a2.get());
+                if (msig) (*msig)(a1, a2);
 #endif
                 if (mmeth)
-                    retv.exec( boost::bind(mmeth, boost::ref(a1.get()), boost::ref(a2.get()) ) );
+                    retv.exec( boost::bind(mmeth, a1, a2 ) );
                 else
                     retv.executed = true;
             }
@@ -419,10 +419,10 @@ namespace RTT
             void store(arg1_type t1, arg2_type t2, arg3_type t3) { a1(t1); a2(t2); a3(t3); }
             void exec() {
 #ifdef ORO_SIGNALLING_OPERATIONS
-                if (msig) (*msig)(a1.get(), a2.get(), a3.get());
+                if (msig) (*msig)(a1, a2, a3);
 #endif
                 if (mmeth)
-                    retv.exec( boost::bind(mmeth, boost::ref(a1.get()), boost::ref(a2.get()), boost::ref(a3.get()) ) );
+                    retv.exec( boost::bind(mmeth, a1, a2, a3 ) );
                 else
                     retv.executed = true;
             }
@@ -462,10 +462,10 @@ namespace RTT
             void store(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4) { a1(t1); a2(t2); a3(t3); a4(t4); }
             void exec() {
 #ifdef ORO_SIGNALLING_OPERATIONS
-                if (msig) (*msig)(a1.get(), a2.get(), a3.get(), a4.get());
+                if (msig) (*msig)(a1, a2, a3, a4);
 #endif
                 if (mmeth)
-                    retv.exec( boost::bind( mmeth, boost::ref(a1.get()), boost::ref(a2.get()), boost::ref(a3.get()), boost::ref(a4.get()) ) );
+                    retv.exec( boost::bind( mmeth, a1, a2, a3, a4 ) );
                 else
                     retv.executed = true;
             }
@@ -507,10 +507,10 @@ namespace RTT
             void store(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5) { a1(t1); a2(t2); a3(t3); a4(t4); a5(t5);}
             void exec() {
 #ifdef ORO_SIGNALLING_OPERATIONS
-                if (msig) (*msig)(a1.get(), a2.get(), a3.get(), a4.get(), a5.get());
+                if (msig) (*msig)(a1, a2, a3, a4, a5);
 #endif
                 if (mmeth)
-                    retv.exec( boost::bind( mmeth, boost::ref(a1.get()), boost::ref(a2.get()), boost::ref(a3.get()), boost::ref(a4.get()), boost::ref(a5.get()) ) );
+                    retv.exec( boost::bind( mmeth, a1, a2, a3, a4, a5 ) );
                 else
                     retv.executed = true;
             }
@@ -554,10 +554,10 @@ namespace RTT
             void store(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5, arg6_type t6) { a1(t1); a2(t2); a3(t3); a4(t4); a5(t5); a6(t6);}
             void exec() {
 #ifdef ORO_SIGNALLING_OPERATIONS
-                if (msig) (*msig)(a1.get(), a2.get(), a3.get(), a4.get(), a5.get(), a6.get());
+                if (msig) (*msig)(a1, a2, a3, a4, a5, a6);
 #endif
                 if (mmeth)
-                    retv.exec( boost::bind( mmeth, boost::ref(a1.get()), boost::ref(a2.get()), boost::ref(a3.get()), boost::ref(a4.get()), boost::ref(a5.get()), boost::ref(a6.get()) ) );
+                    retv.exec( boost::bind( mmeth, a1, a2, a3, a4, a5, a6 ) );
                 else
                     retv.executed = true;
             }
@@ -603,10 +603,10 @@ namespace RTT
             void store(arg1_type t1, arg2_type t2, arg3_type t3, arg4_type t4, arg5_type t5, arg6_type t6, arg7_type t7) { a1(t1); a2(t2); a3(t3); a4(t4); a5(t5); a6(t6); a7(t7);}
             void exec() {
 #ifdef ORO_SIGNALLING_OPERATIONS
-                if (msig) (*msig)(a1.get(), a2.get(), a3.get(), a4.get(), a5.get(), a6.get(), a7.get());
+                if (msig) (*msig)(a1, a2, a3, a4, a5, a6, a7);
 #endif
                 if (mmeth)
-                    retv.exec( boost::bind( mmeth, boost::ref(a1.get()), boost::ref(a2.get()), boost::ref(a3.get()), boost::ref(a4.get()), boost::ref(a5.get()), boost::ref(a6.get()), boost::ref(a7.get()) ) );
+                    retv.exec( boost::bind( mmeth, a1, a2, a3, a4, a5, a6, a7 ) );
                 else
                     retv.executed = true;
             }

--- a/rtt/internal/BindStorage.hpp
+++ b/rtt/internal/BindStorage.hpp
@@ -71,7 +71,7 @@ namespace RTT
 
             T& get() { return arg; }
             void operator()(T a) { arg = a; }
-            operator T() { return arg;}
+            operator T&() { return arg; }
         };
 
         template<class T>
@@ -84,7 +84,7 @@ namespace RTT
 
             T& get() { return *arg; }
             void operator()(T& a) { arg = &a; }
-            operator T&() { return *arg;}
+            operator T&() { return *arg; }
         };
 
         template<class T>

--- a/rtt/internal/BindStorage.hpp
+++ b/rtt/internal/BindStorage.hpp
@@ -64,6 +64,7 @@ namespace RTT
         template<class T>
         struct AStore
         {
+            typedef T arg_type;
             T arg;
             AStore() : arg() {}
             AStore(T t) : arg(t) {}
@@ -77,6 +78,7 @@ namespace RTT
         template<class T>
         struct AStore<T&>
         {
+            typedef T& arg_type;
             T* arg;
             AStore() : arg( &NA<T&>::na() ) {}
             AStore(T& t) : arg(&t) {}

--- a/rtt/internal/CreateSequence.hpp
+++ b/rtt/internal/CreateSequence.hpp
@@ -81,8 +81,10 @@ namespace RTT
             DataStore(DataStore const& o) : arg(o.arg) {}
 
             T& get() { return arg; }
+            T const& get() const { return arg; }
             void operator()(T a) { arg = a; }
             operator T() { return arg;}
+            operator T const&() const { return arg;}
         };
 
         template<class T>
@@ -95,8 +97,10 @@ namespace RTT
             DataStore(DataStore const& o) : arg(o.arg) {}
 
             T& get() { return *arg; }
+            T const& get() const { return *arg; }
             void operator()(T& a) { arg = &a; }
             operator T&() { return *arg;}
+            operator T const&() const { return *arg;}
         };
 
         /**
@@ -154,7 +158,10 @@ namespace RTT
                 typedef typename ds_type::element_type element_type;
 
                 ds_type a =
-                    boost::dynamic_pointer_cast< element_type >( DataSourceTypeInfo<ds_arg_type>::getTypeInfo()->convert(*front) );
+                    boost::dynamic_pointer_cast< element_type >( *front );
+                if ( ! a ) {
+                    a = boost::dynamic_pointer_cast< element_type >( DataSourceTypeInfo<ds_arg_type>::getTypeInfo()->convert(*front) );
+                }
                 if ( ! a ) {
                     //cout << typeid(DataSource<ds_arg_type>).name() << endl;
                     ORO_THROW_OR_RETURN(wrong_types_of_args_exception( argnbr, tname, (*front)->getType() ), ds_type());
@@ -166,8 +173,10 @@ namespace RTT
             template<class ds_arg_type, class ads_type>
             static ads_type assignable(std::vector<base::DataSourceBase::shared_ptr>::const_iterator front, int argnbr, std::string const& tname )
             {
+                typedef typename ads_type::element_type element_type;
+
                 ads_type a =
-                    boost::dynamic_pointer_cast< AssignableDataSource<ds_arg_type> >( *front ); // note: no conversion done, must be same type.
+                    boost::dynamic_pointer_cast< element_type >( *front ); // note: no conversion done, must be same type.
                 if ( ! a ) {
                     ORO_THROW_OR_RETURN(wrong_types_of_args_exception( argnbr, tname, (*front)->getType() ), ads_type());
                 }

--- a/rtt/internal/CreateSequence.hpp
+++ b/rtt/internal/CreateSequence.hpp
@@ -51,6 +51,7 @@
 #include <boost/fusion/mpl.hpp>
 #include <boost/utility/enable_if.hpp>
 
+#include "BindStorage.hpp"
 #include "DataSource.hpp"
 #include "Exceptions.hpp"
 #include "../FactoryExceptions.hpp"
@@ -64,40 +65,6 @@ namespace RTT
     {
         namespace bf = boost::fusion;
         namespace mpl = boost::mpl;
-
-        /**
-         * Store a bound argument which may be a reference, const reference or
-         * any other type.
-         * This class was required to store (const) references, after the reference object storage
-         * was created. Copy of RTT::internal::AStore in BindStorage.hpp.
-         */
-        template<class T>
-        struct DataStore
-        {
-            typedef T arg_type;
-            T arg;
-            DataStore() : arg() {}
-            DataStore(T t) : arg(t) {}
-            DataStore(DataStore const& o) : arg(o.arg) {}
-
-            T& get() { return arg; }
-            void operator()(T a) { arg = a; }
-            operator T&() { return arg; }
-        };
-
-        template<class T>
-        struct DataStore<T&>
-        {
-            typedef T& arg_type;
-            T* arg;
-            DataStore() : arg( &NA<T&>::na() ) {}
-            DataStore(T& t) : arg(&t) {}
-            DataStore(DataStore const& o) : arg(o.arg) {}
-
-            T& get() { return *arg; }
-            void operator()(T& a) { arg = &a; }
-            operator T&() { return *arg; }
-        };
 
         /**
          * Helper class for extracting the bare pointer from a shared_ptr
@@ -233,7 +200,7 @@ namespace RTT
             /**
              * The argument storage type
              */
-            typedef DataStore<arg_type> arg_store_type;
+            typedef AStore<arg_type> arg_store_type;
 
             /**
              * The data source value type of an assignable data source is non-const, non-reference.
@@ -348,7 +315,7 @@ namespace RTT
              * We must return the resulting sequence by value, since boost fusion
              * returns temporaries, which we can't take a reference to.
              * @param in The values to store
-             * @return The receiving DataStore sequence.
+             * @return The receiving AStore sequence.
              */
             static data_store_type store(const data_type& in ) {
                 return data_store_type(bf::front(in), tail::store(bf::pop_front(in)));
@@ -419,7 +386,7 @@ namespace RTT
             typedef typename remove_cr<arg_type>::type ds_arg_type;
             typedef bf::cons<arg_type> data_type;
 
-            typedef DataStore<arg_type> arg_store_type;
+            typedef AStore<arg_type> arg_store_type;
             typedef bf::cons<arg_store_type > data_store_type;
 
             /**

--- a/rtt/internal/CreateSequence.hpp
+++ b/rtt/internal/CreateSequence.hpp
@@ -81,10 +81,8 @@ namespace RTT
             DataStore(DataStore const& o) : arg(o.arg) {}
 
             T& get() { return arg; }
-            T const& get() const { return arg; }
             void operator()(T a) { arg = a; }
-            operator T() { return arg;}
-            operator T const&() const { return arg;}
+            operator T&() { return arg; }
         };
 
         template<class T>
@@ -97,10 +95,8 @@ namespace RTT
             DataStore(DataStore const& o) : arg(o.arg) {}
 
             T& get() { return *arg; }
-            T const& get() const { return *arg; }
             void operator()(T& a) { arg = &a; }
-            operator T&() { return *arg;}
-            operator T const&() const { return *arg;}
+            operator T&() { return *arg; }
         };
 
         /**

--- a/rtt/internal/FusedFunctorDataSource.hpp
+++ b/rtt/internal/FusedFunctorDataSource.hpp
@@ -55,6 +55,9 @@
 #include <boost/mpl/bool.hpp>
 #include <boost/make_shared.hpp>
 
+#include <iostream>
+using namespace std;
+
 namespace RTT
 {
     namespace internal
@@ -475,6 +478,9 @@ namespace RTT
                     typename boost::function_types::parameter_types<Signature>::type> SequenceFactory;
             typedef typename SequenceFactory::atype DataSourceSequence;
             boost::shared_ptr<base::ActionInterface> mact;
+            // We need the arg_cache to store data similar to BindStorage,
+            // such that we can safely access it during execute().
+            typename SequenceFactory::data_store_type arg_cache;
             DataSourceSequence args;
             ExecutionEngine* subscriber;
             /**
@@ -512,8 +518,7 @@ namespace RTT
                 if ( subscriber ) {
                     // asynchronous
                     shared_ptr sg = this->cloneRT();
-                    SequenceFactory::set( seq, sg->args );
-                  
+                    sg->arg_cache = SequenceFactory::store(seq);
                     sg->self = sg;
                     if ( subscriber->process( sg.get() ) ) {
                         // all ok
@@ -530,6 +535,7 @@ namespace RTT
             }
 
             void executeAndDispose() {
+                SequenceFactory::load( this->arg_cache, this->args );
                 mact->execute();
                 dispose();
             }

--- a/rtt/internal/FusedFunctorDataSource.hpp
+++ b/rtt/internal/FusedFunctorDataSource.hpp
@@ -55,9 +55,6 @@
 #include <boost/mpl/bool.hpp>
 #include <boost/make_shared.hpp>
 
-#include <iostream>
-using namespace std;
-
 namespace RTT
 {
     namespace internal


### PR DESCRIPTION
This is a bunch of patches in `toolchain-2.9` that have not yet been on any pull request so far:

From https://github.com/orocos-toolchain/rtt/commit/619fce27b36bfb5abaaeb68ba9ba8fb1683747aa (by @psoetens):
> signals: fix multi-signal emission in case of fused functor data source callbacks
> 
> When an operation was called twice in a row, and a signal callback was installed
using datasource semantics (with produceSignal() ), both callbacks would most
likely receive twice the same data, being equal to the last operation call's values,
since before the callbacks are dispatched, the data sources are already filled in.
The last write wins and the first call-back sees the data of the last.
> 
> This patch fixes that by defining a data_store_type in create_sequence with a
store() and a load() function. The fused signal callback can now first store
the args of the operation, then dispatch and retrieve them later on in the
callback function.

A later patch removed the new `DataStore<T>` class defined in [CreateSequence.hpp](https://github.com/orocos-toolchain/rtt/blob/ca0c42bab65f2696a304ea6935fda13a902e1c6e/rtt/internal/CreateSequence.hpp) again. Instead we use `AStore<T>` already defined in [BindStorage.hpp](https://github.com/orocos-toolchain/rtt/blob/ca0c42bab65f2696a304ea6935fda13a902e1c6e/rtt/internal/BindStorage.hpp) involved in operation calls.

The last patch, https://github.com/orocos-toolchain/rtt/commit/ca0c42bab65f2696a304ea6935fda13a902e1c6e, removes a `using namespace std` directive in [FusedFunctorDataSource.hpp](https://github.com/orocos-toolchain/rtt/blob/ca0c42bab65f2696a304ea6935fda13a902e1c6e%5E/rtt/internal/FusedFunctorDataSource.hpp#L58:L59), probably a leftover from debugging https://github.com/orocos-toolchain/rtt/commit/619fce27b36bfb5abaaeb68ba9ba8fb1683747aa. This commit was cherry-picked directly to `toolchain-2.9` as 23f826a95b986641c70226f9ee50874a4f0d201e.