### PR TITLE
Always build multi component libs and deprecate ORO_CREATE_COMPONENT_TYPE

### DIFF
--- a/rtt/Component.hpp
+++ b/rtt/Component.hpp
@@ -53,54 +53,7 @@
 #include "rtt-fwd.hpp"
 #include "rtt-config.h"
 
-namespace RTT
-{
-    /**
-     * This signature defines how a component can be instantiated.
-     */
-    typedef TaskContext* (*ComponentLoaderSignature)(std::string instance_name);
-    typedef std::map<std::string,ComponentLoaderSignature> FactoryMap;
-
-    /**
-     * A global variable storing all component factories added with
-     * \a ORO_LIST_COMPONENT_TYPE.
-     * This factory needs to be present in both static and dynamic library
-     * deployments.
-     */
-    class ComponentFactories
-    {
-        /**
-         * When static linking is used, the Component library loaders can be
-         * found in this map.
-         */
-        RTT_HIDE static FactoryMap* Factories;
-    public:
-        RTT_HIDE static FactoryMap& Instance() {
-            if ( Factories == 0)
-                Factories = new FactoryMap();
-            return *Factories;
-        }
-    };
-
-    /**
-     * A helper class storing a single component factory
-     * in case of static library deployments.
-     */
-    template<class C>
-    class ComponentFactoryLoader
-    {
-    public:
-        ComponentFactoryLoader(std::string type_name)
-        {
-            ComponentFactories::Instance()[type_name] = &ComponentFactoryLoader<C>::createComponent;
-        }
-
-        static TaskContext* createComponent(std::string instance_name)
-        {
-            return new C(instance_name);
-        }
-    };
-}
+#include <rtt/deployment/ComponentLoader.hpp>
 
 // Helper macros.
 #define ORO_CONCAT_LINE2(x,y) x##y

--- a/rtt/Component.hpp
+++ b/rtt/Component.hpp
@@ -63,6 +63,35 @@
 #define ORO_LIST_COMPONENT_TYPE_str(s) ORO_LIST_COMPONENT_TYPE__str(s)
 #define ORO_LIST_COMPONENT_TYPE__str(s) #s
 
+#if defined(__GNUC__)
+    #define ORO_PP_PRAGMA(x) _Pragma(#x)
+    #define ORO_PP_WARNING(text) ORO_PP_PRAGMA(GCC warning text)
+    #define ORO_PP_ERROR(text) ORO_PP_PRAGMA(GCC error text)
+#else
+    #define ORO_PP_WARNING(text)
+    #define ORO_PP_ERROR(text)
+#endif
+
+/**
+ * Use this macro to register multiple components in a shared library (plug-in).
+ * For each component, add this line in the .cpp file. Use this macro in combination with
+ * ORO_CREATE_COMPONENT_LIBRARY.
+ *
+ * The advantage of this approach is that one library can create different component
+ * \a types and that you may link multiple component libraries with each other.
+ *
+ * This macro can be used for both shared and static libraries. In case of a shared library,
+ * the component factory will be registered to the shared library's local FactoryMap. In case
+ * of a static library, the component factory will be registered in the static library's global
+ * FactoryMap. In both cases, the DeploymentComponent can access these factories and
+ * create the registered component types.
+ *
+ * @param CLASS_NAME the class name of the component you are adding to the library.
+ */
+
+#define ORO_LIST_COMPONENT_TYPE(CLASS_NAME) namespace { namespace ORO_CONCAT_LINE(LOADER_) { RTT::ComponentFactoryLoader<CLASS_NAME> m_cloader(ORO_LIST_COMPONENT_TYPE_str(CLASS_NAME)); } }
+
+
 // ORO_CREATE_COMPONENT and ORO_CREATE_COMPONENT_LIBRARY are only used in shared libraries.
 #if defined(OCL_DLL_EXPORT) || defined (RTT_COMPONENT)
 
@@ -73,36 +102,6 @@
 #ifdef __clang__
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 #endif
-
-/**
- * Use this macro to register a single component in a shared library (plug-in).
- * You can only use this macro \b once in a .cpp file for the whole shared library \b and
- * you may \b not link with another component library when using this macro. Use
- * ORO_CREATE_COMPONENT_LIBRARY if you are in that situation.
- * 
- * It adds a function 'createComponent', which will return a new instance of
- * the library's component type and a function 'getComponentType', which returns
- * the type (namespace::class) name of the component.
- *
- * The advantage of this approach is that the user does not need to know the
- * class name of the component, he just needs to locate the shared library itself.
- * The disadvantage is that only one component \a type per shared library can be created.
- *
- * @param CNAME the class name of the component you are adding to the library.
- */
-#define ORO_CREATE_COMPONENT(CNAME) \
-extern "C" { \
-  RTT_EXPORT RTT::TaskContext* createComponent(std::string instance_name); \
-  RTT::TaskContext* createComponent(std::string instance_name) \
-  { \
-    return new CNAME(instance_name); \
-  } \
-  RTT_EXPORT std::string getComponentType(); \
-  std::string getComponentType() \
-  { \
-    return ORO_LIST_COMPONENT_TYPE_str(CNAME); \
-  } \
-} /* extern "C" */
 
 /**
  * Use this macro to create a component library which contains all components listed with
@@ -132,10 +131,31 @@ extern "C" { \
   RTT_EXPORT RTT::FactoryMap* getComponentFactoryMap() { return &RTT::ComponentFactories::Instance(); } \
 } /* extern "C" */
 
+
+/**
+ * Use this macro to register a single component in a shared library (plug-in).
+ * You can only use this macro \b once in a .cpp file for the whole shared library \b and
+ * you may \b not link with another component library when using this macro. Use
+ * ORO_CREATE_COMPONENT_LIBRARY if you are in that situation.
+ *
+ * It adds a function 'createComponent', which will return a new instance of
+ * the library's component type and a function 'getComponentType', which returns
+ * the type (namespace::class) name of the component.
+ *
+ * The advantage of this approach is that the user does not need to know the
+ * class name of the component, he just needs to locate the shared library itself.
+ * The disadvantage is that only one component \a type per shared library can be created.
+ *
+ * @param CNAME the class name of the component you are adding to the library.
+ */
+#define ORO_CREATE_COMPONENT(CNAME) \
+ORO_LIST_COMPONENT_TYPE(CNAME) \
+ORO_CREATE_COMPONENT_LIBRARY()
+
 #else
 
-#if !defined(OCL_STATIC) && !defined(RTT_STATIC) && !defined(RTT_DLL_EXPORT)
-#warning "You're compiling with static library settings. The resulting component library \
+#if !defined(OCL_STATIC) && !defined(RTT_STATIC) && !defined(RTT_DLL_EXPORT) && !defined(RTT_COMPONENT_HPP_INCLUDED_FROM_COMPONENTLOADER_CPP)
+#error "You're compiling with static library settings. The resulting component library \
  will not be loadable at runtime with the deployer.\
  Compile with -DRTT_COMPONENT to enable dynamic loadable components, \
  or use -DRTT_STATIC to suppress this warning."
@@ -143,34 +163,17 @@ extern "C" { \
 
 // Static OCL library:
 // Identical to ORO_LIST_COMPONENT_TYPE:
-#define ORO_CREATE_COMPONENT(CLASS_NAME) namespace { namespace ORO_CONCAT_LINE(LOADER_) { RTT::ComponentFactoryLoader<CLASS_NAME> m_cloader(ORO_LIST_COMPONENT_TYPE_str(CLASS_NAME)); } }
+#define ORO_CREATE_COMPONENT(CLASS_NAME) ORO_LIST_COMPONENT_TYPE(CLASS_NAME)
 #define ORO_CREATE_COMPONENT_LIBRARY() __attribute__((weak)) RTT::FactoryMap* RTT::ComponentFactories::Factories = 0;
 
 #endif
 
 /**
- * Use this macro to register multiple components in a shared library (plug-in).
- * For each component, add this line in the .cpp file. Use this macro in combination with
- * ORO_CREATE_COMPONENT_LIBRARY.
- *
- * The advantage of this approach is that one library can create different component
- * \a types and that you may link multiple component libraries with each other.
- *
- * This macro can be used for both shared and static libraries. In case of a shared library,
- * the component factory will be registered to the shared library's local FactoryMap. In case
- * of a static library, the component factory will be registered in the static library's global
- * FactoryMap. In both cases, the DeploymentComponent can access these factories and
- * create the registered component types.
- *
- * @param CLASS_NAME the class name of the component you are adding to the library.
- */
-
-#define ORO_LIST_COMPONENT_TYPE(CLASS_NAME) namespace { namespace ORO_CONCAT_LINE(LOADER_) { RTT::ComponentFactoryLoader<CLASS_NAME> m_cloader(ORO_LIST_COMPONENT_TYPE_str(CLASS_NAME)); } }
-
-/**
  * Backwards compatibility macro which is now replaced by ORO_CREATE_COMPONENT_LIBRARY( )
  */
-#define ORO_CREATE_COMPONENT_TYPE( ) ORO_CREATE_COMPONENT_LIBRARY( )
+#define ORO_CREATE_COMPONENT_TYPE( ) \
+    ORO_PP_WARNING("ORO_CREATE_COMPONENT_TYPE() is deprecated. Please use ORO_CREATE_COMPONENT_LIBRARY() instead.") \
+    ORO_CREATE_COMPONENT_LIBRARY( )
 
 #endif
 

--- a/rtt/Component.hpp
+++ b/rtt/Component.hpp
@@ -154,7 +154,7 @@ ORO_CREATE_COMPONENT_LIBRARY()
 
 #else
 
-#if !defined(OCL_STATIC) && !defined(RTT_STATIC) && !defined(RTT_DLL_EXPORT) && !defined(RTT_COMPONENT_HPP_INCLUDED_FROM_COMPONENTLOADER_CPP)
+#if !defined(OCL_STATIC) && !defined(RTT_STATIC) && !defined(RTT_DLL_EXPORT)
 #error "You're compiling with static library settings. The resulting component library \
  will not be loadable at runtime with the deployer.\
  Compile with -DRTT_COMPONENT to enable dynamic loadable components, \

--- a/rtt/deployment/ComponentLoader.cpp
+++ b/rtt/deployment/ComponentLoader.cpp
@@ -36,7 +36,6 @@
  ***************************************************************************/
 
 
-#define RTT_COMPONENT_HPP_INCLUDED_FROM_COMPONENTLOADER_CPP
 #include "ComponentLoader.hpp"
 #include <rtt/TaskContext.hpp>
 #include <rtt/Logger.hpp>

--- a/rtt/deployment/ComponentLoader.cpp
+++ b/rtt/deployment/ComponentLoader.cpp
@@ -630,7 +630,7 @@ bool ComponentLoader::loadInProcess(string file, string libname, bool log_error)
         return false;
     }
 
-    handle = dlopen ( p.string().c_str(), RTLD_NOW);
+    handle = dlopen ( p.string().c_str(), RTLD_NOW | RTLD_GLOBAL );
 
     if (!handle) {
         if ( log_error ) {

--- a/rtt/deployment/ComponentLoader.hpp
+++ b/rtt/deployment/ComponentLoader.hpp
@@ -42,9 +42,56 @@
 #include <string>
 #include <vector>
 #include <boost/shared_ptr.hpp>
-#include <rtt/Component.hpp>
+#include <rtt/TaskContext.hpp>
 
 namespace RTT {
+
+        /**
+         * This signature defines how a component can be instantiated.
+         */
+        typedef TaskContext* (*ComponentLoaderSignature)(std::string instance_name);
+        typedef std::map<std::string,ComponentLoaderSignature> FactoryMap;
+
+        /**
+         * A global variable storing all component factories added with
+         * \a ORO_LIST_COMPONENT_TYPE.
+         * This factory needs to be present in both static and dynamic library
+         * deployments.
+         */
+        class ComponentFactories
+        {
+            /**
+             * When static linking is used, the Component library loaders can be
+             * found in this map.
+             */
+            RTT_HIDE static FactoryMap* Factories;
+        public:
+            RTT_HIDE static FactoryMap& Instance() {
+                if ( Factories == 0)
+                    Factories = new FactoryMap();
+                return *Factories;
+            }
+        };
+
+        /**
+         * A helper class storing a single component factory
+         * in case of static library deployments.
+         */
+        template<class C>
+        class ComponentFactoryLoader
+        {
+        public:
+            ComponentFactoryLoader(std::string type_name)
+            {
+                ComponentFactories::Instance()[type_name] = &ComponentFactoryLoader<C>::createComponent;
+            }
+
+            static TaskContext* createComponent(std::string instance_name)
+            {
+                return new C(instance_name);
+            }
+        };
+
         /**
          * Locates Component libraries found on the filesystem and keeps track of loaded Components.
          * In case a no components of a component library are running, the library can be unloaded.


### PR DESCRIPTION
This merge request is the result of debugging component loading to find the root cause of warnings like
```
0.202 [ Warning][ComponentLoader::import(path_list)] Component type name OCL::logging::Log4cxxAppender already used:  overriding.
```

in macOS deployments today, or in general if one component library is linked to another component library.

1. https://github.com/orocos-toolchain/rtt/commit/88775dcfde50174f3b680232445054c1cdf6cacb deprecates the old-style single component library entry hooks and the `ORO_CREATE_COMPONENT_TYPE()` macro and simply forwards single-component library `ORO_CREATE_COMPONENT(CLASS_NAME)` macro calls to two new-style macro calls. Not sure why it has not been implemented like this from the beginning. I do not see a disadvantage and it is a first step towards eliminating extern C functions returning C++ types (https://github.com/orocos-toolchain/rtt/issues/125). As a side effect, if OCL was compiled with that patch, the entry hook symbols in the component library that is actually being loaded always override the same symbols of other libraries that it might link to.

2. https://github.com/orocos-toolchain/rtt/commit/c12486c77e3c2458c5ff562026a43279c7fe0b39 fixes a long-lasting bug that caused bogus static library warnings when compiling `rtt/deployment/ComponentLoader.cpp` or any other non-component target that includes `rtt/deployment/ComponentLoader.hpp`.

3. https://github.com/orocos-toolchain/rtt/commit/cbedc2f282323f592c79cee784bd27f1898ae925 (http://bugs.orocos.org/show_bug.cgi?id=1001) has been reverted in https://github.com/orocos-toolchain/rtt/commit/a6ccf00cef676d91d5d665baa16ec6ed1b6b0909. The patch caused type mismatch errors on macOS and many additional `Component type name ... already used:  overriding.` errors, even for Linux. I don't have a context anymore why it was originally introduced (@smits, @psoetens).

   I assume that what was meant by "_overriding of ComponentTypes_" in the original commit message is actually "unloading the component library and reloading it into the process by calling [ComponentLoader::reloadInProcess()](https://github.com/orocos-toolchain/rtt/blob/49752330ac2290ffb5206d42245ace716e2d93db/rtt/deployment/ComponentLoader.cpp#L575) or [ComponentLoader::reloadLibrary()](https://github.com/orocos-toolchain/rtt/blob/49752330ac2290ffb5206d42245ace716e2d93db/rtt/deployment/ComponentLoader.cpp#L497)" (and not overriding a registered component type name by loading _another_ library with the same component type defined). In that rare case `RTLD_LOCAL` might be required according to the [man page of dlopen](http://man7.org/linux/man-pages/man3/dlopen.3.html):

   > If the object's reference count drops to zero and no symbols in this object are required by other objects, then the object is unloaded after first calling any destructors defined for the object.  (Symbols in this object might be required in another object because this object was opened with the `RTLD_GLOBAL` flag and one of its symbols satisfied a relocation in another object.)

   However, not adding `RTLD_LOCAL` explicitly leaves the default implementation defined, which is `RTLD_LOCAL` on Linux, but `RTLD_GLOBAL` on macOS ([dlopen](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlopen.3.html)). And adding `RTLD_LOCAL` breaks the Orocos type system on macOS, because the singleton `TypeInfoRepository` might not be a singleton anymore depending on how it is used.

   In my understanding it is still possible to reload a component library, but there is no guarantee that the library actually has been reloaded if other component or plugin libraries have been loaded afterwards (which might still use symbols defined in the library to be unloaded).

   The current (old) behavior is inconsistent with `PluginLoader` ([PluginLoader.cpp:661](https://github.com/orocos-toolchain/rtt/blob/49752330ac2290ffb5206d42245ace716e2d93db/rtt/plugin/PluginLoader.cpp#L661)), but service and typekit plugins are not supposed to be unloaded again until the end of the process. 