### PR TITLE
fix default event port behavior along with FileDescriptorActivity

### DIFF
--- a/rtt/extras/FileDescriptorActivity.hpp
+++ b/rtt/extras/FileDescriptorActivity.hpp
@@ -120,12 +120,23 @@ namespace RTT { namespace extras {
         RTT::os::Mutex m_command_mutex;
         bool m_break_loop;
         bool m_trigger;
+        bool m_user_timeout;
         bool m_update_sets;
 
         /** Internal method that makes sure loop() takes into account
          * modifications in the set of watched FDs
          */
         void triggerUpdateSets();
+
+        /** Internal method that writes on an internal pipe to wake up
+         * the main loop
+         */
+        void writeInterruptPipe();
+
+        /** Internal method that clears the interrupt pipe used to wake
+         * up the main loop
+         */
+        void clearInterruptPipe();
 
     public:
         /**
@@ -278,7 +289,7 @@ namespace RTT { namespace extras {
         virtual void loop();
         virtual bool breakLoop();
         virtual bool stop();
-    
+
         /** Called by loop() when data is available on the file descriptor. By
          * default, it calls step() on the associated runner interface (if any)
          */

--- a/rtt/extras/FileDescriptorActivity.hpp
+++ b/rtt/extras/FileDescriptorActivity.hpp
@@ -285,28 +285,55 @@ namespace RTT { namespace extras {
          */
         int getTimeout_us() const;
 
+        /** Start the underlying thread and make it call \c loop
+         */
         virtual bool start();
+
+        /** The main loop, listening to various wake-up events
+         *
+         * The loop can be broken by calling \c breakLoop. \c timeout and \c trigger
+         * will wake it up and make it call work with resp. a TimeOut and Trigger
+         * reason. Available I/O on watched file descriptors will wake it up and
+         * make it call \c work with a IOReady reason
+         */
         virtual void loop();
+
+        /** Wake-up \c loop and make it return */
         virtual bool breakLoop();
         virtual bool stop();
 
-        /** Called by loop() when data is available on the file descriptor. By
-         * default, it calls step() on the associated runner interface (if any)
+        /** @deprecated does nothing, FileDescriptorActivity uses the \c work interface
          */
         virtual void step();
 
-        /** Called by loop() when data is available on the file descriptor. By
-         * default, it calls step() on the associated runner interface (if any)
+        /** Called by loop() when it is woken up
+         *
+         * The reason parameter allows to know why the loop was woken up:
+         * - TimeOut if the activity time out has been reached or if \c timeout
+         *   has been called. In the former case, \c hasTimeout will return true.
+         * - IOReady is some I/O has been received on the watched file descriptors
+         * - Trigger if trigger() has been called
+         *
+         * Calls runner->work with the same reason. By default \c
+         * ExecutionEngine will call all messages, port callbacks, functions
+         * and hooks in IOReady and TimeOut, but only messages and port
+         * callbacks in Trigger
          */
         virtual void work(base::RunnableInterface::WorkReason reason);
 
-        /** Force calling step() even if no data is available on the file
-         * descriptor, and returns true if the signalling was successful
+        /**
+         * Wake up the main thread (in \c loop) and call \c work with Trigger as reason
+         *
+         * @return true if the activity is active, that is if it is started and
+         *   will process the trigger. false otherwise.
          */
         virtual bool trigger();
 
         /**
-         * Always returns false.
+         * Wake up the main thread (in \c loop) and call \c work with TimeOut as reason
+         *
+         * @return true if the activity is active, that is if it is started and
+         *   will process the trigger. false otherwise.
          */
         virtual bool timeout();
     };


### PR DESCRIPTION
With the introduction of the work() method, which allowed to
be more precise on what gets called in which condition,
an event port under FileDescriptorActivity would not make
updateHook get called anymore.

This broke the Rock workflow with file descriptor activities.
(Un)fortunately, the effect has been subtle enough to not be
noticed readily. Or people started deploying tasks under the
normal Activity where before it would work with the FDA (I'm
guilty of that).

This is a rather convoluted code path (the characters in the
play are a FileDescriptorActivity 'FDA', ExecutionEngine 'EE'
and a TaskContext 'TC'

- the port signal calls FDA::trigger()
- FDA::trigger() wakes-up the FDA loop, which calls EE::work(Trigger)
- EE::work(Trigger) calls EE::processPortCallbacks but NOT
  EE::processHooks (expected from the work() refactoring)

At that point, we have to remember that TC::addEventPort registers
a port callback that by default calls TC->trigger(). The
comment at that point in the code itself says "default schedules
an updateHook" (which we're indeed expecting with a FDA)

- so, EE::processPortCallbacks in the end calls TC::trigger
- which, by default calls FDA::timeout()

Until now, FDA::timeout() was not implemented. This PR implements it.