### PR TITLE
Remove wrong statement in the documentation of class RTT::Activity

### DIFF
--- a/rtt/Activity.hpp
+++ b/rtt/Activity.hpp
@@ -60,11 +60,6 @@ namespace RTT
      * When provided one, it will execute a base::RunnableInterface object, or the equivalent methods in
      * it's own interface when none is given.
      *
-     * For a periodic Activity, when it misses its deadline because user code
-     * take too long to execute, it will skip the required number of periodic
-     * execution steps in order to be back on time. This is the ORO_WAIT_REL wait
-     * policy and can be changed by calling setWaitPeriodPolicy(ORO_WAIT_ABS)
-     *
      * @ingroup CoreLibActivities
      */
     class RTT_API Activity


### PR DESCRIPTION
This sentence was introduced in 06146b6a2c9f05c390113c3ffaf2ceab6d36f616 (#91) due to a wrong understanding of `ORO_WAIT_ABS` and `ORO_WAIT_REL`. The old behavior was restored later in 171a700866a8c03057bec2e5ec59ada4e9f3a8af and 6047c605696280fa14e7c4291a400180cc4faa3b
(https://github.com/Intermodalics/rtt/pull/2), but without updating the class documentation.