### PR TITLE
useorocos: add separate configuration macros independent of installation

### DIFF
--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -351,6 +351,7 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       ${ARGN}
       )
     SET( SOURCES ${ORO_LIBRARY_DEFAULT_ARGS} )
+    # Extract install directory:
     if ( ORO_LIBRARY_INSTALL )
       set(AC_INSTALL_DIR ${ORO_LIBRARY_INSTALL})
       set(AC_INSTALL_RT_DIR bin)
@@ -366,15 +367,25 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       set(AC_INSTALL_EXPORT EXPORT ${PROJECT_NAME}-${OROCOS_TARGET})
     endif()
   
+    # Set library name:
     if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
       set( LIB_NAME ${LIB_TARGET_NAME}-${OROCOS_TARGET})
     else()
       set( LIB_NAME ${LIB_TARGET_NAME})
     endif()
 
+    # Set component version:
+    if (COMPONENT_VERSION)
+      set( LIB_COMPONENT_VERSION VERSION ${COMPONENT_VERSION})
+    endif(COMPONENT_VERSION)
+    if (ORO_LIBRARY_VERSION)
+      set( LIB_COMPONENT_VERSION VERSION ${ORO_LIBRARY_VERSION})
+    endif(ORO_LIBRARY_VERSION)
+
     # Clear the dependencies such that a target switch can be detected:
     unset( ${LIB_TARGET_NAME}_LIB_DEPENDS )
 
+    # Use rosbuild in ros environments:
     if (ORO_USE_ROSBUILD)
       MESSAGE( STATUS "[UseOrocos] Building library ${LIB_TARGET_NAME} in rosbuild source tree." )
       rosbuild_add_library(${LIB_TARGET_NAME} ${SOURCES} )
@@ -383,13 +394,7 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       ADD_LIBRARY( ${LIB_TARGET_NAME} SHARED ${SOURCES} )
     endif()
 
-    if (COMPONENT_VERSION)
-      set( LIB_COMPONENT_VERSION VERSION ${COMPONENT_VERSION})
-    endif(COMPONENT_VERSION)
-    if (ORO_LIBRARY_VERSION)
-      set( LIB_COMPONENT_VERSION VERSION ${ORO_LIBRARY_VERSION})
-    endif(ORO_LIBRARY_VERSION)
-
+    # Prepare lib for out-of-the-ordinary lib directories
     SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
       OUTPUT_NAME ${LIB_NAME}
       ${LIB_COMPONENT_VERSION}
@@ -418,7 +423,6 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       add_dependencies( ${LIB_TARGET_NAME} ${USE_OROCOS_EXPORTED_TARGETS} )
     endif()
 
-    # Install
     INSTALL(TARGETS ${LIB_TARGET_NAME} ${AC_INSTALL_EXPORT} LIBRARY DESTINATION ${AC_INSTALL_DIR} ARCHIVE DESTINATION lib RUNTIME DESTINATION ${AC_INSTALL_RT_DIR})
 
     # Necessary for .pc file generation
@@ -629,6 +633,7 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       ${ARGN}
       )
     SET( SOURCES ${ORO_TYPEKIT_DEFAULT_ARGS} )
+    # Extract install directory:
     if ( ORO_TYPEKIT_INSTALL )
       set(AC_INSTALL_DIR ${ORO_TYPEKIT_INSTALL})
       set(AC_INSTALL_RT_DIR bin)
@@ -644,6 +649,14 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       set(AC_INSTALL_EXPORT EXPORT ${PROJECT_NAME}-${OROCOS_TARGET})
     endif()
 
+    # Set library name:
+    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
+      set( LIB_NAME ${LIB_TARGET_NAME}-${OROCOS_TARGET})
+    else()
+      set( LIB_NAME ${LIB_TARGET_NAME})
+    endif()
+
+    # Set component version:
     if (COMPONENT_VERSION)
       set( LIB_COMPONENT_VERSION VERSION ${COMPONENT_VERSION})
     endif(COMPONENT_VERSION)
@@ -651,21 +664,19 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       set( LIB_COMPONENT_VERSION VERSION ${ORO_TYPEKIT_VERSION})
     endif(ORO_TYPEKIT_VERSION)
 
-    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
-      set( LIB_NAME ${LIB_TARGET_NAME}-${OROCOS_TARGET})
-    else()
-      set( LIB_NAME ${LIB_TARGET_NAME})
-    endif()
-
     # Clear the dependencies such that a target switch can be detected:
     unset( ${LIB_TARGET_NAME}_LIB_DEPENDS )
 
-    MESSAGE( STATUS "[UseOrocos] Building typekit library ${LIB_TARGET_NAME}" )
+    # Use rosbuild in ros environments:
     if (ORO_USE_ROSBUILD)
+      MESSAGE( STATUS "[UseOrocos] Building typekit library ${LIB_TARGET_NAME} in rosbuild source tree." )
       rosbuild_add_library(${LIB_TARGET_NAME} ${SOURCES} )
     else()
+      MESSAGE( STATUS "[UseOrocos] Building typekit library ${LIB_TARGET_NAME}" )
       ADD_LIBRARY( ${LIB_TARGET_NAME} SHARED ${SOURCES} )
     endif()
+
+    # Prepare typekit lib for out-of-the-ordinary lib directories
     SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
       OUTPUT_NAME ${LIB_NAME}
       LIBRARY_OUTPUT_DIRECTORY ${ORO_TYPEKIT_OUTPUT_DIRECTORY}
@@ -723,6 +734,7 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       ${ARGN}
       )
     SET( SOURCES ${ORO_PLUGIN_DEFAULT_ARGS} )
+    # Extract install directory:
     if ( ORO_PLUGIN_INSTALL )
       set(AC_INSTALL_DIR ${ORO_PLUGIN_INSTALL})
       set(AC_INSTALL_RT_DIR bin)
@@ -738,6 +750,14 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       set(AC_INSTALL_EXPORT EXPORT ${PROJECT_NAME}-${OROCOS_TARGET})
     endif()
 
+    # Set library name:
+    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
+      set( LIB_NAME ${LIB_TARGET_NAME}-${OROCOS_TARGET})
+    else()
+      set( LIB_NAME ${LIB_TARGET_NAME})
+    endif()
+
+    # Set component version:
     if (COMPONENT_VERSION)
       set( LIB_COMPONENT_VERSION VERSION ${COMPONENT_VERSION})
     endif(COMPONENT_VERSION)
@@ -745,15 +765,10 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       set( LIB_COMPONENT_VERSION VERSION ${ORO_PLUGIN_VERSION})
     endif(ORO_PLUGIN_VERSION)
 
-    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
-      set( LIB_NAME ${LIB_TARGET_NAME}-${OROCOS_TARGET})
-    else()
-      set( LIB_NAME ${LIB_TARGET_NAME})
-    endif()
-
     # Clear the dependencies such that a target switch can be detected:
     unset( ${LIB_TARGET_NAME}_LIB_DEPENDS )
 
+    # Use rosbuild in ros environments:
     if (ORO_USE_ROSBUILD)
       MESSAGE( STATUS "[UseOrocos] Building plugin library ${LIB_TARGET_NAME} in rosbuild source tree." )
       rosbuild_add_library(${LIB_TARGET_NAME} ${SOURCES} )
@@ -762,6 +777,7 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       ADD_LIBRARY( ${LIB_TARGET_NAME} SHARED ${SOURCES} )
     endif()
 
+    # Prepare plugin lib for out-of-the-ordinary lib directories
     SET_TARGET_PROPERTIES( ${LIB_TARGET_NAME} PROPERTIES
       OUTPUT_NAME ${LIB_NAME}
       LIBRARY_OUTPUT_DIRECTORY ${ORO_PLUGIN_OUTPUT_DIRECTORY}

--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -510,21 +510,16 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
   # WARNING the target name is *not* suffixed with OROCOS_TARGET. That is left
   # to the caller, if necessary.
   #
-  # Usage: orocos_configure_executable( executablename src1 src2 src3 [INSTALL bin] )
+  # Usage: orocos_configure_executable( executablename src1 src2 src3)
   #
   macro( orocos_configure_executable EXE_TARGET_NAME )
 
     ORO_PARSE_ARGUMENTS(ORO_EXECUTABLE
-      "INSTALL"
+      ""
       ""
       ${ARGN}
       )
     SET( SOURCES ${ORO_EXECUTABLE_DEFAULT_ARGS} )
-    if ( ORO_EXECUTABLE_INSTALL )
-      set(AC_INSTALL_DIR ${ORO_EXECUTABLE_INSTALL})
-    else()
-      set(AC_INSTALL_DIR lib)
-    endif()
 
     if (ORO_USE_ROSBUILD)
       MESSAGE( STATUS "[UseOrocos] Configuring executable ${EXE_TARGET_NAME} in rosbuild source tree." )

--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -237,12 +237,18 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
   # specify the optional VERSION parameter. For ros builds, the version
   # number is ignored.
   #
-  # Usage: orocos_component( COMPONENT_NAME src1 src2 src3 [INSTALL lib/orocos/${PROJECT_NAME}] [VERSION x.y.z] )
+  # Pass the optional NO_TARGET_SUFFIX parameter to NOT suffix the library name
+  # with the Orocos target (e.g. removes the "-macosx" or "-gnulinux" suffix).
+  # With NO_TARGET_SUFFIX set the target name and library name will be the same.
+  # WARNING without NO_TARGET_SUFFIX the target library name *is* suffixed with
+  # OROCOS_TARGET, but the target name is *not* suffixed with OROCOS_TARGET.
+  #
+  # Usage: orocos_component( COMPONENT_NAME src1 src2 src3 [INSTALL lib/orocos/${PROJECT_NAME}] [VERSION x.y.z] [NO_TARGET_SUFFIX] )
   #
   macro( orocos_component COMPONENT_NAME )
     ORO_PARSE_ARGUMENTS(ADD_COMPONENT
       "INSTALL;VERSION;EXPORT"
-      ""
+      "NO_TARGET_SUFFIX"
       ${ARGN}
       )
     SET( SOURCES ${ADD_COMPONENT_DEFAULT_ARGS} )
@@ -264,7 +270,8 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
     endif()
 
     # Set library name:
-    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
+    if ( NOT ADD_COMPONENT_NO_TARGET_SUFFIX AND
+        ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx") )
       set( COMPONENT_LIB_NAME ${COMPONENT_NAME}-${OROCOS_TARGET})
     else()
       set( COMPONENT_LIB_NAME ${COMPONENT_NAME})
@@ -340,14 +347,17 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
   # The caller is responsible for any ADD_LIBRARY() or INSTALL() calls for this
   # target.
   #
-  # WARNING the target library name *is* suffixed with OROCOS_TARGET, but the
-  # target name is *not* suffixed with OROCOS_TARGET.
-  #
   # You can set a variable COMPONENT_VERSION x.y.z to set a version or
   # specify the optional VERSION parameter. For ros builds, the version
   # number is ignored.
   #
-  # Usage: orocos_configure_component( COMPONENT_NAME [VERSION x.y.z] )
+  # Pass the optional NO_TARGET_SUFFIX parameter to NOT suffix the library name
+  # with the Orocos target (e.g. removes the "-macosx" or "-gnulinux" suffix).
+  # With NO_TARGET_SUFFIX set the target name and library name will be the same.
+  # WARNING without NO_TARGET_SUFFIX the target library name *is* suffixed with
+  # OROCOS_TARGET, but the target name is *not* suffixed with OROCOS_TARGET.
+  #
+  # Usage: orocos_configure_component( COMPONENT_NAME [VERSION x.y.z] [NO_TARGET_SUFFIX] )
   #
   # EXAMPLE USAGE
   #
@@ -359,13 +369,14 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
   macro( orocos_configure_component COMPONENT_NAME )
     ORO_PARSE_ARGUMENTS(ADD_COMPONENT
       "VERSION"
-      ""
+      "NO_TARGET_SUFFIX"
       ${ARGN}
       )
     SET( SOURCES ${ADD_COMPONENT_DEFAULT_ARGS} )
 
     # Set library name:
-    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
+    if ( NOT ADD_COMPONENT_NO_TARGET_SUFFIX AND
+        ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx") )
       set( COMPONENT_LIB_NAME ${COMPONENT_NAME}-${OROCOS_TARGET})
     else()
       set( COMPONENT_LIB_NAME ${COMPONENT_NAME})
@@ -429,13 +440,19 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
   # specify the optional VERSION parameter. For ros builds, the version
   # number is ignored.
   #
-  # Usage: orocos_library( libraryname src1 src2 src3 [VERSION x.y.z] )
+  # Pass the optional NO_TARGET_SUFFIX parameter to NOT suffix the library name
+  # with the Orocos target (e.g. removes the "-macosx" or "-gnulinux" suffix).
+  # With NO_TARGET_SUFFIX set the target name and library name will be the same.
+  # WARNING without NO_TARGET_SUFFIX the target library name *is* suffixed with
+  # OROCOS_TARGET, but the target name is *not* suffixed with OROCOS_TARGET.
+  #
+  # Usage: orocos_library( libraryname src1 src2 src3 [VERSION x.y.z]  [NO_TARGET_SUFFIX] )
   #
   macro( orocos_library LIB_TARGET_NAME )
 
     ORO_PARSE_ARGUMENTS(ORO_LIBRARY
       "INSTALL;VERSION;EXPORT"
-      ""
+      "NO_TARGET_SUFFIX"
       ${ARGN}
       )
     SET( SOURCES ${ORO_LIBRARY_DEFAULT_ARGS} )
@@ -456,7 +473,8 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
     endif()
   
     # Set library name:
-    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
+    if ( NOT ORO_LIBRARY_NO_TARGET_SUFFIX AND
+        ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx") )
       set( LIB_NAME ${LIB_TARGET_NAME}-${OROCOS_TARGET})
     else()
       set( LIB_NAME ${LIB_TARGET_NAME})
@@ -524,14 +542,17 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
   # The caller is responsible for any ADD_LIBRARY() or INSTALL() calls for this
   # target.
   #
-  # WARNING the target library name *is* suffixed with OROCOS_TARGET, but the
-  # target name is *not* suffixed with OROCOS_TARGET.
-  #
   # You can set a variable COMPONENT_VERSION x.y.z to set a version or
   # specify the optional VERSION parameter. For ros builds, the version
   # number is ignored.
   #
-  # Usage: orocos_configure_library( libraryname [VERSION x.y.z] )
+  # Pass the optional NO_TARGET_SUFFIX parameter to NOT suffix the library name
+  # with the Orocos target (e.g. removes the "-macosx" or "-gnulinux" suffix).
+  # With NO_TARGET_SUFFIX set the target name and library name will be the same.
+  # WARNING without NO_TARGET_SUFFIX the target library name *is* suffixed with
+  # OROCOS_TARGET, but the target name is *not* suffixed with OROCOS_TARGET.
+  #
+  # Usage: orocos_configure_library( libraryname [VERSION x.y.z] [NO_TARGET_SUFFIX] )
   #
   # EXAMPLE USAGE
   #
@@ -544,12 +565,13 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
 
     ORO_PARSE_ARGUMENTS(ORO_LIBRARY
       "VERSION"
-      ""
+      "NO_TARGET_SUFFIX"
       ${ARGN}
       )
 
     # Set library name:
-    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
+    if ( NOT ORO_LIBRARY_NO_TARGET_SUFFIX AND
+        ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx") )
       set( LIB_NAME ${LIB_TARGET_NAME}-${OROCOS_TARGET})
     else()
       set( LIB_NAME ${LIB_TARGET_NAME})
@@ -608,13 +630,19 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
   # Executables should add themselves by calling 'orocos_executable()'
   # instead of 'ADD_EXECUTABLE' in CMakeLists.txt.
   #
-  # Usage: orocos_executable( executablename src1 src2 src3 [INSTALL bin] )
+  # Pass the optional NO_TARGET_SUFFIX parameter to NOT suffix the executable name
+  # with the Orocos target (e.g. removes the "-macosx" or "-gnulinux" suffix).
+  # With NO_TARGET_SUFFIX set the target name and executable name will be the same.
+  # WARNING without NO_TARGET_SUFFIX the target executable name *is* suffixed with
+  # OROCOS_TARGET, but the target name is *not* suffixed with OROCOS_TARGET.
+  #
+  # Usage: orocos_executable( executablename src1 src2 src3 [INSTALL bin] [NO_TARGET_SUFFIX] )
   #
   macro( orocos_executable EXE_TARGET_NAME )
 
     ORO_PARSE_ARGUMENTS(ORO_EXECUTABLE
       "INSTALL;EXPORT"
-      ""
+      "NO_TARGET_SUFFIX"
       ${ARGN}
       )
     SET( SOURCES ${ORO_EXECUTABLE_DEFAULT_ARGS} )
@@ -633,7 +661,8 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       set(AC_INSTALL_EXPORT EXPORT ${PROJECT_NAME}-${OROCOS_TARGET})
     endif()
 
-    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
+    if ( NOT ORO_EXECUTABLE_NO_TARGET_SUFFIX AND
+        ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx") )
       set( EXE_NAME ${EXE_TARGET_NAME}-${OROCOS_TARGET})
     else()
       set( EXE_NAME ${EXE_TARGET_NAME})
@@ -686,10 +715,13 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
   # The caller is responsible for any ADD_EXECUTABLE(), ADD_TEST(), or INSTALL()
   # calls for this target.
   #
-  # WARNING the target executable name *is* suffixed with OROCOS_TARGET, but the
-  # target name is *not* suffixed with OROCOS_TARGET.
+  # Pass the optional NO_TARGET_SUFFIX parameter to NOT suffix the executable name
+  # with the Orocos target (e.g. removes the "-macosx" or "-gnulinux" suffix).
+  # With NO_TARGET_SUFFIX set the target name and executable name will be the same.
+  # WARNING without NO_TARGET_SUFFIX the target executable name *is* suffixed with
+  # OROCOS_TARGET, but the target name is *not* suffixed with OROCOS_TARGET.
   #
-  # Usage: orocos_configure_executable( executablename src1 src2 src3)
+  # Usage: orocos_configure_executable( executablename src1 src2 src3 [NO_TARGET_SUFFIX] )
   #
   # EXAMPLE USAGE
   #
@@ -702,12 +734,13 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
 
     ORO_PARSE_ARGUMENTS(ORO_EXECUTABLE
       ""
-      ""
+      "NO_TARGET_SUFFIX"
       ${ARGN}
       )
     SET( SOURCES ${ORO_EXECUTABLE_DEFAULT_ARGS} )
 
-    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
+    if ( NOT ORO_EXECUTABLE_NO_TARGET_SUFFIX AND
+        ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx") )
       set( EXE_NAME ${EXE_TARGET_NAME}-${OROCOS_TARGET})
     else()
       set( EXE_NAME ${EXE_TARGET_NAME})
@@ -811,13 +844,19 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
   # specify the optional VERSION parameter. For ros builds, the version
   # number is ignored.
   #
-  # Usage: orocos_typekit( typekitname src1 src2 src3 [INSTALL lib/orocos/project/types] [VERSION x.y.z] )
+  # Pass the optional NO_TARGET_SUFFIX parameter to NOT suffix the typekit name
+  # with the Orocos target (e.g. removes the "-macosx" or "-gnulinux" suffix).
+  # With NO_TARGET_SUFFIX set the target name and typekit name will be the same.
+  # WARNING without NO_TARGET_SUFFIX the target typekit name *is* suffixed with
+  # OROCOS_TARGET, but the target name is *not* suffixed with OROCOS_TARGET.
+  #
+  # Usage: orocos_typekit( typekitname src1 src2 src3 [INSTALL lib/orocos/project/types] [VERSION x.y.z] [NO_TARGET_SUFFIX] )
   #
   macro( orocos_typekit LIB_TARGET_NAME )
 
     ORO_PARSE_ARGUMENTS(ORO_TYPEKIT
       "INSTALL;VERSION;EXPORT"
-      ""
+      "NO_TARGET_SUFFIX"
       ${ARGN}
       )
     SET( SOURCES ${ORO_TYPEKIT_DEFAULT_ARGS} )
@@ -838,7 +877,8 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
     endif()
 
     # Set library name:
-    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
+    if ( NOT ORO_TYPEKIT_NO_TARGET_SUFFIX AND
+        ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx") )
       set( LIB_NAME ${LIB_TARGET_NAME}-${OROCOS_TARGET})
     else()
       set( LIB_NAME ${LIB_TARGET_NAME})
@@ -911,14 +951,17 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
   # The caller is responsible for any ADD_LIBRARY() or INSTALL() calls for this
   # target.
   #
-  # WARNING the target library name *is* suffixed with OROCOS_TARGET, but the
-  # target name is *not* suffixed with OROCOS_TARGET.
-  #
   # You can set a variable COMPONENT_VERSION x.y.z to set a version or
   # specify the optional VERSION parameter. For ros builds, the version
   # number is ignored.
   #
-  # Usage: orocos_configure_typekit( COMPONENT_NAME [VERSION x.y.z] )
+  # Pass the optional NO_TARGET_SUFFIX parameter to NOT suffix the typekit name
+  # with the Orocos target (e.g. removes the "-macosx" or "-gnulinux" suffix).
+  # With NO_TARGET_SUFFIX set the target name and typekit name will be the same.
+  # WARNING without NO_TARGET_SUFFIX the target typekit name *is* suffixed with
+  # OROCOS_TARGET, but the target name is *not* suffixed with OROCOS_TARGET.
+  #
+  # Usage: orocos_configure_typekit( COMPONENT_NAME [VERSION x.y.z] [NO_TARGET_SUFFIX] )
   #
   # EXAMPLE USAGE
   #
@@ -931,13 +974,14 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
 
     ORO_PARSE_ARGUMENTS(ORO_TYPEKIT
       "VERSION"
-      ""
+      "NO_TARGET_SUFFIX"
       ${ARGN}
       )
     SET( SOURCES ${ORO_TYPEKIT_DEFAULT_ARGS} )
 
     # Set library name:
-    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
+    if ( NOT ORO_TYPEKIT_NO_TARGET_SUFFIX AND
+        ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx") )
       set( LIB_NAME ${LIB_TARGET_NAME}-${OROCOS_TARGET})
     else()
       set( LIB_NAME ${LIB_TARGET_NAME})
@@ -998,13 +1042,19 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
   # specify the optional VERSION parameter. For ros builds, the version
   # number is ignored.
   #
-  # Usage: orocos_plugin( pluginname src1 src2 src3 [INSTALL lib/orocos/project/plugins] [VERSION x.y.z])
+  # Pass the optional NO_TARGET_SUFFIX parameter to NOT suffix the plugin name
+  # with the Orocos target (e.g. removes the "-macosx" or "-gnulinux" suffix).
+  # With NO_TARGET_SUFFIX set the target name and plugin name will be the same.
+  # WARNING without NO_TARGET_SUFFIX the target plugin name *is* suffixed with
+  # OROCOS_TARGET, but the target name is *not* suffixed with OROCOS_TARGET.
+  #
+  # Usage: orocos_plugin( pluginname src1 src2 src3 [INSTALL lib/orocos/project/plugins] [VERSION x.y.z] [NO_TARGET_SUFFIX] )
   #
   macro( orocos_plugin LIB_TARGET_NAME )
 
     ORO_PARSE_ARGUMENTS(ORO_PLUGIN
       "INSTALL;VERSION;EXPORT"
-      ""
+      "NO_TARGET_SUFFIX"
       ${ARGN}
       )
     SET( SOURCES ${ORO_PLUGIN_DEFAULT_ARGS} )
@@ -1025,7 +1075,8 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
     endif()
 
     # Set library name:
-    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
+    if ( NOT ORO_PLUGIN_NO_TARGET_SUFFIX AND
+        ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx") )
       set( LIB_NAME ${LIB_TARGET_NAME}-${OROCOS_TARGET})
     else()
       set( LIB_NAME ${LIB_TARGET_NAME})
@@ -1099,14 +1150,17 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
   # The caller is responsible for any ADD_LIBRARY() or INSTALL() calls for this
   # target.
   #
-  # WARNING the target library name *is* suffixed with OROCOS_TARGET, but the
-  # target name is *not* suffixed with OROCOS_TARGET.
-  #
   # You can set a variable COMPONENT_VERSION x.y.z to set a version or
   # specify the optional VERSION parameter. For ros builds, the version
   # number is ignored.
   #
-  # Usage: orocos_configure_plugin( COMPONENT_NAME [VERSION x.y.z] )
+  # Pass the optional NO_TARGET_SUFFIX parameter to NOT suffix the plugin name
+  # with the Orocos target (e.g. removes the "-macosx" or "-gnulinux" suffix).
+  # With NO_TARGET_SUFFIX set the target name and plugin name will be the same.
+  # WARNING without NO_TARGET_SUFFIX the target plugin name *is* suffixed with
+  # OROCOS_TARGET, but the target name is *not* suffixed with OROCOS_TARGET.
+  #
+  # Usage: orocos_configure_plugin( COMPONENT_NAME [VERSION x.y.z] [NO_TARGET_SUFFIX] )
   #
   # EXAMPLE USAGE
   #
@@ -1119,13 +1173,14 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
 
     ORO_PARSE_ARGUMENTS(ORO_PLUGIN
       "VERSION"
-      ""
+      "NO_TARGET_SUFFIX"
       ${ARGN}
       )
     SET( SOURCES ${ORO_PLUGIN_DEFAULT_ARGS} )
 
     # Export target
-    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
+    if ( NOT ORO_PLUGIN_NO_TARGET_SUFFIX AND
+        ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx") )
       set( LIB_NAME ${LIB_TARGET_NAME}-${OROCOS_TARGET})
     else()
       set( LIB_NAME ${LIB_TARGET_NAME})

--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -511,10 +511,18 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
   # Configure an executable to work with Orocos.
   # The caller is responsible for any ADD_EXECUTABLE(), ADD_TEST(), or INSTALL()
   # calls for this target.
-  # WARNING the target name is *not* suffixed with OROCOS_TARGET. That is left
-  # to the caller, if necessary.
+  #
+  # WARNING the target executable name *is* suffixed with OROCOS_TARGET, but the
+  # target name is *not* suffixed with OROCOS_TARGET.
   #
   # Usage: orocos_configure_executable( executablename src1 src2 src3)
+  #
+  # EXAMPLE USAGE
+  #
+  #   ADD_EXECUTABLE(acme ...)
+  #   orocos_configure_executable(acme)
+  #   TARGET_LINK_LIBRARIES(acme ...)
+  #   INSTALL(TARGETS acme RUNTIME DESTINATION bin)
   #
   macro( orocos_configure_executable EXE_TARGET_NAME )
 
@@ -525,6 +533,12 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
       )
     SET( SOURCES ${ORO_EXECUTABLE_DEFAULT_ARGS} )
 
+    if ( ${OROCOS_TARGET} STREQUAL "gnulinux" OR ${OROCOS_TARGET} STREQUAL "lxrt" OR ${OROCOS_TARGET} STREQUAL "xenomai" OR ${OROCOS_TARGET} STREQUAL "win32" OR ${OROCOS_TARGET} STREQUAL "macosx")
+      set( EXE_NAME ${EXE_TARGET_NAME}-${OROCOS_TARGET})
+    else()
+      set( EXE_NAME ${EXE_TARGET_NAME})
+    endif()
+
     if (ORO_USE_ROSBUILD)
       MESSAGE( STATUS "[UseOrocos] Configuring executable ${EXE_TARGET_NAME} in rosbuild source tree." )
       MESSAGE( FATAL_ERROR "rosbuild_add_executable not yet supported!")
@@ -534,7 +548,7 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
     endif()
 
     SET_TARGET_PROPERTIES( ${EXE_TARGET_NAME} PROPERTIES
-      OUTPUT_NAME ${EXE_TARGET_NAME}
+      OUTPUT_NAME ${EXE_NAME}
       )
 
     if(CMAKE_DEBUG_POSTFIX)

--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -291,6 +291,10 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
     else()
       INSTALL(TARGETS ${COMPONENT_NAME} ${AC_INSTALL_EXPORT} LIBRARY DESTINATION ${AC_INSTALL_DIR} ARCHIVE DESTINATION lib RUNTIME DESTINATION ${AC_INSTALL_RT_DIR})
     endif()
+
+    # Export library for other packages within the same build-space (e.g. for catkin_make)
+    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARIES "${COMPONENT_NAME}")
+    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS "${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
   endmacro( orocos_component )
 
   # Configure a component library to work with Orocos
@@ -379,8 +383,6 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
 
     # Necessary for .pc file generation
     list(APPEND OROCOS_DEFINED_COMPS " -l${COMPONENT_LIB_NAME}")
-    list(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS "${COMPONENT_NAME}")
-    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS "${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
   endmacro( orocos_configure_component )
 
   # Utility libraries should add themselves by calling 'orocos_library()'
@@ -439,6 +441,10 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
 
     # Install
     INSTALL(TARGETS ${LIB_TARGET_NAME} ${AC_INSTALL_EXPORT} LIBRARY DESTINATION ${AC_INSTALL_DIR} ARCHIVE DESTINATION lib RUNTIME DESTINATION ${AC_INSTALL_RT_DIR})
+
+    # Export library for other packages within the same build-space (e.g. for catkin_make)
+    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARIES "${LIB_TARGET_NAME}")
+    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS "${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
   endmacro( orocos_library )
 
   # Configure a utility library to work with Orocos
@@ -526,8 +532,6 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
 
     # Necessary for .pc file generation
     list(APPEND OROCOS_DEFINED_LIBS " -l${LIB_NAME}")
-    list(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS "${LIB_TARGET_NAME}")
-    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS "${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
   endmacro( orocos_configure_library )
 
   # Executables should add themselves by calling 'orocos_executable()'
@@ -772,6 +776,10 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
     else()
       INSTALL(TARGETS ${LIB_TARGET_NAME} ${AC_INSTALL_EXPORT} LIBRARY DESTINATION ${AC_INSTALL_DIR} ARCHIVE DESTINATION lib RUNTIME DESTINATION ${AC_INSTALL_RT_DIR})
     endif()
+
+    # Export library for other packages within the same build-space (e.g. for catkin_make)
+    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARIES "${LIB_TARGET_NAME}")
+    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS "${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
   endmacro( orocos_typekit )
 
   # Configure a typekit library to work with Orocos
@@ -859,8 +867,6 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
 
     # Necessary for .pc file generation
     list(APPEND OROCOS_DEFINED_TYPES " -l${LIB_NAME}")
-    list(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS "${LIB_TARGET_NAME}")
-    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS "${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
   endmacro( orocos_configure_typekit )
 
   # plugin libraries should add themselves by calling 'orocos_plugin()'
@@ -923,6 +929,10 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
     else()
       INSTALL(TARGETS ${LIB_TARGET_NAME} ${AC_INSTALL_EXPORT} LIBRARY DESTINATION ${AC_INSTALL_DIR} ARCHIVE DESTINATION lib RUNTIME DESTINATION ${AC_INSTALL_RT_DIR})
     endif()
+
+    # Export library for other packages within the same build-space (e.g. for catkin_make)
+    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARIES "${LIB_TARGET_NAME}")
+    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS "${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
   endmacro( orocos_plugin )
 
   # Configure a plugin library to work with Orocos
@@ -1011,8 +1021,6 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
 
     # Necessary for .pc file generation
     list(APPEND OROCOS_DEFINED_PLUGINS " -l${LIB_NAME}")
-    list(APPEND ${PROJECT_NAME}_EXPORTED_TARGETS "${LIB_TARGET_NAME}")
-    list(APPEND ${PROJECT_NAME}_EXPORTED_LIBRARY_DIRS "${CMAKE_INSTALL_PREFIX}/${AC_INSTALL_DIR}")
   endmacro( orocos_configure_plugin )
 
   # service libraries should add themselves by calling 'orocos_service()'

--- a/UseOROCOS-RTT.cmake
+++ b/UseOROCOS-RTT.cmake
@@ -523,6 +523,7 @@ if(OROCOS-RTT_FOUND AND NOT USE_OROCOS_RTT)
 
     if (ORO_USE_ROSBUILD)
       MESSAGE( STATUS "[UseOrocos] Configuring executable ${EXE_TARGET_NAME} in rosbuild source tree." )
+      MESSAGE( FATAL_ERROR "rosbuild_add_executable not yet supported!")
 # TODO      rosbuild_add_executable(${EXE_TARGET_NAME} ${SOURCES} )
     else()
       MESSAGE( STATUS "[UseOrocos] Configuring executable ${EXE_TARGET_NAME}" )


### PR DESCRIPTION
This patch adds separate CMake macros to [UseOROCOS-RTT.cmake](https://github.com/orocos-toolchain/rtt/blob/master/UseOROCOS-RTT.cmake) to configure existing targets (component and plugin libraries) for Orocos independent of their creation and installation. Most work has been done by @snrkiwi.

#### `orocos_configure_xxx(TARGET ...)`

The configuration of a target for Orocos applies the following changes to the given target:

- Append the Orocos target name (e.g. `-gnulinux`) to the library output name unless disabled by the macro flag `NO_TARGET_SUFFIX` (cmake property [OUTPUT_NAME](https://cmake.org/cmake/help/latest/prop_tgt/OUTPUT_NAME.html))
- Set the library version if either `COMPONENT_VERSION` is set or `VERSION` is passed as a macro argument (cmake property [VERSION](https://cmake.org/cmake/help/latest/prop_tgt/VERSION.html))
- Set the library output directory for component, plugin and typekit libraries generated in devel-space (without installation), such that they can be found in the respective paths expected by the RTT `ComponentLoader` and `PluginLoader` (cmake property [LIBRARY_OUTPUT_DIRECTORY](https://cmake.org/cmake/help/latest/prop_tgt/LIBRARY_OUTPUT_DIRECTORY.html))
- Define preprocessor symbol `RTT_COMPONENT` (for component libraries only)
- Link to the Orocos RTT core libraries (`OROCOS-RTT_LIBRARIES`)
- Add include directories, compile flags and linker flags exported by other Orocos packages that have been found by calling `orocos_use_package()` before. In catkin build mode (`ORO_USE_CATKIN` is true) the macro is implicitly called for all Orocos packages listed as build dependencies in `package.xml`. Unless `OROCOS_NO_AUTO_LINKING` is set, also link to all Orocos library targets.
- Configure the [rpath](https://en.wikipedia.org/wiki/Rpath) of installed libraries such that all library dependencies can be found at run-time, even if they are not located in a directory searched by default by the dynamic linker (cmake properties [INSTALL_RPATH](https://cmake.org/cmake/help/latest/prop_tgt/INSTALL_RPATH.html) and [CMAKE_INSTALL_RPATH_USE_LINK_PATH](https://cmake.org/cmake/help/latest/prop_tgt/CMAKE_INSTALL_RPATH_USE_LINK_PATH.html))
- Add cmake dependencies to other exported targets (other than libraries) that need to be generated before, e.g. for code generation (see also https://github.com/orocos-toolchain/rtt/pull/244).
- Append the target to `OROCOS_DEFINED_<COMPS|LIBS|TYPES|PLUGINS>` needed for the generation of pkg-config (.pc) files in `orocos_generate_package()`.

#### `orocos_xxx(TARGET SOURCES ...)`

Everything else is only done by the full macros. The behavior of those macros should not have been changed by this patch.

- Add the CMake target ([add_library()](https://cmake.org/cmake/help/latest/command/add_library.html) or [add_executable()](https://cmake.org/cmake/help/latest/command/add_executable.html)) with the given source files
- Install the target at the expected destination relative to the `CMAKE_INSTALL_PREFIX`
- Add the target to either the default CMake export set or another explicitly named export set (see [install(EXPORT)](https://cmake.org/cmake/help/latest/command/install.html#installing-exports), https://github.com/orocos-toolchain/rtt/pull/144)
- Export the library target for other packages within the same build-space (e.g. when using `catkin_make`), where the generated pkg-config files cannot be used yet.
- All the steps of the respective `orocos_configure_xxx()` macro mentioned above.

#### New options for all macros
- `NO_TARGET_SUFFIX`: do not append the Orocos target to the library and executable names (not required for single target installations)
- `QUIET`: suppress the informational output of the macros