### PR TITLE
Fix compiler warnings with GCC 9 (with API changes)

### DIFF
--- a/rtt/Handle.cpp
+++ b/rtt/Handle.cpp
@@ -53,11 +53,6 @@ namespace RTT {
     {
     }
 
-    Handle::Handle(const Handle& hs)
-        : m_conn( hs.m_conn )
-    {
-    }
-
     Handle::~Handle()
     {
     }

--- a/rtt/Handle.hpp
+++ b/rtt/Handle.hpp
@@ -77,11 +77,6 @@ namespace RTT
         Handle(connection_t conn);
 
         /**
-         * Create a copy-equivalent Handle.
-         */
-        Handle(const Handle& hs);
-
-        /**
          * No-op destructor, does not change signal/slot state.
          */
 		~Handle();

--- a/rtt/Property.hpp
+++ b/rtt/Property.hpp
@@ -174,13 +174,38 @@ namespace RTT
         }
 
         /**
+         * Assignment copies the name, description and value
+         * as \b deep copies.
+         * @post ready() will be true if orig.ready() is true.
+         */
+        Property<T>& operator=( const Property<T>& orig)
+        {
+            if ( this == &orig )
+                return *this;
+
+            this->setName( orig.getName() );
+            this->setDescription( orig.getDescription() );
+
+            if (orig._value) {
+                _value = orig._value->clone();
+                // need to do this on the clone() in order to have access to set()/rvalue() of the data source.
+                _value->evaluate();
+            } else {
+                _value = 0;
+            }
+
+            return *this;
+        }
+
+        /**
          * Set the property's value.
          * @param value The value to be set.
          * @return A reference to newly set property value.
          */
         Property<T>& operator=( param_t value )
         {
-            _value->set( value );
+            if (_value)
+                _value->set( value );
             return *this;
         }
 

--- a/rtt/PropertyBag.cpp
+++ b/rtt/PropertyBag.cpp
@@ -72,9 +72,11 @@ namespace RTT
         this->clear();
     }
 
-    void PropertyBag::add(PropertyBase *p)
+    bool PropertyBag::add(PropertyBase *p)
     {
-        this->addProperty(*p);
+        if (p == 0)
+            return false;
+        return this->addProperty(*p);
     }
 
     void PropertyBag::remove(PropertyBase *p)
@@ -106,8 +108,6 @@ namespace RTT
 
     bool PropertyBag::addProperty(PropertyBase& p)
     {
-        if (&p == 0)
-            return false;
         if ( ! p.ready() )
             return false;
         mproperties.push_back(&p);

--- a/rtt/PropertyBag.hpp
+++ b/rtt/PropertyBag.hpp
@@ -144,8 +144,9 @@ namespace RTT
         /**
          * Add a valid property to the container. Analogous to addProperty.
          * @param p Pointer to the property to be added.
+         * @return false if !p || !p->ready(), true otherwise.
          */
-        void add(base::PropertyBase *p);
+        bool add(base::PropertyBase *p);
 
         /**
          * Remove a property from the container. Analogous to removeProperty.
@@ -173,8 +174,8 @@ namespace RTT
 
         /**
          * Add a valid property to the container.
-         * @param p Pointer to the property to be added.
-         * @return false if !p || !p->ready(), true otherwise.
+         * @param p Reference to the property to be added.
+         * @return false if !p.ready(), true otherwise.
          */
         bool addProperty(base::PropertyBase& p);
 

--- a/rtt/SendHandle.hpp
+++ b/rtt/SendHandle.hpp
@@ -78,11 +78,6 @@ namespace RTT
         SendHandle(typename internal::CollectBase<Signature>::shared_ptr coll) : CBase( coll.get() ), RBase(coll) {}
 
         /**
-         * Create a copy-equivalent SendHandle.
-         */
-        SendHandle(const SendHandle& hs) : CBase(hs.cimpl), RBase(hs.impl) {}
-
-        /**
          * No-op destructor, does not change signal/slot state.
          */
         ~SendHandle() {

--- a/rtt/os/oro_gcc/oro_arch.h
+++ b/rtt/os/oro_gcc/oro_arch.h
@@ -149,7 +149,7 @@ static __inline__ int oro_atomic_inc_and_test(oro_atomic_t *a_int)
  * Compare o with *ptr and swap with n if equal.
  */
 #define oro_cmpxchg(ptr,o,n)\
-    ((__typeof__(*(ptr)))__sync_val_compare_and_swap((ptr),(o),(n)))
+    (__sync_val_compare_and_swap((ptr),(o),(n)))
 
 
 #endif // __GCC_ORO_ARCH__

--- a/rtt/scripting/parse_exception.hpp
+++ b/rtt/scripting/parse_exception.hpp
@@ -85,9 +85,10 @@ namespace RTT
         // make these private
         parse_exception& operator=( const parse_exception& );
     protected:
-        parse_exception() {};
+        parse_exception() {}
+        parse_exception( const parse_exception& ) {}
     public:
-        virtual ~parse_exception() {};
+        virtual ~parse_exception() {}
         virtual const std::string what() const = 0;
         virtual parse_exception* copy() const = 0;
     };
@@ -105,7 +106,8 @@ namespace RTT
             // make these private
             semantic_parse_exception& operator=( const semantic_parse_exception& );
         protected:
-            semantic_parse_exception() {};
+            semantic_parse_exception() {}
+            semantic_parse_exception( const semantic_parse_exception& other ) : parse_exception(other) {}
         };
 
         /**
@@ -119,7 +121,8 @@ namespace RTT
             // make these private
             fatal_syntactic_parse_exception& operator=( const fatal_syntactic_parse_exception& );
         protected:
-            fatal_syntactic_parse_exception() {};
+            fatal_syntactic_parse_exception() {}
+            fatal_syntactic_parse_exception( const fatal_syntactic_parse_exception& other ) : parse_exception(other) {}
         };
 
         /**
@@ -134,7 +137,8 @@ namespace RTT
             // make these private
             fatal_semantic_parse_exception& operator=( const fatal_syntactic_parse_exception& );
         protected:
-            fatal_semantic_parse_exception() {};
+            fatal_semantic_parse_exception() {}
+            fatal_semantic_parse_exception( const fatal_syntactic_parse_exception& other ) : parse_exception(other) {}
         };
 
         /**
@@ -148,7 +152,8 @@ namespace RTT
             // make these private
             syntactic_parse_exception& operator=( const syntactic_parse_exception& );
         protected:
-            syntactic_parse_exception() {};
+            syntactic_parse_exception() {}
+            syntactic_parse_exception( const syntactic_parse_exception& other ) : parse_exception(other) {}
         };
 
 
@@ -160,8 +165,7 @@ namespace RTT
         public:
             parse_exception_illegal_identifier( const std::string& ident )
                 : mident( ident )
-            {
-            };
+            {}
 
             const std::string what() const
             {
@@ -190,8 +194,7 @@ namespace RTT
         public:
             parse_exception_semantic_error( const std::string& desc )
                 : mdesc( desc )
-            {
-            };
+            {}
 
             const std::string what() const
             {
@@ -220,8 +223,7 @@ namespace RTT
         public:
             parse_exception_fatal_semantic_error( const std::string& desc )
                 : mdesc( desc )
-            {
-            };
+            {}
 
             const std::string what() const
             {
@@ -276,8 +278,7 @@ namespace RTT
         public:
             parse_exception_syntactic_error( const std::string& desc )
                 : mdesc( desc )
-            {
-            };
+            {}
 
             const std::string what() const
             {
@@ -331,8 +332,7 @@ namespace RTT
             parse_exception_no_such_method_on_component(
                                                         const std::string& componentname, const std::string& methodname )
                 : mcomponentname( componentname ), mmethodname( methodname )
-            {
-            };
+            {}
 
             const std::string what() const
             {
@@ -369,8 +369,7 @@ namespace RTT
                 : mcomponentname( componentname ), mmethodname( methodname ),
                   mexpectednumber( expectednumber ),
                   mreceivednumber( receivednumber )
-            {
-            };
+            {}
 
             const std::string what() const;
 
@@ -414,8 +413,7 @@ namespace RTT
                                                    int argnumber, const std::string& expected, const std::string& received )
                 : mcomponentname( componentname ), mmethodname( methodname ),
                   margnumber( argnumber ), mexpected( expected), mreceived( received )
-            {
-            };
+            {}
 
             const std::string what() const;
 

--- a/tests/datasource_test.cpp
+++ b/tests/datasource_test.cpp
@@ -75,9 +75,9 @@ BOOST_AUTO_TEST_CASE( testConstantDataSource )
     DataSource<AType>::shared_ptr d = new ConstantDataSource<AType>( atype );
 
     // Do not take by reference:
-    BOOST_CHECK_EQUAL( d->get(), atype );
+    BOOST_CHECK_EQUAL( d->rvalue(), atype );
     atype.a = -atype.a;
-    BOOST_CHECK_EQUAL( d->get(), atype_orig );
+    BOOST_CHECK_EQUAL( d->rvalue(), atype_orig );
 }
 
 // Test reference to C++ data
@@ -100,9 +100,9 @@ BOOST_AUTO_TEST_CASE( testConstReferenceDataSource )
     DataSource<AType>::shared_ptr d = new ConstReferenceDataSource<AType>( atype );
 
     // Take by reference:
-    BOOST_CHECK_EQUAL( d->get(), atype );
+    BOOST_CHECK_EQUAL( d->rvalue(), atype );
     atype.a = -atype.a;
-    BOOST_CHECK_EQUAL( d->get(), atype );
+    BOOST_CHECK_EQUAL( d->rvalue(), atype );
 }
 
 // Test part reference to C++ data
@@ -118,12 +118,12 @@ BOOST_AUTO_TEST_CASE( testPartDataSource )
 
     // Test both versions of set(). This also checks updated():
     d->set( "Long gone!" );
-    BOOST_CHECK_EQUAL( d->set(), abase->get().c );
+    BOOST_CHECK_EQUAL( d->set(), abase->rvalue().c );
     BOOST_CHECK_EQUAL( d->set(), atype.c );
 
     d->set() = "And back!";
     d->updated();
-    BOOST_CHECK_EQUAL( d->set(), abase->get().c );
+    BOOST_CHECK_EQUAL( d->set(), abase->rvalue().c );
     BOOST_CHECK_EQUAL( d->set(), atype.c );
 }
 
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE( testArrayDataSource )
     *d->set().address() = 'L';
     d->updated();
     BOOST_CHECK_EQUAL( "Lorld", btype.c );
-    BOOST_CHECK_EQUAL( "Lorld", d->get().address() );
+    BOOST_CHECK_EQUAL( "Lorld", d->rvalue().address() );
     BOOST_CHECK_EQUAL( d->set().address(), btype.c );
 }
 
@@ -166,19 +166,19 @@ BOOST_AUTO_TEST_CASE( testArrayPartDataSource )
     // Test both versions of set(). This also checks updated():
     d->set( 'L' );
     BOOST_CHECK_EQUAL( "Lorld", btype.c );
-    BOOST_CHECK( strcmp( &d->set(), abase->get().c) == 0 );
+    BOOST_CHECK( strcmp( &d->set(), abase->rvalue().c) == 0 );
     BOOST_CHECK_EQUAL( &d->set(), btype.c );
 
     d->set() = 'W';
     d->updated();
     BOOST_CHECK_EQUAL( "World", btype.c );
-    BOOST_CHECK( strcmp( &d->set(), abase->get().c) == 0 );
+    BOOST_CHECK( strcmp( &d->set(), abase->rvalue().c) == 0 );
     BOOST_CHECK_EQUAL( &d->set(), btype.c );
 
     index->set( 3 );
     d->set( 'L' );
     BOOST_CHECK_EQUAL( "WorLd", btype.c );
-    BOOST_CHECK( strcmp( &d->set(), &abase->get().c[3]) == 0 );
+    BOOST_CHECK( strcmp( &d->set(), &abase->rvalue().c[3]) == 0 );
     BOOST_CHECK_EQUAL( &d->set(), &btype.c[3] );
 }
 

--- a/tests/taskthread_fd_test.cpp
+++ b/tests/taskthread_fd_test.cpp
@@ -30,7 +30,11 @@
 using namespace std;
 
 #include <boost/test/unit_test.hpp>
+#if BOOST_VERSION < 105900
 #include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 
 using namespace RTT;

--- a/tests/unit.hpp
+++ b/tests/unit.hpp
@@ -36,7 +36,11 @@
 #include <boost/test/unit_test_suite.hpp>
 #endif
 #include <boost/test/unit_test.hpp>
+#if BOOST_VERSION < 105900
 #include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 
 using namespace RTT;
 using namespace RTT::detail;


### PR DESCRIPTION
This pull request eliminates some compiler warnings with newer compilers (GCC 9 in upcoming Ubuntu 20.04, with Boost 1.72). Some warnings are older and already appeared before.

The patch also includes an API update proposal for more consistent copy assignment semantics of `RTT::Property<T>`, which was inconsistent with copy construction, and a slightly modified API of `RTT::PropertyBag` for adding properties, that likely has no effect in practice.