### PR TITLE
[WIP] fix deadlock in concurrent connection disconnection

### DIFF
--- a/rtt/base/ChannelElement.hpp
+++ b/rtt/base/ChannelElement.hpp
@@ -98,7 +98,7 @@ namespace RTT { namespace base {
         }
 
         /** Writes a new sample on this connection. \a sample is the sample to
-         * write. 
+         * write.
          *
          * @returns false if an error occured that requires the channel to be invalidated. In no ways it indicates that the sample has been received by the other side of the channel.
          */
@@ -241,6 +241,12 @@ namespace RTT { namespace base {
         {
             if (last == input) last = 0;
             MultipleInputsChannelElementBase::removeInput(input);
+        }
+
+        virtual void removedInputs(Inputs const& inputs)
+        {
+            if (find(inputs.begin(), inputs.end(), last) != inputs.end())
+                last = 0;
         }
 
     private:

--- a/rtt/base/ChannelElementBase.hpp
+++ b/rtt/base/ChannelElementBase.hpp
@@ -248,11 +248,11 @@ namespace RTT { namespace base {
         }
 
         /**
-         * This function may be used to identify, 
+         * This function may be used to identify,
          * if the current element uses a network
          * transport, to send the data to the next
          * Element in the logical chain.
-         * 
+         *
          * @return true if a network transport is used.
          * */
         virtual bool isRemoteElement() const;
@@ -264,7 +264,7 @@ namespace RTT { namespace base {
          * E.g: In the local case output->getLocalURI()
          * In the remote case the URI of the remote
          * channel element.
-         * 
+         *
          * @return URI of the next element.
          * */
         virtual std::string getRemoteURI() const;
@@ -278,7 +278,7 @@ namespace RTT { namespace base {
 
         /**
          * Returns the class name of this
-         * element. This is primary useful 
+         * element. This is primary useful
          * for special case handling in the
          * connection tracking.
          * @return The name of the class of the ChannelElement
@@ -372,6 +372,8 @@ namespace RTT { namespace base {
         bool signalFrom(ChannelElementBase *caller);
 
     protected:
+        bool disconnectSingleInputChannel(ChannelElementBase::shared_ptr const& channel, bool forward);
+
         /**
          * Sets the new input channel element of this element or adds a channel to the inputs list.
          * @param input the previous element in chain.
@@ -384,6 +386,8 @@ namespace RTT { namespace base {
          * @param input the element to be removed
          */
         virtual void removeInput(ChannelElementBase::shared_ptr const& input);
+
+        virtual void removedInputs(Inputs const& inputs) = 0;
     };
 
     /**
@@ -435,6 +439,15 @@ namespace RTT { namespace base {
         virtual bool disconnect(ChannelElementBase::shared_ptr const& channel, bool forward = false);
 
     protected:
+        /**
+         * Disconnects a single channel
+         *
+         * \ref disconnect's channel argument may be null, which is meant to indicate that
+         * all channels must be disconnected. This method handles the non-null case for
+         * clarity.
+         */
+        bool disconnectSingleOutputChannel(ChannelElementBase::shared_ptr const& channel, bool forward);
+
         /**
          * Sets the new output channel element of this element or adds a channel to the outputs list.
          * @param output the next element in chain.

--- a/rtt/internal/ConnectionManager.hpp
+++ b/rtt/internal/ConnectionManager.hpp
@@ -163,8 +163,13 @@ namespace RTT
             /** Helper method for disconnect()
              *
              * Unconditionally removes the given connection and returns the next connection in the list or connections.end()
+             *
+             * It requires the lock to be taken, but does not perform any disconnection itself
              */
-            Connections::iterator eraseConnection(const Connections::iterator& descriptor, bool disconnect);
+            Connections::iterator eraseConnection(const Connections::iterator& descriptor, Connections& erased);
+
+            /** Helper for disconnection methods */
+            void disconnectConnections(Connections& connections);
 
             /**
              * The port for which we manage connections.

--- a/tests/ports_test.cpp
+++ b/tests/ports_test.cpp
@@ -1185,6 +1185,11 @@ public:
     InputPort<T> another_input_port;
     PortConnectorThread another_output_connector, another_input_connector;
 
+    OutputPort<T> forward_backward_output_port;
+    InputPort<T> forward_backward_input_port;
+    PortConnectorThread forward_connector;
+    PortConnectorThread backward_connector;
+
 public:
     ConcurrencyPortsTestFixture()
         : writer()
@@ -1194,6 +1199,8 @@ public:
         , another_input_port("another_input_port")
         , another_output_connector(another_output_port, reader.port)
         , another_input_connector(another_input_port, writer.port)
+        , forward_connector(forward_backward_output_port, forward_backward_input_port)
+        , backward_connector(forward_backward_input_port, forward_backward_output_port)
     {}
 
     ~ConcurrencyPortsTestFixture()
@@ -1214,6 +1221,8 @@ public:
         reader.port.disconnect();
         another_output_port.disconnect();
         another_input_port.disconnect();
+        forward_backward_output_port.disconnect();
+        forward_backward_input_port.disconnect();
     }
 
     bool start()
@@ -1224,6 +1233,8 @@ public:
         result = connector.start() && result;
         result = another_output_connector.start() && result;
         result = another_input_connector.start() && result;
+        result = forward_connector.start() && result;
+        result = backward_connector.start() && result;
         return true;
     }
 
@@ -1235,6 +1246,8 @@ public:
         result = connector.stop() && result;
         result = another_output_connector.stop() && result;
         result = another_input_connector.stop() && result;
+        result = forward_connector.stop() && result;
+        result = backward_connector.stop() && result;
         return true;
     }
 };
@@ -1275,6 +1288,18 @@ BOOST_AUTO_TEST_CASE( testConcurrencyPerConnection )
     BOOST_CHECK_GE( another_input_connector.connect_counter, 100 );
     BOOST_CHECK_EQUAL( another_input_connector.connect_failure_counter, 0 );
     BOOST_CHECK_EQUAL( another_input_connector.disconnect_failure_counter, 0 );
+    BOOST_TEST_MESSAGE("Number of connects/disconnects to the forward connector:     "
+                       << forward_connector.connect_counter << "/" << backward_connector.disconnect_counter
+                       << " (" << forward_connector.connect_failure_counter << "/" << forward_connector.disconnect_failure_counter << " failures)");
+    BOOST_CHECK_GE( forward_connector.connect_counter, 100 );
+    BOOST_CHECK_EQUAL( forward_connector.connect_failure_counter, 0 );
+    BOOST_CHECK_EQUAL( forward_connector.disconnect_failure_counter, 0 );
+    BOOST_TEST_MESSAGE("Number of connects/disconnects to the backward connector:     "
+                       << backward_connector.connect_counter << "/" << backward_connector.disconnect_counter
+                       << " (" << backward_connector.connect_failure_counter << "/" << backward_connector.disconnect_failure_counter << " failures)");
+    BOOST_CHECK_GE( backward_connector.connect_counter, 100 );
+    BOOST_CHECK_EQUAL( backward_connector.connect_failure_counter, 0 );
+    BOOST_CHECK_EQUAL( backward_connector.disconnect_failure_counter, 0 );
 }
 
 BOOST_AUTO_TEST_CASE( testConcurrencyPerInputPort )
@@ -1310,6 +1335,18 @@ BOOST_AUTO_TEST_CASE( testConcurrencyPerInputPort )
     BOOST_CHECK_GE( another_input_connector.connect_counter, 100 );
     BOOST_CHECK_EQUAL( another_input_connector.connect_failure_counter, 0 );
     BOOST_CHECK_EQUAL( another_input_connector.disconnect_failure_counter, 0 );
+    BOOST_TEST_MESSAGE("Number of connects/disconnects to the forward connector:     "
+                       << forward_connector.connect_counter << "/" << backward_connector.disconnect_counter
+                       << " (" << forward_connector.connect_failure_counter << "/" << forward_connector.disconnect_failure_counter << " failures)");
+    BOOST_CHECK_GE( forward_connector.connect_counter, 100 );
+    BOOST_CHECK_EQUAL( forward_connector.connect_failure_counter, 0 );
+    BOOST_CHECK_EQUAL( forward_connector.disconnect_failure_counter, 0 );
+    BOOST_TEST_MESSAGE("Number of connects/disconnects to the backward connector:     "
+                       << backward_connector.connect_counter << "/" << backward_connector.disconnect_counter
+                       << " (" << backward_connector.connect_failure_counter << "/" << backward_connector.disconnect_failure_counter << " failures)");
+    BOOST_CHECK_GE( backward_connector.connect_counter, 100 );
+    BOOST_CHECK_EQUAL( backward_connector.connect_failure_counter, 0 );
+    BOOST_CHECK_EQUAL( backward_connector.disconnect_failure_counter, 0 );
 }
 
 BOOST_AUTO_TEST_CASE( testConcurrencyPerOutputPort )
@@ -1345,6 +1382,18 @@ BOOST_AUTO_TEST_CASE( testConcurrencyPerOutputPort )
     BOOST_CHECK_GE( another_input_connector.connect_counter, 100 );
     BOOST_CHECK_EQUAL( another_input_connector.connect_failure_counter, 0 );
     BOOST_CHECK_EQUAL( another_input_connector.disconnect_failure_counter, 0 );
+    BOOST_TEST_MESSAGE("Number of connects/disconnects to the forward connector:     "
+                       << forward_connector.connect_counter << "/" << backward_connector.disconnect_counter
+                       << " (" << forward_connector.connect_failure_counter << "/" << forward_connector.disconnect_failure_counter << " failures)");
+    BOOST_CHECK_GE( forward_connector.connect_counter, 100 );
+    BOOST_CHECK_EQUAL( forward_connector.connect_failure_counter, 0 );
+    BOOST_CHECK_EQUAL( forward_connector.disconnect_failure_counter, 0 );
+    BOOST_TEST_MESSAGE("Number of connects/disconnects to the backward connector:     "
+                       << backward_connector.connect_counter << "/" << backward_connector.disconnect_counter
+                       << " (" << backward_connector.connect_failure_counter << "/" << backward_connector.disconnect_failure_counter << " failures)");
+    BOOST_CHECK_GE( backward_connector.connect_counter, 100 );
+    BOOST_CHECK_EQUAL( backward_connector.connect_failure_counter, 0 );
+    BOOST_CHECK_EQUAL( backward_connector.disconnect_failure_counter, 0 );
 }
 
 BOOST_AUTO_TEST_CASE( testConcurrencySharedConnection )
@@ -1388,6 +1437,18 @@ BOOST_AUTO_TEST_CASE( testConcurrencySharedConnection )
     BOOST_CHECK_GE( another_input_connector.connect_counter, 100 );
     BOOST_CHECK_EQUAL( another_input_connector.connect_failure_counter, 0 );
     BOOST_CHECK_EQUAL( another_input_connector.disconnect_failure_counter, 0 );
+    BOOST_TEST_MESSAGE("Number of connects/disconnects to the forward connector:     "
+                       << forward_connector.connect_counter << "/" << backward_connector.disconnect_counter
+                       << " (" << forward_connector.connect_failure_counter << "/" << forward_connector.disconnect_failure_counter << " failures)");
+    BOOST_CHECK_GE( forward_connector.connect_counter, 100 );
+    BOOST_CHECK_EQUAL( forward_connector.connect_failure_counter, 0 );
+    BOOST_CHECK_EQUAL( forward_connector.disconnect_failure_counter, 0 );
+    BOOST_TEST_MESSAGE("Number of connects/disconnects to the backward connector:     "
+                       << backward_connector.connect_counter << "/" << backward_connector.disconnect_counter
+                       << " (" << backward_connector.connect_failure_counter << "/" << backward_connector.disconnect_failure_counter << " failures)");
+    BOOST_CHECK_GE( backward_connector.connect_counter, 100 );
+    BOOST_CHECK_EQUAL( backward_connector.connect_failure_counter, 0 );
+    BOOST_CHECK_EQUAL( backward_connector.disconnect_failure_counter, 0 );
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/ports_test.cpp
+++ b/tests/ports_test.cpp
@@ -782,6 +782,7 @@ BOOST_AUTO_TEST_CASE(testInvalidSharedConnection)
     BOOST_CHECK( !wp2.createConnection(rp1) );          // different connection => failure
 }
 
+#ifndef ORO_DISABLE_PORT_DATA_SCRIPTING
 BOOST_AUTO_TEST_CASE( testPortObjects)
 {
     OutputPort<double> wp1("Write");
@@ -825,6 +826,7 @@ BOOST_AUTO_TEST_CASE( testPortObjects)
     BOOST_CHECK( tc->provides()->hasService("Write") == 0 );
     BOOST_CHECK( tc->ports()->getPort("Write") == 0 );
 }
+#endif
 
 #ifdef ORO_SIGNALLING_PORTS
 BOOST_AUTO_TEST_CASE(testPortSignalling)


### PR DESCRIPTION
This PR aims at fixing the issue identified in #300. The deadlock happens essentially when disconnecting the same ports from two directions. The easiest way is to disconnect the same connection from both directions at the same time, which leads reliably to deadlocking (associated test in https://github.com/orocos-toolchain/rtt/commit/bb6fbc14306362e1e92c1160c58058bc2492ac34).

So far, the PR fixed the few easy places. However, there are a few very large codepaths still executed under lock, as removing the lock was breaking the tests without an obvious reason from my side. I figured that you guys might have more insight.

- [ ] the whole connection creation codepath is done under lock (for instance https://github.com/orocos-toolchain/rtt/blob/master/rtt/internal/ConnFactory.cpp#L216, https://github.com/orocos-toolchain/rtt/blob/master/rtt/internal/ConnFactory.hpp#L460). The original design was making sure that the channel is created first and then added to the ports, which would remove the need for such a wide-ranging lock.
- [ ] the endpoint disconnection is done under lock for the port. I am also not sure why, as the connection manager is meant to be thread-safe already. But tests start failing without that lock, so it probably is there for a good reason: https://github.com/orocos-toolchain/rtt/blob/master/rtt/internal/ConnOutputEndPoint.hpp#L133 and https://github.com/orocos-toolchain/rtt/blob/master/rtt/internal/ConnInputEndPoint.hpp#L76.

In general, my gut feeling is that the general design should be to connect/disconnect a channel from a port under the port lock, but wait until the lock is released to actually dismantle the channel. This would ensure that the large latency part (hitting the transports) is done without affecting the component.