### PR TITLE
Fix race condition when waiting for functions

### DIFF
--- a/rtt/ExecutionEngine.cpp
+++ b/rtt/ExecutionEngine.cpp
@@ -105,6 +105,14 @@ namespace RTT
             assert(foo);
             if ( foo->execute() == false ){
                 foo->unloaded();
+                {
+                    // There's no need to hold the lock while
+                    // processing the queue. But we must hold the
+                    // lock once between foo->execute() and the
+                    // broadcast to avoid the race condition in
+                    // waitForMessagesInternal().
+                    MutexLock locker( msg_lock );
+                }
                 msg_cond.broadcast(); // required for waitForFunctions() (3rd party thread)
             } else {
                 f_queue->enqueue( foo );


### PR DESCRIPTION
Without the added lock of the message mutex it can happen that the calling thread wakes up and checks the completion condition in `waitForMessagesInternal()`, but the runner engine finishes and signals the condition variable in `processFunctions()` before the calling thread enters waiting state again.

This is a race condition and it is hard to catch it in a unit test.

This lock was already introduced in https://github.com/orocos-toolchain/rtt/commit/58cb4bb733fc14de0ca520620cfcb689e2155797 as part of #91, but has been reverted in https://github.com/orocos-toolchain/rtt/commit/b9f2f348959216f32819967d1b49910deeb4bed6 before the merge. There was a comment in https://github.com/psoetens/rtt/pull/3#issuecomment-280170267 that explains why the revert was needed, which also leaves the question open whether to keep the lock in `processFunctions()`:
> The interesting part is the comment in processMessages(). Maybe something similar was the case in processFunctions() and this is the only lock that was really required?