### PR TITLE
corba: manage links to Service instances in weak pointers [master]

### DIFF
--- a/rtt/transports/corba/ServiceI.cpp
+++ b/rtt/transports/corba/ServiceI.cpp
@@ -94,19 +94,19 @@ PortableServer::POA_ptr RTT_corba_CService_i::_default_POA()
 char * RTT_corba_CService_i::getName (
     void)
 {
-    return CORBA::string_dup( mservice->getName().c_str() );
+    return CORBA::string_dup( mservice.lock()->getName().c_str() );
 }
 
 char * RTT_corba_CService_i::getServiceDescription (
     void)
 {
-    return CORBA::string_dup( mservice->doc().c_str() );
+    return CORBA::string_dup( mservice.lock()->doc().c_str() );
 }
 
 ::RTT::corba::CService::CProviderNames * RTT_corba_CService_i::getProviderNames (
     void)
 {
-    Service::ProviderNames names = mservice->getProviderNames();
+    Service::ProviderNames names = mservice.lock()->getProviderNames();
     ::RTT::corba::CService::CProviderNames_var result = new ::RTT::corba::CService::CProviderNames();
     result->length( names.size() );
     for (unsigned int i=0; i != names.size(); ++i )
@@ -122,7 +122,7 @@ char * RTT_corba_CService_i::getServiceDescription (
     if ( svc == "this" )
         return _this();
 
-    Service::shared_ptr provider = mservice->getService(svc);
+    Service::shared_ptr provider = mservice.lock()->getService(svc);
     if ( !provider )
     	return RTT::corba::CService::_nil();
 
@@ -143,7 +143,7 @@ char * RTT_corba_CService_i::getServiceDescription (
 ::CORBA::Boolean RTT_corba_CService_i::hasService (
     const char * name)
 {
-    return mservice->hasService( name );
+    return mservice.lock()->hasService( name );
 }
 
 ::RTT::corba::CServiceDescription * RTT_corba_CService_i::getCServiceDescription (
@@ -168,7 +168,7 @@ char * RTT_corba_CService_i::getServiceDescription (
     d->attributes = attributes;
 
     // Child services
-    Service::ProviderNames providers = mservice->getProviderNames();
+    Service::ProviderNames providers = mservice.lock()->getProviderNames();
     d->children.length( providers.size() );
     d->children_descriptions.length( providers.size() );
     j = 0;
@@ -177,7 +177,7 @@ char * RTT_corba_CService_i::getServiceDescription (
         if (providers[i] == "this") continue;
 
         // omit PortObject services
-        if (mservice->getPort(providers[i])) continue;
+        if (mservice.lock()->getPort(providers[i])) continue;
 
         ::RTT::corba::CService_ptr provider = getService(providers[i].c_str());
         Servants::const_iterator it = mservs.find(providers[i]);

--- a/rtt/transports/corba/ServiceI.cpp
+++ b/rtt/transports/corba/ServiceI.cpp
@@ -94,19 +94,22 @@ PortableServer::POA_ptr RTT_corba_CService_i::_default_POA()
 char * RTT_corba_CService_i::getName (
     void)
 {
-    return CORBA::string_dup( mservice.lock()->getName().c_str() );
+    Service::shared_ptr service(mservice);
+    return CORBA::string_dup( service->getName().c_str() );
 }
 
 char * RTT_corba_CService_i::getServiceDescription (
     void)
 {
-    return CORBA::string_dup( mservice.lock()->doc().c_str() );
+    Service::shared_ptr service(mservice);
+    return CORBA::string_dup( service->doc().c_str() );
 }
 
 ::RTT::corba::CService::CProviderNames * RTT_corba_CService_i::getProviderNames (
     void)
 {
-    Service::ProviderNames names = mservice.lock()->getProviderNames();
+    Service::shared_ptr service(mservice);
+    Service::ProviderNames names = service->getProviderNames();
     ::RTT::corba::CService::CProviderNames_var result = new ::RTT::corba::CService::CProviderNames();
     result->length( names.size() );
     for (unsigned int i=0; i != names.size(); ++i )
@@ -122,7 +125,8 @@ char * RTT_corba_CService_i::getServiceDescription (
     if ( svc == "this" )
         return _this();
 
-    Service::shared_ptr provider = mservice.lock()->getService(svc);
+    Service::shared_ptr service(mservice);
+    Service::shared_ptr provider = service->getService(svc);
     if ( !provider )
     	return RTT::corba::CService::_nil();
 
@@ -143,12 +147,14 @@ char * RTT_corba_CService_i::getServiceDescription (
 ::CORBA::Boolean RTT_corba_CService_i::hasService (
     const char * name)
 {
-    return mservice.lock()->hasService( name );
+    Service::shared_ptr service(mservice);
+    return service->hasService( name );
 }
 
 ::RTT::corba::CServiceDescription * RTT_corba_CService_i::getCServiceDescription (
     void)
 {
+    Service::shared_ptr service(mservice);
     ::RTT::corba::CServiceDescription_var d = new ::RTT::corba::CServiceDescription;
     unsigned int j = 0;
 
@@ -168,7 +174,7 @@ char * RTT_corba_CService_i::getServiceDescription (
     d->attributes = attributes;
 
     // Child services
-    Service::ProviderNames providers = mservice.lock()->getProviderNames();
+    Service::ProviderNames providers = service->getProviderNames();
     d->children.length( providers.size() );
     d->children_descriptions.length( providers.size() );
     j = 0;
@@ -177,7 +183,7 @@ char * RTT_corba_CService_i::getServiceDescription (
         if (providers[i] == "this") continue;
 
         // omit PortObject services
-        if (mservice.lock()->getPort(providers[i])) continue;
+        if (service->getPort(providers[i])) continue;
 
         ::RTT::corba::CService_ptr provider = getService(providers[i].c_str());
         Servants::const_iterator it = mservs.find(providers[i]);

--- a/rtt/transports/corba/ServiceI.h
+++ b/rtt/transports/corba/ServiceI.h
@@ -93,7 +93,7 @@ class  RTT_corba_CService_i
 {
 protected:
     PortableServer::POA_var mpoa;
-    RTT::Service::shared_ptr mservice;
+    boost::weak_ptr<RTT::Service> mservice;
     // child services
     typedef std::map<std::string, std::pair<RTT::corba::CService_var,PortableServer::ServantBase_var> > Servants;
     Servants mservs;


### PR DESCRIPTION
Follow-up on #238, but targeting master now:
> The CORBA layer should not delay the destruction of Service instances once the owning TaskContext gets destroyed. Accessing a destroyed service instance through CORBA would result in a bad_weak_ptr exception now which is handled by the CORBA implementation, but does not cause a segfault.

The usage of the `weak_ptr` instances in #238 was actually invalid: The intention was to trigger an exception when dereferencing an expired weak pointer, which is then returned to the caller through the CORBA layer. But [boost::weak_ptr<T>::lock()](https://www.boost.org/doc/libs/1_70_0/libs/smart_ptr/doc/html/smart_ptr.html#weak_ptr_lock) does not throw and might return a null pointer, which would result in a segmentation fault instead. Not better than before the patch, but at least it resolved the problem that CORBA cannot prevent RTT service instances from being destroyed. Only constructing a `shared_ptr` from an expired `weak_ptr` actually throws a `bad_weak_ptr` exception.

For completeness it would be nice to also use weak pointers in [DataFlowI](https://github.com/meyerj/rtt/blob/1fdce17c6c7578e58cea28b081359f05bf13f970/rtt/transports/corba/DataFlowI.h), [OperationInterfaceI](https://github.com/meyerj/rtt/blob/1fdce17c6c7578e58cea28b081359f05bf13f970/rtt/transports/corba/OperationInterfaceI.h) and [ConfigurationInterfaceI](https://github.com/meyerj/rtt/blob/1fdce17c6c7578e58cea28b081359f05bf13f970/rtt/transports/corba/ConfigurationInterfaceI.h), which all have simple raw pointers to their actual non-corba implementations. But it is not straight-forward to apply a similar patch to those servants, because they are not always constructed from a `shared_ptr` instance. Depending on how they are used within RTT and the CORBA transport layer, dangling servant instances might continue to exist while the actual object has already been destroyed. Calls from a remote would then trigger segmentation faults.

Only port connections should be able to handle disconnection and destruction correctly because they notify the remote end before.

RTT does not depend on C++11 features yet. Otherwise the same could have been done with [std::weak_ptr](https://en.cppreference.com/w/cpp/memory/weak_ptr).